### PR TITLE
Begin work on VCS import support

### DIFF
--- a/vcs/discovertool/discovertool.go
+++ b/vcs/discovertool/discovertool.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Serulian/compiler/vcs"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	var url string
+	var cmdRun = &cobra.Command{
+		Use:   "discovertool --url [url]",
+		Short: "Small tool for testing VCS discovery",
+		Long:  `A small tool for testing VCS discovery against a URL`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if url == "" {
+				fmt.Println("Expected URL")
+				return
+			}
+
+			fmt.Printf("Performing discovery for URL: %v\n", url)
+
+			found, err := vcs.GetVCSInformation(url, nil)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+
+			fmt.Printf("Discovery information: %v\n", found)
+		},
+	}
+
+	cmdRun.Flags().StringVar(&url, "url", "", "The URL to discovr")
+	cmdRun.Execute()
+}

--- a/vcs/metadiscovery.go
+++ b/vcs/metadiscovery.go
@@ -1,0 +1,123 @@
+package vcs
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// discoveryUrlParamter holds the name of the parameter added to the URL to request it
+// to add the golang <meta> discovery tag.
+const discoveryUrlParamter = "go-get"
+
+// discoveryUrlValue holds the value of the paramter added to the URL to request it
+// to add the golang <meta> discovery tag.
+const discoveryUrlValue = "1"
+
+// discoveryMetaTagName holds the name of the <meta> tag holding the VCS discovery
+// information.
+const discoveryMetaTagName = "go-import"
+
+// discoverInformationForVCSUrl attempts to download the given URL, find the discovery <meta> tag,
+// and return the VCSUrlInformation found.
+func discoverInformationForVCSUrl(vcsUrl string) (VCSUrlInformation, error) {
+	log.Printf("Parsing VCS URL %s", vcsUrl)
+
+	// Parse the VCS url.
+	parsedUrl, err := url.Parse(vcsUrl)
+	if err != nil {
+		return VCSUrlInformation{}, fmt.Errorf("Could not parse VCS url '%s': %v", vcsUrl, err)
+	}
+
+	// Add the discovery parameter.
+	query := parsedUrl.Query()
+	query.Set(discoveryUrlParamter, discoveryUrlValue)
+	parsedUrl.RawQuery = query.Encode()
+
+	// Make sure we have a known scheme.
+	if parsedUrl.Scheme == "" {
+		parsedUrl.Scheme = "http"
+	}
+
+	// Attempt to download the URL.
+	log.Printf("Retrieving VCS URL %s", parsedUrl.String())
+	response, err := http.Get(parsedUrl.String())
+	if err != nil {
+		return VCSUrlInformation{}, fmt.Errorf("Could not download VCS url '%s': %v", vcsUrl, err)
+	}
+
+	// Parse the contents into HTML and search for the <meta> tag.
+	doc, err := html.Parse(response.Body)
+	if err != nil {
+		return VCSUrlInformation{}, fmt.Errorf("VCS url '%s' returned an invalid body", vcsUrl)
+	}
+
+	notFoundErr := fmt.Errorf("Could not discover VCS url '%s'", vcsUrl)
+	discoveryTag, ok := findVCSDiscoveryTag(doc)
+	if !ok {
+		log.Printf("Discovery <meta> tag not found for VCS URL %v", vcsUrl)
+		return VCSUrlInformation{}, notFoundErr
+	}
+
+	// Find the <meta> tag's value.
+	var metaTagValue string
+	for _, attr := range discoveryTag.Attr {
+		if attr.Key == "content" {
+			metaTagValue = attr.Val
+			break
+		}
+	}
+
+	if metaTagValue == "" {
+		log.Printf("<meta> tag value not found for VCS URL %v", vcsUrl)
+		return VCSUrlInformation{}, notFoundErr
+	}
+
+	// <meta name="go-import" content="github.com/repo/path git https://github.com/repo/path">
+	pieces := strings.SplitN(metaTagValue, " ", 3)
+	if pieces == nil {
+		log.Printf("<meta> tag value could not be parsed for VCS URL %v", vcsUrl)
+		return VCSUrlInformation{}, notFoundErr
+	}
+
+	// Ensure that the path component (index 0) matches or is a prefix of the import URL.
+	if strings.Index(vcsUrl, pieces[0]) != 0 {
+		log.Printf("<meta> tag prefix '%v' does not match VCS URL %v", pieces[0], vcsUrl)
+		return VCSUrlInformation{}, notFoundErr
+	}
+
+	// Find the associated VCS.
+	handler, ok := vcsById[pieces[1]]
+	if !ok {
+		err := fmt.Errorf("VCS url '%s' requires engine '%s', which is not currently supported", vcsUrl, pieces[1])
+		return VCSUrlInformation{}, err
+	}
+
+	return VCSUrlInformation{pieces[0], handler.kind, pieces[2]}, nil
+}
+
+// findVCSDiscoveryTag searches the parsed HTML DOM from the given start node, downward,
+// looking for the VCS <meta> discovery tag. If found, the tag is returned.
+func findVCSDiscoveryTag(n *html.Node) (*html.Node, bool) {
+	if n.Type == html.ElementNode && n.Data == "meta" {
+		for _, attr := range n.Attr {
+			if attr.Key == "name" && attr.Val == discoveryMetaTagName {
+				return n, true
+			}
+		}
+	}
+
+	// Search recursively.
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		found, ok := findVCSDiscoveryTag(c)
+		if ok {
+			return found, true
+		}
+	}
+
+	return nil, false
+}

--- a/vcs/vcs.go
+++ b/vcs/vcs.go
@@ -1,0 +1,71 @@
+// Copyright 2015 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// Some code based on the Golang VCS portion of the cmd package:
+// https://golang.org/src/cmd/go/vcs.go
+
+// vcs package defines helpers functions and interfaces for working with Version Control Systems
+// such as git, including discovery of VCS information based on the Golang VCS discovery protocol.
+package vcs
+
+// VCSKind identifies the supported kinds of VCS.
+type VCSKind int
+
+const (
+	VCSKindUnknown VCSKind = iota // an unknown kind of VCS
+	VCSKindGit                    // Git
+)
+
+// VCSUrlInformation holds information about a VCS source URL.
+type VCSUrlInformation struct {
+	UrlPrefix    string  // The prefix matching the source URL.
+	Kind         VCSKind // The kind of VCS for the source URL.
+	DownloadPath string  // The VCS-specific download path.
+}
+
+// VCSCache is an interface for a cache that can read and write information about a VCS
+// url.
+type VCSCache interface {
+	// Get returns the cached VCSInformation for the specified URL. If none, returns false
+	// an empty struct.
+	Get(url string) (VCSUrlInformation, bool)
+
+	// Write saves the given VCSUrlInformation for the given source URL to the cache.
+	Write(url string, information VCSUrlInformation)
+}
+
+// GetVCSInformation returns the VCS information for a given VCS URL.
+func GetVCSInformation(vcsUrl string, cache VCSCache) (VCSUrlInformation, error) {
+	// Check the VCS cache first.
+	if cache != nil {
+		if cached, ok := cache.Get(vcsUrl); ok {
+			return cached, nil
+		}
+	}
+
+	// Perform discovery.
+	information, err := discoverInformationForVCSUrl(vcsUrl)
+	if err != nil {
+		return information, err
+	}
+
+	if cache != nil {
+		cache.Write(vcsUrl, information)
+	}
+
+	return information, err
+}
+
+// vcsHandler represents the defined handler information for a specific kind of VCS.
+type vcsHandler struct {
+	// The kind of the VCS being handled.
+	kind VCSKind
+}
+
+// vcsById holds a map from string ID for the VCS to its associated vcsHandler struct.
+var vcsById = map[string]vcsHandler{
+	"git": vcsHandler{
+		kind: VCSKindGit,
+	},
+}


### PR DESCRIPTION
This change adds a VCS discovery mechanism which uses the Golang VCS discovery <meta> protocol to turn a URL into a known SCM engine and the SCM source.
