### PR TITLE
Nominal shortcutting support

### DIFF
--- a/generator/es5/dombuilder/build_literal_expr.go
+++ b/generator/es5/dombuilder/build_literal_expr.go
@@ -165,7 +165,7 @@ func (db *domBuilder) buildCollectionLiteralExpression(node compilergraph.GraphN
 		Out(valuePredicate).
 		BuildNodeIterator()
 
-	valueExprs := db.buildExpressions(vit)
+	valueExprs := db.buildExpressions(vit, buildExprNormally)
 	return db.buildCollectionInitializerExpression(collectionType, valueExprs, emptyConstructorName, arrayConstructorName, node)
 }
 

--- a/generator/es5/dombuilder/build_op_expr.go
+++ b/generator/es5/dombuilder/build_op_expr.go
@@ -65,7 +65,7 @@ func (db *domBuilder) buildFunctionCall(node compilergraph.GraphNode) codedom.Ex
 		Out(parser.NodeFunctionCallArgument).
 		BuildNodeIterator()
 
-	arguments := db.buildExpressions(ait)
+	arguments := db.buildExpressions(ait, buildExprCheckNominalShortcutting)
 	childExpr := db.buildExpression(childExprNode)
 
 	// If the function call is to a member, then we return a MemberCall.

--- a/generator/es5/dombuilder/build_sml_expr.go
+++ b/generator/es5/dombuilder/build_sml_expr.go
@@ -65,7 +65,7 @@ func (db *domBuilder) buildSmlExpression(node compilergraph.GraphNode) codedom.E
 			Out(parser.NodeSmlExpressionChild).
 			BuildNodeIterator()
 
-		children := db.buildExpressions(cit)
+		children := db.buildExpressions(cit, buildExprNormally)
 
 		switch {
 		case smlScope.HasLabel(proto.ScopeLabel_SML_SINGLE_CHILD):

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -185,6 +185,7 @@ var tests = []generationTest{
 	generationTest{"base nominal type", "nominal", "nominalbase", integrationTestSuccessExpected, ""},
 	generationTest{"interface nominal type", "nominal", "interface", integrationTestSuccessExpected, ""},
 	generationTest{"literal nominal type", "nominal", "literal", integrationTestSuccessExpected, ""},
+	generationTest{"shortcut nominal type", "nominal", "shortcut", integrationTestSuccessExpected, ""},
 
 	generationTest{"basic json test", "serialization", "json", integrationTestSuccessExpected, ""},
 	generationTest{"nominal json test", "serialization", "nominaljson", integrationTestSuccessExpected, ""},

--- a/generator/es5/tests/nominal/shortcut.js
+++ b/generator/es5/tests/nominal/shortcut.js
@@ -1,0 +1,115 @@
+$module('shortcut', function () {
+  var $static = this;
+  this.$class('SomeClass', false, '', function () {
+    var $static = this;
+    var $instance = this.prototype;
+    $static.new = function () {
+      var instance = new $static();
+      var init = [];
+      return $promise.all(init).then(function () {
+        return instance;
+      });
+    };
+    $instance.Value = $t.property(function () {
+      var $this = this;
+      var $current = 0;
+      var $continue = function ($resolve, $reject) {
+        $resolve($t.box(true, $g.____testlib.basictypes.Boolean));
+        return;
+      };
+      return $promise.new($continue);
+    });
+    this.$typesig = function () {
+      return $t.createtypesig(['Value', 3, $g.____testlib.basictypes.Boolean.$typeref()], ['new', 1, $g.____testlib.basictypes.Function($g.shortcut.SomeClass).$typeref()]);
+    };
+  });
+
+  this.$type('SomeNominalType', false, '', function () {
+    var $instance = this.prototype;
+    var $static = this;
+    this.$box = function ($wrapped) {
+      var instance = new this();
+      instance[BOXED_DATA_PROPERTY] = $wrapped;
+      return instance;
+    };
+    this.$roottype = function () {
+      return $g.shortcut.SomeClass;
+    };
+    this.$typesig = function () {
+      return $t.createtypesig();
+    };
+  });
+
+  $static.DoSomething = function (sc) {
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      while (true) {
+        switch ($current) {
+          case 0:
+            sc.Value().then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            $resolve($result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  };
+  $static.TEST = function () {
+    var st;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      while (true) {
+        switch ($current) {
+          case 0:
+            $g.shortcut.SomeClass.new().then(function ($result0) {
+              $result = $t.box($result0, $g.shortcut.SomeNominalType);
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            st = $result;
+            $g.shortcut.DoSomething($t.unbox(st)).then(function ($result0) {
+              $result = $result0;
+              $current = 2;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 2:
+            $resolve($result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  };
+});

--- a/generator/es5/tests/nominal/shortcut.seru
+++ b/generator/es5/tests/nominal/shortcut.seru
@@ -1,0 +1,16 @@
+class SomeClass {
+	property<bool> Value {
+		get { return true }
+	}
+}
+
+type SomeNominalType : SomeClass {}
+
+function<bool> DoSomething(sc SomeClass) {
+	return sc.Value
+}
+
+function<any> TEST() {
+	var st = SomeNominalType(SomeClass.new())
+	return DoSomething(st)
+}

--- a/graphs/scopegraph/builder.go
+++ b/graphs/scopegraph/builder.go
@@ -6,6 +6,7 @@ package scopegraph
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/serulian/compiler/compilercommon"
 	"github.com/serulian/compiler/compilergraph"
@@ -341,6 +342,13 @@ func (sb *scopeBuilder) decorateWithError(node compilergraph.GraphNode, message 
 	errorNode := sb.modifier.CreateNode(NodeTypeError)
 	errorNode.Decorate(NodePredicateNoticeMessage, fmt.Sprintf(message, args...))
 	errorNode.Connect(NodePredicateNoticeSource, node)
+}
+
+// decorateWithSecondaryLabel decorates an *SRG* node with a secondary scope label.
+func (sb *scopeBuilder) decorateWithSecondaryLabel(node compilergraph.GraphNode, label proto.ScopeLabel) {
+	labelNode := sb.modifier.CreateNode(NodeTypeSecondaryLabel)
+	labelNode.Decorate(NodePredicateSecondaryLabelValue, strconv.Itoa(int(label)))
+	labelNode.Connect(NodePredicateLabelSource, node)
 }
 
 // GetWarnings returns the warnings created during the build pass.

--- a/graphs/scopegraph/proto/scopeinfo.pb.go
+++ b/graphs/scopegraph/proto/scopeinfo.pb.go
@@ -64,38 +64,41 @@ func (x *ScopeKind) UnmarshalJSON(data []byte) error {
 type ScopeLabel int32
 
 const (
-	ScopeLabel_STREAM_LOOP         ScopeLabel = 1
-	ScopeLabel_STREAMABLE_LOOP     ScopeLabel = 2
-	ScopeLabel_GENERATOR_STATEMENT ScopeLabel = 3
-	ScopeLabel_SML_FUNCTION        ScopeLabel = 4
-	ScopeLabel_SML_CONSTRUCTOR     ScopeLabel = 5
-	ScopeLabel_SML_SINGLE_CHILD    ScopeLabel = 6
-	ScopeLabel_SML_STREAM_CHILD    ScopeLabel = 7
-	ScopeLabel_SML_NO_CHILDREN     ScopeLabel = 8
-	ScopeLabel_SML_CHILDREN        ScopeLabel = 9
+	ScopeLabel_STREAM_LOOP             ScopeLabel = 1
+	ScopeLabel_STREAMABLE_LOOP         ScopeLabel = 2
+	ScopeLabel_GENERATOR_STATEMENT     ScopeLabel = 3
+	ScopeLabel_SML_FUNCTION            ScopeLabel = 4
+	ScopeLabel_SML_CONSTRUCTOR         ScopeLabel = 5
+	ScopeLabel_SML_SINGLE_CHILD        ScopeLabel = 6
+	ScopeLabel_SML_STREAM_CHILD        ScopeLabel = 7
+	ScopeLabel_SML_NO_CHILDREN         ScopeLabel = 8
+	ScopeLabel_SML_CHILDREN            ScopeLabel = 9
+	ScopeLabel_NOMINALLY_SHORTCUT_EXPR ScopeLabel = 10
 )
 
 var ScopeLabel_name = map[int32]string{
-	1: "STREAM_LOOP",
-	2: "STREAMABLE_LOOP",
-	3: "GENERATOR_STATEMENT",
-	4: "SML_FUNCTION",
-	5: "SML_CONSTRUCTOR",
-	6: "SML_SINGLE_CHILD",
-	7: "SML_STREAM_CHILD",
-	8: "SML_NO_CHILDREN",
-	9: "SML_CHILDREN",
+	1:  "STREAM_LOOP",
+	2:  "STREAMABLE_LOOP",
+	3:  "GENERATOR_STATEMENT",
+	4:  "SML_FUNCTION",
+	5:  "SML_CONSTRUCTOR",
+	6:  "SML_SINGLE_CHILD",
+	7:  "SML_STREAM_CHILD",
+	8:  "SML_NO_CHILDREN",
+	9:  "SML_CHILDREN",
+	10: "NOMINALLY_SHORTCUT_EXPR",
 }
 var ScopeLabel_value = map[string]int32{
-	"STREAM_LOOP":         1,
-	"STREAMABLE_LOOP":     2,
-	"GENERATOR_STATEMENT": 3,
-	"SML_FUNCTION":        4,
-	"SML_CONSTRUCTOR":     5,
-	"SML_SINGLE_CHILD":    6,
-	"SML_STREAM_CHILD":    7,
-	"SML_NO_CHILDREN":     8,
-	"SML_CHILDREN":        9,
+	"STREAM_LOOP":             1,
+	"STREAMABLE_LOOP":         2,
+	"GENERATOR_STATEMENT":     3,
+	"SML_FUNCTION":            4,
+	"SML_CONSTRUCTOR":         5,
+	"SML_SINGLE_CHILD":        6,
+	"SML_STREAM_CHILD":        7,
+	"SML_NO_CHILDREN":         8,
+	"SML_CHILDREN":            9,
+	"NOMINALLY_SHORTCUT_EXPR": 10,
 }
 
 func (x ScopeLabel) Enum() *ScopeLabel {

--- a/graphs/scopegraph/proto/scopeinfo.proto
+++ b/graphs/scopegraph/proto/scopeinfo.proto
@@ -22,6 +22,10 @@ enum ScopeLabel {
 	SML_STREAM_CHILD = 7; // Marks a SML declaration as having a single stream as a child.
 	SML_NO_CHILDREN = 8; // Mark a SML declaration as having no children.
 	SML_CHILDREN = 9; // Mark a SML declaration as having a set of children.
+
+	NOMINALLY_SHORTCUT_EXPR = 10; // Marks an expression of a nominal type being used 
+					 		      // where its root data is expected. This is a special
+							      // allowance as a shortcut for easier working with native APIs.s
 }
 
 message ScopeInfo {

--- a/graphs/scopegraph/scopegraph.go
+++ b/graphs/scopegraph/scopegraph.go
@@ -8,6 +8,7 @@ package scopegraph
 
 import (
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/serulian/compiler/compilercommon"
@@ -188,6 +189,17 @@ func (sg *ScopeGraph) GetScope(srgNode compilergraph.GraphNode) (proto.ScopeInfo
 
 	scopeInfo := scopeNode.GetTagged(NodePredicateScopeInfo, &proto.ScopeInfo{}).(*proto.ScopeInfo)
 	return *scopeInfo, true
+}
+
+// HasSecondaryLabel returns whether the given SRG node has a secondary scope label of the given kind.
+func (sg *ScopeGraph) HasSecondaryLabel(srgNode compilergraph.GraphNode, label proto.ScopeLabel) bool {
+	_, found := sg.layer.
+		StartQuery(string(srgNode.NodeId)).
+		In(NodePredicateLabelSource).
+		Has(NodePredicateSecondaryLabelValue, strconv.Itoa(int(label))).
+		TryGetNode()
+
+	return found
 }
 
 // resolveSRGTypeRef builds an SRG type reference into a resolved type reference.

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1236,6 +1236,10 @@ var scopeGraphTests = []scopegraphTest{
 		[]expectedScopeEntry{},
 		"Could not find instance name 'DoSomething' under nominal type MyType", ""},
 
+	scopegraphTest{"nominal shortcut (wrapped in place of base)", "nominal", "wrappedinplaceofbase",
+		[]expectedScopeEntry{},
+		"", ""},
+
 	/////////// structural tests /////////////////
 
 	scopegraphTest{"structural equality test", "structnew", "equality",

--- a/graphs/scopegraph/scopegraph_types.go
+++ b/graphs/scopegraph/scopegraph_types.go
@@ -15,9 +15,10 @@ type NodeType int
 
 const (
 	// Top-level
-	NodeTypeError         NodeType = iota // A scope error
-	NodeTypeWarning                       // A scope warning
-	NodeTypeResolvedScope                 // Resolved scope for an SRG node
+	NodeTypeError          NodeType = iota // A scope error
+	NodeTypeWarning                        // A scope warning
+	NodeTypeResolvedScope                  // Resolved scope for an SRG node
+	NodeTypeSecondaryLabel                 // A secondary label on an SRG node
 
 	// NodeType is a tagged type.
 	NodeTypeTagged
@@ -29,6 +30,12 @@ const (
 
 	// Decorates a scope node with its scope info.
 	NodePredicateScopeInfo = "scope-info"
+
+	// Connects a secondary label to its SRG source.
+	NodePredicateLabelSource = "secondary-label-source"
+
+	// Decorates a secondary label node with its label value.
+	NodePredicateSecondaryLabelValue = "secondary-label-value"
 
 	// Connects an error or warning to its SRG source.
 	NodePredicateNoticeSource = "scope-notice"

--- a/graphs/scopegraph/tests/nominal/wrappedinplaceofbase.seru
+++ b/graphs/scopegraph/tests/nominal/wrappedinplaceofbase.seru
@@ -1,0 +1,9 @@
+class SomeClass {}
+
+type SomeType : SomeClass {}
+
+function<void> AnotherFunction(sc SomeClass) {}
+
+function<void> DoSomething(st SomeType) {
+	AnotherFunction(st)
+}


### PR DESCRIPTION
Allows usage of nominally-wrapped values in function calls as arguments where the nominal root data type is expected. 

For example in:

```
class SomeClass {}
type SomeNominalType : SomeClass {}
function<void> DoSomething(sc SomeClass) { ... }
```

The following call will now succeed:

```
var sn = SomeNominalType(...)
DoSomething(sn)
```

This is type safe because an item of `SomeNominalType` is, by definition, merely a boxing of the underlying `SomeClass`.

This change makes working with native ES functions that require native ES types much easier.
