### PR TITLE
Add check to disallow nullable types in match statements

### DIFF
--- a/graphs/scopegraph/scope_statements.go
+++ b/graphs/scopegraph/scope_statements.go
@@ -174,7 +174,12 @@ func (sb *scopeBuilder) scopeMatchStatement(node compilergraph.GraphNode, contex
 				panic(rerr)
 			}
 
-			if serr := matchTypeRef.CheckSubTypeOf(matchExprType); serr != nil {
+			// Ensure that the type is not nullable, as then a null could match anything.
+			if matchTypeRef.IsNullable() {
+				sb.decorateWithError(node, "Match cases cannot be nullable. Found: %v", matchTypeRef)
+				isValid = false
+			} else if serr := matchTypeRef.CheckSubTypeOf(matchExprType); serr != nil {
+				// Ensure that the type is a subtype of the expression type.
 				sb.decorateWithError(node, "Match cases must be subtype of values of type '%v': %v", matchExprType, serr)
 				isValid = false
 			} else {

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -234,6 +234,10 @@ var scopeGraphTests = []scopegraphTest{
 		[]expectedScopeEntry{},
 		"Match cases must be subtype of values of type 'Integer': 'String' cannot be used in place of non-interface 'Integer'", ""},
 
+	scopegraphTest{"match nullable branch test", "match", "nullable",
+		[]expectedScopeEntry{},
+		"Match cases cannot be nullable. Found: String?", ""},
+
 	/////////// Switch ///////////
 
 	scopegraphTest{"basic bool switch test", "switch", "bool",

--- a/graphs/scopegraph/tests/match/nullable.seru
+++ b/graphs/scopegraph/tests/match/nullable.seru
@@ -1,0 +1,6 @@
+function<void> DoSomething(someValue any) {
+	match someValue {
+		case string?:
+			return
+	}
+}


### PR DESCRIPTION
Matching against a nullable would not work if the value is null and there are multiple branches, so we simply disallow it
