### PR TITLE
Reduce the noise of errors by skipping checks on invalid scoped names

### DIFF
--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -335,6 +335,10 @@ var scopeGraphTests = []scopegraphTest{
 		},
 		"", ""},
 
+	scopegraphTest{"bad expression var test", "var", "badexpr",
+		[]expectedScopeEntry{},
+		"The name 'bar' could not be found in this context", ""},
+
 	/////////// SML expression ///////////
 
 	scopegraphTest{"sml expression success test", "sml", "success",

--- a/graphs/scopegraph/tests/var/badexpr.seru
+++ b/graphs/scopegraph/tests/var/badexpr.seru
@@ -1,0 +1,4 @@
+function<void> DoSomething() {
+	var foo = bar
+	foo.something
+}


### PR DESCRIPTION
Before this change, if a variable or other named scope was invalid, it would be treated as a value of type `any`, which resulted in resolution errors. After this change, the error of the scope propagates to all sites _using_ that scope as well, to ensure we skip that checking path.
