### PR TITLE
AssignmentType should never be overridden by context

### DIFF
--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -146,6 +146,10 @@ var scopeGraphTests = []scopegraphTest{
 		},
 		"", ""},
 
+	scopegraphTest{"conditional nullable assignment test", "conditional", "nullableassign",
+		[]expectedScopeEntry{},
+		"", ""},
+
 	scopegraphTest{"conditional with else test", "conditional", "else",
 		[]expectedScopeEntry{
 			expectedScopeEntry{"conditional", expectedScope{true, proto.ScopeKind_VALUE, "void", "Integer"}},

--- a/graphs/scopegraph/tests/conditional/nullableassign.seru
+++ b/graphs/scopegraph/tests/conditional/nullableassign.seru
@@ -1,0 +1,6 @@
+function<void> DoSomething() {
+	var<string?> someString = null
+	if someString is null {
+		someString = 'hello world'
+	}
+}


### PR DESCRIPTION
Fixes a bug where assignment under a conditional with `is null` would fail because the scope graph though the var was now only "null"
