### PR TITLE
Better define the rules around when types can be cast and cannot

### DIFF
--- a/graphs/scopegraph/scope_access_expr.go
+++ b/graphs/scopegraph/scope_access_expr.go
@@ -146,12 +146,12 @@ func (sb *scopeBuilder) scopeCastExpression(node compilergraph.GraphNode, contex
 		return newScope().Invalid().Resolving(castType).GetScope()
 	}
 
-	// Ensure the child expression is a subtype of the cast expression OR is a structural subtype.
+	// Ensure the child expression is a castable type of the cast expression OR is a structural subtype.
 	if childType.CheckStructuralSubtypeOf(castType) {
 		return newScope().Valid().Resolving(castType).GetScope()
 	}
 
-	if serr := castType.CheckSubTypeOf(childType); serr != nil {
+	if serr := castType.CheckCastableFrom(childType); serr != nil {
 		sb.decorateWithError(node, "Cannot cast value of type '%v' to type '%v': %v", childType, castType, serr)
 		return newScope().Invalid().Resolving(castType).GetScope()
 	}

--- a/graphs/scopegraph/scope_statements.go
+++ b/graphs/scopegraph/scope_statements.go
@@ -178,9 +178,9 @@ func (sb *scopeBuilder) scopeMatchStatement(node compilergraph.GraphNode, contex
 			if matchTypeRef.IsNullable() {
 				sb.decorateWithError(node, "Match cases cannot be nullable. Found: %v", matchTypeRef)
 				isValid = false
-			} else if serr := matchTypeRef.CheckSubTypeOf(matchExprType); serr != nil {
+			} else if serr := matchTypeRef.CheckCastableFrom(matchExprType); serr != nil {
 				// Ensure that the type is a subtype of the expression type.
-				sb.decorateWithError(node, "Match cases must be subtype of values of type '%v': %v", matchExprType, serr)
+				sb.decorateWithError(node, "Match cases must be castable from type '%v': %v", matchExprType, serr)
 				isValid = false
 			} else {
 				matchBranchType = matchTypeRef

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -256,7 +256,7 @@ var scopeGraphTests = []scopegraphTest{
 
 	scopegraphTest{"match invalid branch test", "match", "invalidbranch",
 		[]expectedScopeEntry{},
-		"Match cases must be subtype of values of type 'Integer': 'String' cannot be used in place of non-interface 'Integer'", ""},
+		"Match cases must be castable from type 'Integer': 'String' cannot be used in place of non-interface 'Integer'", ""},
 
 	scopegraphTest{"match nullable branch test", "match", "nullable",
 		[]expectedScopeEntry{},
@@ -942,11 +942,15 @@ var scopeGraphTests = []scopegraphTest{
 
 	/////////// Cast expression ///////////
 
-	scopegraphTest{"cast interface success test", "castexpr", "success",
+	scopegraphTest{"cast expr success test", "castexpr", "success",
 		[]expectedScopeEntry{
 			expectedScopeEntry{"cast", expectedScope{true, proto.ScopeKind_VALUE, "SomeClass", "void"}},
 			expectedScopeEntry{"anycast", expectedScope{true, proto.ScopeKind_VALUE, "any", "void"}},
 		},
+		"", ""},
+
+	scopegraphTest{"cast interfaces test", "castexpr", "interfaces",
+		[]expectedScopeEntry{},
 		"", ""},
 
 	scopegraphTest{"cast struct success test", "castexpr", "structcast",

--- a/graphs/scopegraph/tests/castexpr/interfaces.seru
+++ b/graphs/scopegraph/tests/castexpr/interfaces.seru
@@ -1,0 +1,12 @@
+interface First {
+	function<void> FirstFunc()
+}
+
+interface Second {
+	function<void> SecondFunc()
+}
+
+function<void> DoSomething(first First, second Second) {
+	first.(Second)
+	second.(First)
+}


### PR DESCRIPTION
Before this change, we used a simple subtype check. This was too strict and resulted in allowable casts failing to type check.
