### PR TITLE
Fix generation of nullable access operator

### DIFF
--- a/generator/es5/dombuilder/build_access_expr.go
+++ b/generator/es5/dombuilder/build_access_expr.go
@@ -26,8 +26,8 @@ func (db *domBuilder) buildNamedAccess(node compilergraph.GraphNode, name string
 	scope, _ := db.scopegraph.GetScope(node)
 	namedReference, hasNamedReference := db.scopegraph.GetReferencedName(scope)
 
-	// Reference to an unknown name must be a dynamic access.
-	if !hasNamedReference {
+	// Reference to an unknown name or a nullable member access must be a dynamic access.
+	if !hasNamedReference || node.Kind() == parser.NodeNullableMemberAccessExpression {
 		return codedom.DynamicAccess(db.buildExpression(*childExprNode), name, node)
 	}
 

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -152,6 +152,7 @@ var generationTests = []generationTest{
 	generationTest{"stream member access expression", "accessexpr", "streammember", integrationTestNone, ""},
 	generationTest{"member access expressions", "accessexpr", "memberaccess", integrationTestSuccessExpected, ""},
 	generationTest{"function reference access expression", "accessexpr", "funcref", integrationTestSuccessExpected, ""},
+	generationTest{"nullable member access expression", "accessexpr", "nullaccess", integrationTestSuccessExpected, ""},
 
 	generationTest{"full lambda expression", "lambdaexpr", "full", integrationTestSuccessExpected, ""},
 	generationTest{"mini lambda expression", "lambdaexpr", "mini", integrationTestSuccessExpected, ""},

--- a/generator/es5/expressiongenerator/generators.go
+++ b/generator/es5/expressiongenerator/generators.go
@@ -492,7 +492,7 @@ func (eg *expressionGenerator) generateMemberCall(memberCall *codedom.MemberCall
 	var functionCall = codedom.FunctionCall(callPath, arguments, memberCall.BasisNode())
 	if memberCall.Nullable {
 		// Invoke the function with a specialized nullable-invoke.
-		refExpr := callPath.(*codedom.MemberReferenceNode).ChildExpression
+		refExpr := callPath.(*codedom.DynamicAccessNode).ChildExpression
 
 		var isPromising = "false"
 		if memberCall.Member.IsPromising() {

--- a/generator/es5/tests/accessexpr/memberaccess.js
+++ b/generator/es5/tests/accessexpr/memberaccess.js
@@ -73,6 +73,7 @@ $module('memberaccess', function () {
           case 0:
             $t.dynamicaccess($g.memberaccess.SomeClass, 'Build');
             $t.dynamicaccess($g.memberaccess.SomeClass, 'Build');
+            $t.dynamicaccess(scn, 'someInt');
             $t.dynamicaccess(maimport, 'AnotherFunction');
             $g.maimport.AnotherFunction;
             $g.maimport.AnotherFunction;

--- a/generator/es5/tests/accessexpr/nullaccess.js
+++ b/generator/es5/tests/accessexpr/nullaccess.js
@@ -1,0 +1,95 @@
+$module('nullaccess', function () {
+  var $static = this;
+  this.$class('SomeClass', false, '', function () {
+    var $static = this;
+    var $instance = this.prototype;
+    $static.new = function () {
+      var instance = new $static();
+      var init = [];
+      return $promise.all(init).then(function () {
+        return instance;
+      });
+    };
+    $instance.SomeBool = $t.property(function () {
+      var $this = this;
+      var $current = 0;
+      var $continue = function ($resolve, $reject) {
+        $resolve($t.box(true, $g.____testlib.basictypes.Boolean));
+        return;
+      };
+      return $promise.new($continue);
+    });
+    this.$typesig = function () {
+      return $t.createtypesig(['SomeBool', 3, $g.____testlib.basictypes.Boolean.$typeref()], ['new', 1, $g.____testlib.basictypes.Function($g.nullaccess.SomeClass).$typeref()]);
+    };
+  });
+
+  $static.TEST = function () {
+    var $result;
+    var sc;
+    var sc2;
+    var sc3;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      while (true) {
+        switch ($current) {
+          case 0:
+            $g.nullaccess.SomeClass.new().then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            sc = $result;
+            $g.nullaccess.SomeClass.new().then(function ($result0) {
+              $result = $result0;
+              $current = 2;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 2:
+            sc2 = $result;
+            sc3 = null;
+            sc.SomeBool().then(function ($result2) {
+              return $promise.resolve($t.unbox($result2)).then(function ($result1) {
+                return $promise.resolve($t.dynamicaccess(sc2, 'SomeBool')).then(function ($result3) {
+                  return $promise.resolve($result1 && $t.unbox($t.nullcompare($result3, $t.box(false, $g.____testlib.basictypes.Boolean)))).then(function ($result0) {
+                    return $promise.resolve($t.dynamicaccess(sc3, 'SomeBool')).then(function ($result4) {
+                      $result = $t.box($result0 && $t.unbox($t.nullcompare($result4, $t.box(true, $g.____testlib.basictypes.Boolean))), $g.____testlib.basictypes.Boolean);
+                      $current = 3;
+                      $continue($resolve, $reject);
+                      return;
+                    });
+                  });
+                });
+              });
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 3:
+            $resolve($result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  };
+});

--- a/generator/es5/tests/accessexpr/nullaccess.seru
+++ b/generator/es5/tests/accessexpr/nullaccess.seru
@@ -1,0 +1,13 @@
+class SomeClass {
+	property<bool> SomeBool {
+		get { return true }
+	}
+}
+
+function<any> TEST() {
+	var sc = SomeClass.new()
+	var<SomeClass?> sc2 = SomeClass.new()
+	var<SomeClass?> sc3 = null
+
+	return sc.SomeBool && (sc2?.SomeBool ?? false) && (sc3?.SomeBool ?? true)
+}


### PR DESCRIPTION
Before this change, they were simply not generated properly for any member access except function calls (which have special handler code)
