### PR TITLE
Depromise vars for a small performance boost

### DIFF
--- a/generator/es5/generate_type.go
+++ b/generator/es5/generate_type.go
@@ -202,14 +202,13 @@ this.$class('{{ .Type.Name }}', {{ .HasGenerics }}, '{{ .Alias }}', function({{ 
 		{{ range $idx, $kv := $composed.UnsafeIter }}
 			init.push({{ emit $kv.Value }});
   		{{ end }}
+
 		{{ range $idx, $field := .RequiredFields }}
 		{{ if not $field.HasBaseMember }}
-			init.push($promise.new(function(resolve) {
-				instance.{{ $field.Name }} = {{ $field.Name }};
-				resolve();
-			}));
+			instance.{{ $field.Name }} = {{ $field.Name }};
 		{{ end }}
 		{{ end }}
+
 		{{ range $idx, $kv := $vars.UnsafeIter }}
 			init.push({{ emit $kv.Value }});
 		{{ end }}

--- a/generator/es5/generate_type.go
+++ b/generator/es5/generate_type.go
@@ -70,8 +70,10 @@ func (gt generatingType) GenerateImplementedMembers() *ordered_map.OrderedMap {
 }
 
 // GenerateVariables generates the source for all the variables defined under the type.
-func (gt generatingType) GenerateVariables() *ordered_map.OrderedMap {
-	return gt.Generator.generateVariables(gt.Type)
+func (gt generatingType) GenerateVariables() *generatedInitMap {
+	varMap := newGeneratedInitMap()
+	gt.Generator.generateVariables(gt.Type, varMap)
+	return varMap
 }
 
 // RequiredFields returns the fields required to be initialized by this type.
@@ -126,8 +128,8 @@ func (gt generatingType) MappingAnyType() typegraph.TypeReference {
 }
 
 // GenerateComposition generates the source for all the composed types structurually inherited by the type.
-func (gt generatingType) GenerateComposition() *ordered_map.OrderedMap {
-	typeMap := ordered_map.NewOrderedMap()
+func (gt generatingType) GenerateComposition() *generatedInitMap {
+	initMap := newGeneratedInitMap()
 	parentTypes := gt.Type.ParentTypes()
 	for _, parentTypeRef := range parentTypes {
 		data := struct {
@@ -141,10 +143,10 @@ func (gt generatingType) GenerateComposition() *ordered_map.OrderedMap {
 		}
 
 		source := esbuilder.Template("composition", compositionTemplateStr, data)
-		typeMap.Set(parentTypeRef, source)
+		initMap.Set(parentTypeRef, generatedSourceResult{source, true})
 	}
 
-	return typeMap
+	return initMap
 }
 
 // TypeSignatureMethod generates the $typesig method on a type definition.
@@ -196,25 +198,31 @@ this.$class('{{ .Type.Name }}', {{ .HasGenerics }}, '{{ .Alias }}', function({{ 
 
     {{ $vars := .GenerateVariables }}
     {{ $composed := .GenerateComposition }}
+    {{ $combined := $vars.CombineWith $composed }}
+
 	$static.new = function({{ range $ridx, $field := .RequiredFields }}{{ if $ridx }}, {{ end }}{{ $field.Name }}{{ end }}) {
 		var instance = new $static();
-		var init = [];
-		{{ range $idx, $kv := $composed.UnsafeIter }}
-			init.push({{ emit $kv.Value }});
-  		{{ end }}
-
 		{{ range $idx, $field := .RequiredFields }}
 		{{ if not $field.HasBaseMember }}
 			instance.{{ $field.Name }} = {{ $field.Name }};
 		{{ end }}
 		{{ end }}
 
-		{{ range $idx, $kv := $vars.UnsafeIter }}
-			init.push({{ emit $kv.Value }});
+		{{ if $combined.Promising }}
+		var init = [];
 		{{ end }}
+
+		{{ range $idx, $kv := $combined.Iter }}
+			{{ emit $kv.Value }};
+  		{{ end }}
+
+		{{ if $combined.Promising }}
 		return $promise.all(init).then(function() {
 			return instance;
 		});
+		{{ else }}
+		return $promise.resolve(instance);
+		{{ end }}
 	};
 
 	{{range $idx, $kv := .GenerateImplementedMembers.UnsafeIter }}
@@ -235,22 +243,27 @@ this.$struct('{{ .Type.Name }}', {{ .HasGenerics }}, '{{ .Alias }}', function({{
     {{ $vars := .GenerateVariables }}
 	$static.new = function({{ range $ridx, $field := .RequiredFields }}{{ if $ridx }}, {{ end }}{{ $field.Name }}{{ end }}) {
 		var instance = new $static();
-		var init = [];
-
 		instance.$unboxed = false;
-
 		instance[BOXED_DATA_PROPERTY] = {
 			{{ range $idx, $field := .RequiredFields }}
 			'{{ $field.SerializableName }}': {{ $field.Name }},
 			{{ end }}
 		};
 
-		{{ range $idx, $kv := $vars.UnsafeIter }}
-			init.push({{ emit $kv.Value }});
+		{{ if $vars.Promising }}
+		var init = [];
 		{{ end }}
+		{{ range $idx, $kv := $vars.Iter }}
+			{{ emit $kv.Value }};
+		{{ end }}
+
+		{{ if $vars.Promising }}
 		return $promise.all(init).then(function() {
 			return instance;
 		});
+		{{ else }}
+		return $promise.resolve(instance);
+		{{ end }}
 	};
 
 	$static.$fields = [];

--- a/generator/es5/generatedinitmap.go
+++ b/generator/es5/generatedinitmap.go
@@ -1,0 +1,79 @@
+// Copyright 2016 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package es5
+
+import (
+	"github.com/serulian/compiler/generator/escommon/esbuilder"
+
+	"github.com/cevaris/ordered_map"
+)
+
+// generatedSourceResult is the result of generating some expression source.
+type generatedSourceResult struct {
+	// Source is the generated source code.
+	Source esbuilder.SourceBuilder
+
+	// IsPromise indicates whether the generated source is a promise.
+	IsPromise bool
+}
+
+// generatedInitMap defines an ordered map for generated source results, that also
+// tracks whether any are promising.
+type generatedInitMap struct {
+	promising  bool
+	orderedMap *ordered_map.OrderedMap
+}
+
+func newGeneratedInitMap() *generatedInitMap {
+	return &generatedInitMap{
+		promising:  false,
+		orderedMap: ordered_map.NewOrderedMap(),
+	}
+}
+
+// CombineWith combines the other map with this map.
+func (gim *generatedInitMap) CombineWith(other *generatedInitMap) *generatedInitMap {
+	if other.orderedMap.Len() == 0 {
+		return gim
+	}
+
+	combinedMap := gim.orderedMap
+
+	iter := other.orderedMap.IterFunc()
+	for v, ok := iter(); ok; v, ok = iter() {
+		combinedMap.Set(v.Key, v.Value)
+	}
+
+	return &generatedInitMap{
+		promising:  gim.promising || other.promising,
+		orderedMap: combinedMap,
+	}
+}
+
+// Iter returns an iterator over the key/value pairs in this map.
+func (gim *generatedInitMap) Iter() <-chan *ordered_map.KVPair {
+	return gim.orderedMap.UnsafeIter()
+}
+
+// Promising returns whether any of the generated source items in the map are promising.
+func (gim *generatedInitMap) Promising() bool {
+	return gim.promising
+}
+
+// Set sets the given key to the given value. Note that the value *must* be a generatedSourceResult,
+// but this function takes in an interface{} to match the interface of the normal OrderedMap.
+func (gim *generatedInitMap) Set(key interface{}, value interface{}) {
+	result := value.(generatedSourceResult)
+	if result.IsPromise {
+		gim.promising = true
+		wrappedSource := esbuilder.Template("wrappedinit", `
+			(init.push({{ emit . }}))
+		`, result.Source)
+
+		gim.orderedMap.Set(key, wrappedSource)
+	} else {
+		gim.orderedMap.Set(key, result.Source)
+	}
+}

--- a/generator/es5/tests/accessexpr/cast.js
+++ b/generator/es5/tests/accessexpr/cast.js
@@ -5,10 +5,7 @@ $module('cast', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Result = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/accessexpr/funcref.js
+++ b/generator/es5/tests/accessexpr/funcref.js
@@ -5,11 +5,8 @@ $module('funcref', function () {
     var $instance = this.prototype;
     $static.new = function (value) {
       var instance = new $static();
-      var init = [];
       instance.value = value;
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.SomeFunction = function () {
       var $this = this;

--- a/generator/es5/tests/accessexpr/funcref.js
+++ b/generator/es5/tests/accessexpr/funcref.js
@@ -6,10 +6,7 @@ $module('funcref', function () {
     $static.new = function (value) {
       var instance = new $static();
       var init = [];
-      init.push($promise.new(function (resolve) {
-        instance.value = value;
-        resolve();
-      }));
+      instance.value = value;
       return $promise.all(init).then(function () {
         return instance;
       });

--- a/generator/es5/tests/accessexpr/memberaccess.js
+++ b/generator/es5/tests/accessexpr/memberaccess.js
@@ -5,16 +5,9 @@ $module('memberaccess', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(2, $g.____testlib.basictypes.Integer)).then(function (result) {
-        instance.someInt = result;
-      }));
-      init.push($promise.resolve($t.box(true, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.someBool = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.someInt = $t.box(2, $g.____testlib.basictypes.Integer);
+      instance.someBool = $t.box(true, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $static.Build = function () {
       var $result;

--- a/generator/es5/tests/accessexpr/nullaccess.js
+++ b/generator/es5/tests/accessexpr/nullaccess.js
@@ -5,10 +5,7 @@ $module('nullaccess', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.SomeBool = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/accessexpr/streammember.js
+++ b/generator/es5/tests/accessexpr/streammember.js
@@ -5,13 +5,8 @@ $module('streammember', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(2, $g.____testlib.basictypes.Integer)).then(function (result) {
-        instance.SomeInt = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.SomeInt = $t.box(2, $g.____testlib.basictypes.Integer);
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.streammember.SomeClass).$typeref()]);

--- a/generator/es5/tests/accessexpr/structuralcast.js
+++ b/generator/es5/tests/accessexpr/structuralcast.js
@@ -5,10 +5,7 @@ $module('structuralcast', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Result = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/arrowexpr/arrow.js
+++ b/generator/es5/tests/arrowexpr/arrow.js
@@ -5,10 +5,7 @@ $module('arrow', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Then = function (resolve) {
       var $this = this;

--- a/generator/es5/tests/arrowexpr/await.js
+++ b/generator/es5/tests/arrowexpr/await.js
@@ -5,10 +5,7 @@ $module('await', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Then = function (resolve) {
       var $this = this;

--- a/generator/es5/tests/arrowexpr/multiawait.js
+++ b/generator/es5/tests/arrowexpr/multiawait.js
@@ -5,10 +5,7 @@ $module('multiawait', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$plus = function (first, second) {
       var $current = 0;

--- a/generator/es5/tests/async/asyncstruct.js
+++ b/generator/es5/tests/async/asyncstruct.js
@@ -5,15 +5,12 @@ $module('asyncstruct', function () {
     var $instance = this.prototype;
     $static.new = function (Foo, Bar) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         Foo: Foo,
         Bar: Bar,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'Foo', 'Foo', function () {

--- a/generator/es5/tests/cast/classcastfail.js
+++ b/generator/es5/tests/cast/classcastfail.js
@@ -5,10 +5,7 @@ $module('classcastfail', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.classcastfail.SomeClass).$typeref()]);
@@ -20,10 +17,7 @@ $module('classcastfail', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.classcastfail.AnotherClass).$typeref()]);

--- a/generator/es5/tests/cast/genericinterfacecast.js
+++ b/generator/es5/tests/cast/genericinterfacecast.js
@@ -5,10 +5,7 @@ $module('genericinterfacecast', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.SomeValue = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/cast/interfacecast.js
+++ b/generator/es5/tests/cast/interfacecast.js
@@ -5,10 +5,7 @@ $module('interfacecast', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.SomeValue = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/cast/interfacecastfail.js
+++ b/generator/es5/tests/cast/interfacecastfail.js
@@ -5,10 +5,7 @@ $module('interfacecastfail', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.SomeValue = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/cast/nominalautobox.js
+++ b/generator/es5/tests/cast/nominalautobox.js
@@ -5,10 +5,7 @@ $module('nominalautobox', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.nominalautobox.SomeClass).$typeref()]);

--- a/generator/es5/tests/cast/nominalcastfail.js
+++ b/generator/es5/tests/cast/nominalcastfail.js
@@ -5,10 +5,7 @@ $module('nominalcastfail', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.nominalcastfail.SomeClass).$typeref()]);
@@ -20,10 +17,7 @@ $module('nominalcastfail', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.nominalcastfail.AnotherClass).$typeref()]);

--- a/generator/es5/tests/class/basic.js
+++ b/generator/es5/tests/class/basic.js
@@ -6,9 +6,7 @@ $module('basic', function () {
     $static.new = function () {
       var instance = new $static();
       var init = [];
-      init.push($promise.resolve($t.box(2, $g.____testlib.basictypes.Integer)).then(function (result) {
-        instance.SomeInt = result;
-      }));
+      instance.SomeInt = $t.box(2, $g.____testlib.basictypes.Integer);
       init.push($g.basic.CoolFunction().then(function ($result0) {
         instance.AnotherBool = $result0;
       }));

--- a/generator/es5/tests/class/inheritance.js
+++ b/generator/es5/tests/class/inheritance.js
@@ -5,13 +5,8 @@ $module('inheritance', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(true, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.SomeBool = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.SomeBool = $t.box(true, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.DoSomething = function () {
       var $this = this;
@@ -27,13 +22,8 @@ $module('inheritance', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.SomeBool = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.SomeBool = $t.box(false, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.AnotherThing = function () {
       var $this = this;

--- a/generator/es5/tests/class/property.js
+++ b/generator/es5/tests/class/property.js
@@ -5,13 +5,8 @@ $module('property', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.SomeBool = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.SomeBool = $t.box(false, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.SomeProp = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/class/requiredcomposition.js
+++ b/generator/es5/tests/class/requiredcomposition.js
@@ -5,11 +5,8 @@ $module('requiredcomposition', function () {
     var $instance = this.prototype;
     $static.new = function (FirstValue) {
       var instance = new $static();
-      var init = [];
       instance.FirstValue = FirstValue;
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.requiredcomposition.First).$typeref()]);
@@ -21,11 +18,8 @@ $module('requiredcomposition', function () {
     var $instance = this.prototype;
     $static.new = function (SecondValue) {
       var instance = new $static();
-      var init = [];
       instance.SecondValue = SecondValue;
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.requiredcomposition.Second).$typeref()]);

--- a/generator/es5/tests/class/requiredcomposition.js
+++ b/generator/es5/tests/class/requiredcomposition.js
@@ -6,10 +6,7 @@ $module('requiredcomposition', function () {
     $static.new = function (FirstValue) {
       var instance = new $static();
       var init = [];
-      init.push($promise.new(function (resolve) {
-        instance.FirstValue = FirstValue;
-        resolve();
-      }));
+      instance.FirstValue = FirstValue;
       return $promise.all(init).then(function () {
         return instance;
       });
@@ -25,10 +22,7 @@ $module('requiredcomposition', function () {
     $static.new = function (SecondValue) {
       var instance = new $static();
       var init = [];
-      init.push($promise.new(function (resolve) {
-        instance.SecondValue = SecondValue;
-        resolve();
-      }));
+      instance.SecondValue = SecondValue;
       return $promise.all(init).then(function () {
         return instance;
       });

--- a/generator/es5/tests/class/requiredfields.js
+++ b/generator/es5/tests/class/requiredfields.js
@@ -5,14 +5,9 @@ $module('requiredfields', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField) {
       var instance = new $static();
-      var init = [];
       instance.SomeField = SomeField;
-      init.push($promise.resolve($t.box(true, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.AnotherField = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.AnotherField = $t.box(true, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.requiredfields.SomeClass).$typeref()]);

--- a/generator/es5/tests/class/requiredfields.js
+++ b/generator/es5/tests/class/requiredfields.js
@@ -6,10 +6,7 @@ $module('requiredfields', function () {
     $static.new = function (SomeField) {
       var instance = new $static();
       var init = [];
-      init.push($promise.new(function (resolve) {
-        instance.SomeField = SomeField;
-        resolve();
-      }));
+      instance.SomeField = SomeField;
       init.push($promise.resolve($t.box(true, $g.____testlib.basictypes.Boolean)).then(function (result) {
         instance.AnotherField = result;
       }));

--- a/generator/es5/tests/condexpr/calls.js
+++ b/generator/es5/tests/condexpr/calls.js
@@ -5,10 +5,7 @@ $module('calls', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Message = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/generator/resource.js
+++ b/generator/es5/tests/generator/resource.js
@@ -5,13 +5,8 @@ $module('resource', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.released = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.released = $t.box(false, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.Release = function () {
       var $this = this;

--- a/generator/es5/tests/interface/constructable.js
+++ b/generator/es5/tests/interface/constructable.js
@@ -5,10 +5,7 @@ $module('constructable', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.Get = function () {
       var $result;

--- a/generator/es5/tests/literals/identifier.js
+++ b/generator/es5/tests/literals/identifier.js
@@ -5,10 +5,7 @@ $module('identifier', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.identifier.SomeClass).$typeref()]);

--- a/generator/es5/tests/literals/structnew.js
+++ b/generator/es5/tests/literals/structnew.js
@@ -6,10 +6,7 @@ $module('structnew', function () {
     $static.new = function (SomeField) {
       var instance = new $static();
       var init = [];
-      init.push($promise.new(function (resolve) {
-        instance.SomeField = SomeField;
-        resolve();
-      }));
+      instance.SomeField = SomeField;
       init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
         instance.anotherField = result;
       }));

--- a/generator/es5/tests/literals/structnew.js
+++ b/generator/es5/tests/literals/structnew.js
@@ -5,14 +5,9 @@ $module('structnew', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField) {
       var instance = new $static();
-      var init = [];
       instance.SomeField = SomeField;
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.anotherField = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.anotherField = $t.box(false, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.AnotherField = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/literals/this.js
+++ b/generator/es5/tests/literals/this.js
@@ -5,10 +5,7 @@ $module('this', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.DoSomething = function () {
       var $this = this;

--- a/generator/es5/tests/module/basic.js
+++ b/generator/es5/tests/module/basic.js
@@ -17,8 +17,9 @@ $module('basic', function () {
     return $promise.new($continue);
   };
   this.$init(function () {
-    return $promise.resolve($t.box(true, $g.____testlib.basictypes.Boolean)).then(function (result) {
-      $static.someInt = result;
+    return $promise.new(function (resolve) {
+      $static.someInt = $t.box(true, $g.____testlib.basictypes.Boolean);
+      resolve();
     });
   }, 'af4b3683', []);
   this.$init(function () {

--- a/generator/es5/tests/nominal/basic.js
+++ b/generator/es5/tests/nominal/basic.js
@@ -5,10 +5,7 @@ $module('basic', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.DoSomething = function () {
       var $this = this;

--- a/generator/es5/tests/nominal/generic.js
+++ b/generator/es5/tests/nominal/generic.js
@@ -5,10 +5,7 @@ $module('generic', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.DoSomething = function () {
       var $this = this;

--- a/generator/es5/tests/nominal/interface.js
+++ b/generator/es5/tests/nominal/interface.js
@@ -5,10 +5,7 @@ $module('interface', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.SomeValue = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/nominal/nominalbase.js
+++ b/generator/es5/tests/nominal/nominalbase.js
@@ -5,13 +5,8 @@ $module('nominalbase', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(true, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.SomeField = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.SomeField = $t.box(true, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.nominalbase.SomeClass).$typeref()]);

--- a/generator/es5/tests/nominal/shortcut.js
+++ b/generator/es5/tests/nominal/shortcut.js
@@ -5,10 +5,7 @@ $module('shortcut', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Value = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/opexpr/binary.js
+++ b/generator/es5/tests/opexpr/binary.js
@@ -5,10 +5,7 @@ $module('binary', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$xor = function (left, right) {
       var $current = 0;

--- a/generator/es5/tests/opexpr/compare.js
+++ b/generator/es5/tests/opexpr/compare.js
@@ -5,10 +5,7 @@ $module('compare', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$equals = function (first, second) {
       var $current = 0;

--- a/generator/es5/tests/opexpr/functioncallnullable.js
+++ b/generator/es5/tests/opexpr/functioncallnullable.js
@@ -5,10 +5,7 @@ $module('functioncallnullable', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.SomeMethod = function () {
       var $this = this;
@@ -29,10 +26,7 @@ $module('functioncallnullable', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.AnotherMethod = function () {
       var $this = this;

--- a/generator/es5/tests/opexpr/generic.js
+++ b/generator/es5/tests/opexpr/generic.js
@@ -5,10 +5,7 @@ $module('generic', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.BoolValue = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/opexpr/in.js
+++ b/generator/es5/tests/opexpr/in.js
@@ -5,10 +5,7 @@ $module('in', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.$contains = function (value) {
       var $this = this;

--- a/generator/es5/tests/opexpr/indexer.js
+++ b/generator/es5/tests/opexpr/indexer.js
@@ -5,13 +5,8 @@ $module('indexer', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.result = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.result = $t.box(false, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.$index = function (someParam) {
       var $this = this;

--- a/generator/es5/tests/opexpr/notop.js
+++ b/generator/es5/tests/opexpr/notop.js
@@ -6,10 +6,7 @@ $module('notop', function () {
     $static.new = function (boolValue) {
       var instance = new $static();
       var init = [];
-      init.push($promise.new(function (resolve) {
-        instance.boolValue = boolValue;
-        resolve();
-      }));
+      instance.boolValue = boolValue;
       return $promise.all(init).then(function () {
         return instance;
       });

--- a/generator/es5/tests/opexpr/notop.js
+++ b/generator/es5/tests/opexpr/notop.js
@@ -5,11 +5,8 @@ $module('notop', function () {
     var $instance = this.prototype;
     $static.new = function (boolValue) {
       var instance = new $static();
-      var init = [];
       instance.boolValue = boolValue;
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$bool = function (sc) {
       var $current = 0;

--- a/generator/es5/tests/opexpr/nullcomparecall.js
+++ b/generator/es5/tests/opexpr/nullcomparecall.js
@@ -5,10 +5,7 @@ $module('nullcomparecall', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Message = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/opexpr/shortcircuit.js
+++ b/generator/es5/tests/opexpr/shortcircuit.js
@@ -5,10 +5,7 @@ $module('shortcircuit', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Message = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/opexpr/slice.js
+++ b/generator/es5/tests/opexpr/slice.js
@@ -5,10 +5,7 @@ $module('slice', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.$slice = function (start, end) {
       var $this = this;

--- a/generator/es5/tests/opexpr/unary.js
+++ b/generator/es5/tests/opexpr/unary.js
@@ -5,10 +5,7 @@ $module('unary', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$not = function (instance) {
       var $current = 0;

--- a/generator/es5/tests/resolve/expectrejection.js
+++ b/generator/es5/tests/resolve/expectrejection.js
@@ -5,10 +5,7 @@ $module('expectrejection', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Message = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/serialization/custom.js
+++ b/generator/es5/tests/serialization/custom.js
@@ -5,10 +5,7 @@ $module('custom', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.Get = function () {
       var $result;
@@ -116,14 +113,11 @@ $module('custom', function () {
     var $instance = this.prototype;
     $static.new = function (AnotherBool) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         AnotherBool: AnotherBool,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'AnotherBool', 'AnotherBool', function () {
@@ -141,16 +135,13 @@ $module('custom', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField, AnotherField, SomeInstance) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         SomeField: SomeField,
         AnotherField: AnotherField,
         SomeInstance: SomeInstance,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeField', 'SomeField', function () {

--- a/generator/es5/tests/serialization/json.js
+++ b/generator/es5/tests/serialization/json.js
@@ -5,14 +5,11 @@ $module('json', function () {
     var $instance = this.prototype;
     $static.new = function (AnotherBool) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         AnotherBool: AnotherBool,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'AnotherBool', 'AnotherBool', function () {
@@ -30,16 +27,13 @@ $module('json', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField, AnotherField, SomeInstance) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         SomeField: SomeField,
         AnotherField: AnotherField,
         SomeInstance: SomeInstance,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeField', 'SomeField', function () {

--- a/generator/es5/tests/serialization/nominaljson.js
+++ b/generator/es5/tests/serialization/nominaljson.js
@@ -30,14 +30,11 @@ $module('nominaljson', function () {
     var $instance = this.prototype;
     $static.new = function (AnotherBool) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         AnotherBool: AnotherBool,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'AnotherBool', 'AnotherBool', function () {
@@ -55,14 +52,11 @@ $module('nominaljson', function () {
     var $instance = this.prototype;
     $static.new = function (Nested) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         Nested: Nested,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'Nested', 'Nested', function () {

--- a/generator/es5/tests/serialization/slice.js
+++ b/generator/es5/tests/serialization/slice.js
@@ -5,14 +5,11 @@ $module('slice', function () {
     var $instance = this.prototype;
     $static.new = function (AnotherInt) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         AnotherInt: AnotherInt,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'AnotherInt', 'AnotherInt', function () {
@@ -30,14 +27,11 @@ $module('slice', function () {
     var $instance = this.prototype;
     $static.new = function (Values) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         Values: Values,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'Values', 'Values', function () {

--- a/generator/es5/tests/serialization/tagged.js
+++ b/generator/es5/tests/serialization/tagged.js
@@ -5,14 +5,11 @@ $module('tagged', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         somefield: SomeField,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeField', 'somefield', function () {

--- a/generator/es5/tests/sml/classprops.js
+++ b/generator/es5/tests/sml/classprops.js
@@ -5,12 +5,9 @@ $module('classprops', function () {
     var $instance = this.prototype;
     $static.new = function (BoolValue, StringValue) {
       var instance = new $static();
-      var init = [];
       instance.BoolValue = BoolValue;
       instance.StringValue = StringValue;
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     this.$typesig = function () {
       return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.classprops.SomeProps).$typeref()]);

--- a/generator/es5/tests/sml/classprops.js
+++ b/generator/es5/tests/sml/classprops.js
@@ -6,14 +6,8 @@ $module('classprops', function () {
     $static.new = function (BoolValue, StringValue) {
       var instance = new $static();
       var init = [];
-      init.push($promise.new(function (resolve) {
-        instance.BoolValue = BoolValue;
-        resolve();
-      }));
-      init.push($promise.new(function (resolve) {
-        instance.StringValue = StringValue;
-        resolve();
-      }));
+      instance.BoolValue = BoolValue;
+      instance.StringValue = StringValue;
       return $promise.all(init).then(function () {
         return instance;
       });

--- a/generator/es5/tests/sml/simpleclass.js
+++ b/generator/es5/tests/sml/simpleclass.js
@@ -5,10 +5,7 @@ $module('simpleclass', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.Declare = function () {
       var $result;

--- a/generator/es5/tests/sml/structprops.js
+++ b/generator/es5/tests/sml/structprops.js
@@ -5,15 +5,12 @@ $module('structprops', function () {
     var $instance = this.prototype;
     $static.new = function (BoolValue, StringValue) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         BoolValue: BoolValue,
         StringValue: StringValue,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'BoolValue', 'BoolValue', function () {

--- a/generator/es5/tests/sourcemapping/basic.js
+++ b/generator/es5/tests/sourcemapping/basic.js
@@ -683,16 +683,9 @@ this.Serulian = function ($global) {
       var $instance = this.prototype;
       $static.new = function () {
         var instance = new $static();
-        var init = [];
-        init.push($promise.resolve(/*#null#*/null).then(/*#null#*/function (/*#null#*/result) /*#null#*/{
-          instance.First = result;
-        }));
-        init.push($promise.resolve(/*#null#*/null).then(/*#null#*/function (/*#null#*/result) /*#null#*/{
-          instance.Second = result;
-        }));
-        return $promise.all(init).then(function () {
-          return instance;
-        });
+        instance.First = /*#null#*/null;
+        instance.Second = /*#null#*/null;
+        return $promise.resolve(instance);
       };
       $static.Build = function (first, second) {
         var $result;
@@ -738,10 +731,7 @@ this.Serulian = function ($global) {
       var $instance = this.prototype;
       $static.new = function () {
         var instance = new $static();
-        var init = [];
-        return $promise.all(init).then(function () {
-          return instance;
-        });
+        return $promise.resolve(instance);
       };
       this.$typesig = function () {
         return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.____testlib.basictypes.Function(T)).$typeref()]);
@@ -753,19 +743,10 @@ this.Serulian = function ($global) {
       var $instance = this.prototype;
       $static.new = function () {
         var instance = new $static();
-        var init = [];
-        init.push($promise.resolve(/*#0#*/$t.box(/*#0#*/0, /*#0#*/$g.____testlib.basictypes.Integer)).then(/*#0#*/function (/*#0#*/result) /*#0#*/{
-          instance.start = result;
-        }));
-        init.push($promise.resolve(/*#-1#*/$t.box(/*#-1#*/-/*#-1#*/1, /*#-1#*/$g.____testlib.basictypes.Integer)).then(/*#-1#*/function (/*#-1#*/result) /*#-1#*/{
-          instance.end = result;
-        }));
-        init.push($promise.resolve(/*#0#*/$t.box(/*#0#*/0, /*#0#*/$g.____testlib.basictypes.Integer)).then(/*#0#*/function (/*#0#*/result) /*#0#*/{
-          instance.current = result;
-        }));
-        return $promise.all(init).then(function () {
-          return instance;
-        });
+        instance.start = /*#0#*/$t.box(/*#0#*/0, /*#0#*/$g.____testlib.basictypes.Integer);
+        instance.end = /*#-1#*/$t.box(/*#-1#*/-/*#-1#*/1, /*#-1#*/$g.____testlib.basictypes.Integer);
+        instance.current = /*#0#*/$t.box(/*#0#*/0, /*#0#*/$g.____testlib.basictypes.Integer);
+        return $promise.resolve(instance);
       };
       $static.OverRange = function (start, end) {
         var $result;
@@ -895,10 +876,7 @@ this.Serulian = function ($global) {
       var $instance = this.prototype;
       $static.new = function () {
         var instance = new $static();
-        var init = [];
-        return $promise.all(init).then(function () {
-          return instance;
-        });
+        return $promise.resolve(instance);
       };
       this.$typesig = function () {
         return $t.createtypesig(['new', 1, $g.____testlib.basictypes.Function($g.____testlib.basictypes.Float64).$typeref()]);
@@ -910,13 +888,8 @@ this.Serulian = function ($global) {
       var $instance = this.prototype;
       $static.new = function () {
         var instance = new $static();
-        var init = [];
-        init.push($promise.resolve(/*#Array.new()#*/$t.nativenew(/*#Array.new()#*/$global.Array)()).then(/*#Array.new()#*/function (/*#Array.new()#*/result) /*#Array.new()#*/{
-          instance.items = result;
-        }));
-        return $promise.all(init).then(function () {
-          return instance;
-        });
+        instance.items = /*#Array.new()#*/$t.nativenew(/*#Array.new()#*/$global.Array)();
+        return $promise.resolve(instance);
       };
       $static.forArray = function (arr) {
         var $result;
@@ -1160,13 +1133,8 @@ this.Serulian = function ($global) {
       var $instance = this.prototype;
       $static.new = function () {
         var instance = new $static();
-        var init = [];
-        init.push($promise.resolve(/*#Object.new()#*/$t.nativenew(/*#Object.new()#*/$global.Object)()).then(/*#Object.new()#*/function (/*#Object.new()#*/result) /*#Object.new()#*/{
-          instance.internalObject = result;
-        }));
-        return $promise.all(init).then(function () {
-          return instance;
-        });
+        instance.internalObject = /*#Object.new()#*/$t.nativenew(/*#Object.new()#*/$global.Object)();
+        return $promise.resolve(instance);
       };
       $static.forArrays = function (keys, values) {
         var $result;
@@ -1367,10 +1335,7 @@ this.Serulian = function ($global) {
       var $instance = this.prototype;
       $static.new = function () {
         var instance = new $static();
-        var init = [];
-        return $promise.all(init).then(function () {
-          return instance;
-        });
+        return $promise.resolve(instance);
       };
       $static.Get = function () {
         var $result;

--- a/generator/es5/tests/statements/loopstreamable.js
+++ b/generator/es5/tests/statements/loopstreamable.js
@@ -5,10 +5,7 @@ $module('loopstreamable', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Stream = function () {
       var $this = this;
@@ -51,13 +48,8 @@ $module('loopstreamable', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.wasChecked = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.wasChecked = $t.box(false, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.Next = function () {
       var $this = this;

--- a/generator/es5/tests/statements/loopvar.js
+++ b/generator/es5/tests/statements/loopvar.js
@@ -5,13 +5,8 @@ $module('loopvar', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.wasChecked = result;
-      }));
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      instance.wasChecked = $t.box(false, $g.____testlib.basictypes.Boolean);
+      return $promise.resolve(instance);
     };
     $instance.Next = function () {
       var $this = this;

--- a/generator/es5/tests/statements/match.js
+++ b/generator/es5/tests/statements/match.js
@@ -5,10 +5,7 @@ $module('match', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Value = $t.property(function () {
       var $this = this;

--- a/generator/es5/tests/statements/with.js
+++ b/generator/es5/tests/statements/with.js
@@ -5,10 +5,7 @@ $module('with', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Release = function () {
       var $this = this;
@@ -77,8 +74,9 @@ $module('with', function () {
     return $promise.new($continue);
   };
   this.$init(function () {
-    return $promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-      $static.someBool = result;
+    return $promise.new(function (resolve) {
+      $static.someBool = $t.box(false, $g.____testlib.basictypes.Boolean);
+      resolve();
     });
   }, '19a53bdb', []);
 });

--- a/generator/es5/tests/statements/withexit.js
+++ b/generator/es5/tests/statements/withexit.js
@@ -5,10 +5,7 @@ $module('withexit', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $instance.Release = function () {
       var $this = this;
@@ -102,8 +99,9 @@ $module('withexit', function () {
     return $promise.new($continue);
   };
   this.$init(function () {
-    return $promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-      $static.someBool = result;
+    return $promise.new(function (resolve) {
+      $static.someBool = $t.box(false, $g.____testlib.basictypes.Boolean);
+      resolve();
     });
   }, '0b58b8ac', []);
 });

--- a/generator/es5/tests/struct/basic.js
+++ b/generator/es5/tests/struct/basic.js
@@ -5,14 +5,11 @@ $module('basic', function () {
     var $instance = this.prototype;
     $static.new = function (AnotherBool) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         AnotherBool: AnotherBool,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'AnotherBool', 'AnotherBool', function () {
@@ -30,16 +27,13 @@ $module('basic', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField, AnotherField, SomeInstance) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         SomeField: SomeField,
         AnotherField: AnotherField,
         SomeInstance: SomeInstance,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeField', 'SomeField', function () {

--- a/generator/es5/tests/struct/clone.js
+++ b/generator/es5/tests/struct/clone.js
@@ -5,15 +5,12 @@ $module('clone', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField, AnotherField) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         SomeField: SomeField,
         AnotherField: AnotherField,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeField', 'SomeField', function () {

--- a/generator/es5/tests/struct/defaults.js
+++ b/generator/es5/tests/struct/defaults.js
@@ -5,14 +5,11 @@ $module('defaults', function () {
     var $instance = this.prototype;
     $static.new = function (AnotherBool) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         AnotherBool: AnotherBool,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'AnotherBool', 'AnotherBool', function () {
@@ -30,16 +27,12 @@ $module('defaults', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
       };
-      init.push($promise.resolve($t.box(42, $g.____testlib.basictypes.Integer)).then(function (result) {
-        instance.SomeField = result;
-      }));
-      init.push($promise.resolve($t.box(false, $g.____testlib.basictypes.Boolean)).then(function (result) {
-        instance.AnotherField = result;
-      }));
+      var init = [];
+      instance.SomeField = $t.box(42, $g.____testlib.basictypes.Integer);
+      instance.AnotherField = $t.box(false, $g.____testlib.basictypes.Boolean);
       init.push($g.defaults.AnotherStruct.new($t.box(true, $g.____testlib.basictypes.Boolean)).then(function ($result0) {
         instance.SomeInstance = $result0;
       }));

--- a/generator/es5/tests/struct/equals.js
+++ b/generator/es5/tests/struct/equals.js
@@ -5,15 +5,12 @@ $module('equals', function () {
     var $instance = this.prototype;
     $static.new = function (SomeValue, AnotherValue) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         SomeValue: SomeValue,
         AnotherValue: AnotherValue,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeValue', 'SomeValue', function () {
@@ -36,14 +33,11 @@ $module('equals', function () {
     var $instance = this.prototype;
     $static.new = function (StringValue) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         StringValue: StringValue,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'StringValue', 'StringValue', function () {

--- a/generator/es5/tests/struct/generic.js
+++ b/generator/es5/tests/struct/generic.js
@@ -5,14 +5,11 @@ $module('generic', function () {
     var $instance = this.prototype;
     $static.new = function (BoolValue) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         BoolValue: BoolValue,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'BoolValue', 'BoolValue', function () {
@@ -30,14 +27,11 @@ $module('generic', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         SomeField: SomeField,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeField', 'SomeField', function () {

--- a/generator/es5/tests/struct/innergeneric.js
+++ b/generator/es5/tests/struct/innergeneric.js
@@ -5,14 +5,11 @@ $module('innergeneric', function () {
     var $instance = this.prototype;
     $static.new = function (BoolValue) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         BoolValue: BoolValue,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'BoolValue', 'BoolValue', function () {
@@ -30,14 +27,11 @@ $module('innergeneric', function () {
     var $instance = this.prototype;
     $static.new = function (SomeField) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         SomeField: SomeField,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'SomeField', 'SomeField', function () {

--- a/generator/es5/tests/struct/nominal.js
+++ b/generator/es5/tests/struct/nominal.js
@@ -21,14 +21,11 @@ $module('nominal', function () {
     var $instance = this.prototype;
     $static.new = function (someField) {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
         someField: someField,
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'someField', 'someField', function () {

--- a/generator/es5/tests/struct/nullbox.js
+++ b/generator/es5/tests/struct/nullbox.js
@@ -5,13 +5,10 @@ $module('nullbox', function () {
     var $instance = this.prototype;
     $static.new = function () {
       var instance = new $static();
-      var init = [];
       instance.$unboxed = false;
       instance[BOXED_DATA_PROPERTY] = {
       };
-      return $promise.all(init).then(function () {
-        return instance;
-      });
+      return $promise.resolve(instance);
     };
     $static.$fields = [];
     $t.defineStructField($static, 'Value', 'Value', function () {


### PR DESCRIPTION
Removes unnecessary promises around variable initialization whenever possible to boost performance a bit
