### PR TITLE
Statically verify agent construction location

### DIFF
--- a/graphs/scopegraph/helpers.go
+++ b/graphs/scopegraph/helpers.go
@@ -1,0 +1,103 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package scopegraph
+
+import (
+	"fmt"
+
+	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/graphs/typegraph"
+	"github.com/serulian/compiler/parser"
+)
+
+var _ = fmt.Printf
+
+// checkAccessAgentConstruction checks to ensure that if the given node is a member access of
+// a constructor of an *agent*, that the access occurs as part of a call to the constructor,
+// which (in turn) must be under a call to a constructor of a composing type. Returns a pair
+// of booleans indicating whether the call is to an agent constructor and (if so) whether that
+// call met the conditions required.
+func (sb *scopeBuilder) checkAccessAgentConstruction(node compilergraph.GraphNode,
+	memberScope namedScopeInfo,
+	staticTypeRef typegraph.TypeReference,
+	context scopeContext) (bool, bool) {
+	// Only check for agents.
+	if !staticTypeRef.IsRefToAgent() {
+		return false, false
+	}
+
+	// Only for constructors.
+	member, isMember := memberScope.Member()
+	if !isMember {
+		return false, false
+	}
+
+	_, isConstructor := member.ConstructorType()
+	if !isConstructor {
+		return false, false
+	}
+
+	return true, sb.checkAgentConstruction(node, staticTypeRef, context)
+}
+
+// checkAgentStructuralConstruction checks to ensure that if the given node is a structural
+// constructor of an *agent*, that  call is (in turn) under a call to a constructor of a composing
+// type. Returns a pair of booleans indicating whether the call is to an agent constructor and
+// (if so) whether that call met the conditions required.
+func (sb *scopeBuilder) checkAgentStructuralConstruction(node compilergraph.GraphNode,
+	staticTypeRef typegraph.TypeReference,
+	context scopeContext) (bool, bool) {
+
+	// Only check for agents.
+	if !staticTypeRef.IsRefToAgent() {
+		return false, false
+	}
+
+	return true, sb.checkAgentConstruction(node, staticTypeRef, context)
+}
+
+// checkAgentConstruction ensures that construction of an agent of the specified type
+// (which is being performed by the given node, either as a function call or structurally)
+// only occurs where context allows it or under a constructor of the agent itself.
+func (sb *scopeBuilder) checkAgentConstruction(node compilergraph.GraphNode,
+	agentType typegraph.TypeReference, context scopeContext) bool {
+	// Check in context.
+	if context.allowsAgentConstruction(agentType) {
+		return true
+	}
+
+	// Check for being under the agent's constructor.
+	_, parentMember, hasParentType, hasParentMember := context.getParentTypeAndMember(sb.sg.srg, sb.sg.tdg)
+	if !hasParentType || !hasParentMember {
+		sb.decorateWithError(node, "Cannot construct agent '%v' without a composing type's context", agentType)
+		return false
+	}
+
+	constructedType, isConstructor := parentMember.ConstructorType()
+	if !isConstructor || constructedType != agentType {
+		sb.decorateWithError(node, "Cannot construct agent '%v' outside its own constructor or without a composing type's context", agentType)
+		return false
+	}
+
+	// Ensure the call is directly under a `return` statement.
+	_, directlyUnderReturn := node.TryGetIncomingNode(parser.NodeReturnStatementValue)
+	if directlyUnderReturn {
+		return true
+	}
+
+	callNode, underCall := node.TryGetIncomingNode(parser.NodeFunctionCallExpressionChildExpr)
+	if !underCall {
+		sb.decorateWithError(node, "Cannot construct agent '%v' outside a return statement in its own constructor", agentType)
+		return false
+	}
+
+	_, callUnderReturn := callNode.TryGetIncomingNode(parser.NodeReturnStatementValue)
+	if callUnderReturn {
+		return true
+	}
+
+	sb.decorateWithError(node, "Cannot construct agent '%v' outside a return statement in its own constructor", agentType)
+	return false
+}

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1521,15 +1521,15 @@ var scopeGraphTests = []scopegraphTest{
 
 	scopegraphTest{"agent constructor fail test", "agent", "constructorfail",
 		[]expectedScopeEntry{},
-		"Cannot reference constructor 'new' of agent 'SomeAgent' under non-composing type 'SomeClass'", ""},
+		"Cannot construct agent 'SomeAgent' outside its own constructor or without a composing type's context", ""},
 
 	scopegraphTest{"agent struct constructor fail test", "agent", "structconstructfail",
 		[]expectedScopeEntry{},
-		"Cannot structurally construct agent 'SomeAgent' under non-composing type 'SomeClass'", ""},
+		"Cannot construct agent 'SomeAgent' outside its own constructor or without a composing type's context", ""},
 
 	scopegraphTest{"agent constructor generic fail test", "agent", "genericfail",
 		[]expectedScopeEntry{},
-		"Cannot reference constructor 'new' of agent 'SomeAgent<Boolean>' under non-composing type 'SomeClass'", ""},
+		"Cannot construct agent 'SomeAgent<Boolean>' outside its own constructor or without a composing type's context", ""},
 
 	/////////// known issue tests /////////////////
 

--- a/graphs/srg/typeconstructor/tests/agent/agent_shadowing.json
+++ b/graphs/srg/typeconstructor/tests/agent/agent_shadowing.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "52c97fb8f2fc9d689d55e6c1740889be",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "94f2d3b164b8ebf12f5291dbf7a6f3cf": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "94f2d3b164b8ebf12f5291dbf7a6f3cf",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -193,7 +206,20 @@
                 "Child": {
                     "Key": "d0e3bc6ff47ecea2edd0c4140e80f7be",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -224,7 +250,20 @@
                 "Child": {
                     "Key": "18098400da7fc12d2513b83465760868",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "d92fea3634ac6f760e7b15994cfd018f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/agent/agentmeetsprincipal.json
+++ b/graphs/srg/typeconstructor/tests/agent/agentmeetsprincipal.json
@@ -86,7 +86,20 @@
                 "Child": {
                     "Key": "e03daa2917161d4d8342c7af9b95d809",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -182,7 +195,20 @@
                 "Child": {
                     "Key": "c9d92c1837cfdd5e06e1eee79a33a419",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "d92fea3634ac6f760e7b15994cfd018f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/agent/basic.json
+++ b/graphs/srg/typeconstructor/tests/agent/basic.json
@@ -52,7 +52,20 @@
                 "Child": {
                     "Key": "b1cd22b8331a572b0cfb97f54ef4d02e",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -129,7 +142,20 @@
                 "Child": {
                     "Key": "fb2c85022ed61d3e30f8b657996cce0f",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "d92fea3634ac6f760e7b15994cfd018f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/agent/class_shadowing.json
+++ b/graphs/srg/typeconstructor/tests/agent/class_shadowing.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "1407343a1a8765698bf7d0ee2986b474",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -117,7 +130,20 @@
                 "Child": {
                     "Key": "0922c4e3cf04c17baa2b3435dfe86def",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "d92fea3634ac6f760e7b15994cfd018f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/agent/generic.json
+++ b/graphs/srg/typeconstructor/tests/agent/generic.json
@@ -39,7 +39,20 @@
                 "Child": {
                     "Key": "430f7f139a9fe280c40b65949bce378a",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "33a1f689b23bf0ffc8aadd1d6a697b01": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "33a1f689b23bf0ffc8aadd1d6a697b01",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cQ\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -168,7 +181,20 @@
                 "Child": {
                     "Key": "e21d42761f290751551d7488061cd62e",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "f9424aed2e1f3e63b931820d5573bac5": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "f9424aed2e1f3e63b931820d5573bac5",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/agent/multiple.json
+++ b/graphs/srg/typeconstructor/tests/agent/multiple.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "c262fd2b91afd4aae245ddfbc9f8b4aa",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "94f2d3b164b8ebf12f5291dbf7a6f3cf": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "94f2d3b164b8ebf12f5291dbf7a6f3cf",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -126,7 +139,20 @@
                 "Child": {
                     "Key": "e8771491ae5733fdbac5f159b6930c9c",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -157,7 +183,20 @@
                 "Child": {
                     "Key": "d8896c4b9a0b85726f218d822475b31a",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "d92fea3634ac6f760e7b15994cfd018f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/agent/simplegeneric.json
+++ b/graphs/srg/typeconstructor/tests/agent/simplegeneric.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "1fd87f3c37c8e1a1ea87680975e436bd",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "2d6718b793cfc4ee895ab88693a9d0a7": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "2d6718b793cfc4ee895ab88693a9d0a7",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent\u003cT, Q\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/agent/tree.json
+++ b/graphs/srg/typeconstructor/tests/agent/tree.json
@@ -52,7 +52,20 @@
                 "Child": {
                     "Key": "eb1f85038a5e2c3c3e93655a99ce5dcc",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -83,7 +96,20 @@
                 "Child": {
                     "Key": "a7269e5b3719f1c9e220d741eb5ffc04",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "d92fea3634ac6f760e7b15994cfd018f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -127,7 +153,20 @@
                 "Child": {
                     "Key": "704c807541a33c8a425f3f376fa0071f",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "94f2d3b164b8ebf12f5291dbf7a6f3cf": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "94f2d3b164b8ebf12f5291dbf7a6f3cf",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherAgent"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/complexgeneric/complexgeneric.json
+++ b/graphs/srg/typeconstructor/tests/complexgeneric/complexgeneric.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "764117a04f3a13f9710e540a560d6d0d",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "9d366be668aecef79b006adcb03d11f2": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "9d366be668aecef79b006adcb03d11f2",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "InnerClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -55,7 +68,20 @@
                 "Child": {
                     "Key": "935a57265641ed1766d85e683fe657a9",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "4f41ee3216ce8c395e499afc55c6b0cf": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4f41ee3216ce8c395e499afc55c6b0cf",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT, Q\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -116,7 +142,20 @@
                 "Child": {
                     "Key": "b14d78c480398eb776b5722b4f206e07",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "3d9a18c17850718996979c1e14f38576": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "3d9a18c17850718996979c1e14f38576",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/generic/generic.json
+++ b/graphs/srg/typeconstructor/tests/generic/generic.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "b2c7188d26d71e74a7841fd4c681e861",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -85,7 +98,20 @@
                 "Child": {
                     "Key": "cccdf8b1c86dd20df79afacfc83c6c3b",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "4f41ee3216ce8c395e499afc55c6b0cf": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4f41ee3216ce8c395e499afc55c6b0cf",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT, Q\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/genericfunctionconstraint/example.json
+++ b/graphs/srg/typeconstructor/tests/genericfunctionconstraint/example.json
@@ -22,7 +22,20 @@
                 "Child": {
                     "Key": "b3b69f4e1b8dbad9b00a627843cec599",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/genericlocalconstraint/example.json
+++ b/graphs/srg/typeconstructor/tests/genericlocalconstraint/example.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "0ee7f3206405340cace67cb95a00b3b7",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "4f41ee3216ce8c395e499afc55c6b0cf": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4f41ee3216ce8c395e499afc55c6b0cf",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT, Q\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/functiongeneric.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/functiongeneric.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "50a1ad6417ecbc615321bb0005f8fcbe",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -164,7 +177,20 @@
                 "Child": {
                     "Key": "7a27d589e49f715812b2689f1656682c",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "d231ee6741b4360405aefafffb699f45": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d231ee6741b4360405aefafffb699f45",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Tester"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -212,7 +238,20 @@
                 "Child": {
                     "Key": "05e94325067ebb6ec808a38761c03e2c",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "3d9a18c17850718996979c1e14f38576": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "3d9a18c17850718996979c1e14f38576",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/genericinterface.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/genericinterface.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "41f50e75c9b46558f14940a16c2341bf",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "ThirdClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -134,7 +147,20 @@
                 "Child": {
                     "Key": "3613720066c596a273606474d7461123",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -182,7 +208,20 @@
                 "Child": {
                     "Key": "6e1e43d3ad8e72b1c7d9d37b674cad93",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e22eab3a9ec64e59c0293abd20190686": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e22eab3a9ec64e59c0293abd20190686",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/interface.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/interface.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "0be6017a81fda5ec47cfb88b2f8d3e38",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -56,7 +69,20 @@
                 "Child": {
                     "Key": "7c1f9624d25e8dcf2e32e2dbd3ebff67",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e22eab3a9ec64e59c0293abd20190686": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e22eab3a9ec64e59c0293abd20190686",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -196,7 +222,20 @@
                 "Child": {
                     "Key": "9260f40e3b58d354b00a49d66a851f69",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "ThirdClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/interfaceoperator.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/interfaceoperator.json
@@ -56,7 +56,20 @@
                 "Child": {
                     "Key": "c8480145704c500f68a1fc9ce9642d0a",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "ThirdClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -122,7 +135,20 @@
                 "Child": {
                     "Key": "46dcd60662d0febd3ecf87d2afb54706",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -184,7 +210,20 @@
                 "Child": {
                     "Key": "5f372374888e01d2bdc8a234eb2aace0",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e22eab3a9ec64e59c0293abd20190686": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e22eab3a9ec64e59c0293abd20190686",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/nullable.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/nullable.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "6b421a06458d41ac30a5b9a9a2480c15",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "ThirdClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -150,7 +163,20 @@
                 "Child": {
                     "Key": "b491a8d569f7660daefebb750a5db3e2",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e22eab3a9ec64e59c0293abd20190686": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e22eab3a9ec64e59c0293abd20190686",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -195,7 +221,20 @@
                 "Child": {
                     "Key": "2b4c3236c1e417a8f379d5d58bb6fd88",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/interfaceunexported/unexported.json
+++ b/graphs/srg/typeconstructor/tests/interfaceunexported/unexported.json
@@ -24,7 +24,20 @@
                 "Child": {
                     "Key": "e10a99accbbe17cc31c04cd26c4ccbda",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e9ba28b09e703a885097fc3b04962f4b": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e9ba28b09e703a885097fc3b04962f4b",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "GenericClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -55,7 +68,20 @@
                 "Child": {
                     "Key": "3ede2ad0874ba3b18e8554b1e0b2e53d",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -194,7 +220,20 @@
                 "Child": {
                     "Key": "a627f4dd0d39bfc7c452e0377a71b042",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/members/class.json
+++ b/graphs/srg/typeconstructor/tests/members/class.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "8a086d6a923a03022ebd597184a89020",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -73,7 +86,20 @@
                 "Child": {
                     "Key": "4a44ce97287eec29faff2307d5ac7a85",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -320,7 +346,20 @@
                 "Child": {
                     "Key": "70c85c078b256e107039732a98bea66f",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "ThirdClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/members/interface.json
+++ b/graphs/srg/typeconstructor/tests/members/interface.json
@@ -178,7 +178,20 @@
                 "Child": {
                     "Key": "c3d3555d909ad57b389c3744df67ac9c",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/nominal/success.json
+++ b/graphs/srg/typeconstructor/tests/nominal/success.json
@@ -69,7 +69,20 @@
                 "Child": {
                     "Key": "ec1b16967a62ad58d117d36b7e2076a4",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/simple/simple.json
+++ b/graphs/srg/typeconstructor/tests/simple/simple.json
@@ -20,7 +20,20 @@
                 "Child": {
                     "Key": "0529f156d5c905f27137f6e92ba45aac",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b945553b92023e4fd1ae23820ab04ff1": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/stream/stream.json
+++ b/graphs/srg/typeconstructor/tests/stream/stream.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "14fe747fcd77b32d827cbd0822f1361c",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b260da3385668751b37c86a31828c51f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b260da3385668751b37c86a31828c51f",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherClass"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -55,7 +68,20 @@
                 "Child": {
                     "Key": "8debb27b3370756eb8de2b3879599a24",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e22eab3a9ec64e59c0293abd20190686": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e22eab3a9ec64e59c0293abd20190686",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeClass\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/struct/default.json
+++ b/graphs/srg/typeconstructor/tests/struct/default.json
@@ -23,6 +23,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -42,7 +54,20 @@
                 "Child": {
                     "Key": "541eb6aaa164f9127793a6967d3b2bc9",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "String",
@@ -86,6 +111,18 @@
                                     "tdg-source-node": ""
                                 }
                             }
+                        },
+                        "cbbf192423101e2637d29f1e63ab02e8": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Boolean"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -107,7 +144,20 @@
                 "Child": {
                     "Key": "961cce9b25257f750ba7885ed51c4188",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "8fa22a75b14c72936d3e832b686eda58": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "8fa22a75b14c72936d3e832b686eda58",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Clone",
@@ -124,7 +174,20 @@
                 "Child": {
                     "Key": "9b7943d4bf3803f827cc294e6d2f80a1",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "8fa22a75b14c72936d3e832b686eda58": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "8fa22a75b14c72936d3e832b686eda58",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -175,6 +238,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "8fa22a75b14c72936d3e832b686eda58": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "8fa22a75b14c72936d3e832b686eda58",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -195,7 +270,20 @@
                 "Child": {
                     "Key": "b7f4f5c2f7a07403af08afcf842d42a1",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Mapping\u003cany\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Mapping",
@@ -225,7 +313,20 @@
                 "Child": {
                     "Key": "0a7c0c47041a43e81e712c50d038f7c2",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -278,6 +379,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -317,7 +430,20 @@
                 "Child": {
                     "Key": "541eb6aaa164f9127793a6967d3b2bc9",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "String",
@@ -369,6 +495,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -389,7 +527,20 @@
                 "Child": {
                     "Key": "b7f4f5c2f7a07403af08afcf842d42a1",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Mapping\u003cany\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Mapping",
@@ -406,7 +557,20 @@
                 "Child": {
                     "Key": "e6a0df7bee4009aa9ec90fede82bdf14",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Clone",
@@ -434,6 +598,18 @@
                                     "tdg-node-kind": "12|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": ""
+                                }
+                            }
+                        },
+                        "cbbf192423101e2637d29f1e63ab02e8": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Boolean"
                                 }
                             }
                         }

--- a/graphs/srg/typeconstructor/tests/struct/referenced.json
+++ b/graphs/srg/typeconstructor/tests/struct/referenced.json
@@ -26,7 +26,20 @@
                 "Child": {
                     "Key": "40c505f9cf5fdba6c107df5dc47e4959",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "8fa22a75b14c72936d3e832b686eda58": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "8fa22a75b14c72936d3e832b686eda58",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Clone",
@@ -43,7 +56,20 @@
                 "Child": {
                     "Key": "a17e1bfe06b48213f2958413accc4983",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "String",
@@ -60,7 +86,20 @@
                 "Child": {
                     "Key": "a72e06a0d4e89ad288c84b7fb4bd7e18",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Mapping\u003cany\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Mapping",
@@ -90,6 +129,18 @@
                                     "tdg-source-node": ""
                                 }
                             }
+                        },
+                        "cbbf192423101e2637d29f1e63ab02e8": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Boolean"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -111,7 +162,20 @@
                 "Child": {
                     "Key": "cef193a0a94a29b0b205fe33fc6fdab7",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "8fa22a75b14c72936d3e832b686eda58": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "8fa22a75b14c72936d3e832b686eda58",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -158,6 +222,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -190,6 +266,18 @@
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Parser",
                                     "tdg-node-kind": "13|NodeType|tdg"
+                                }
+                            }
+                        },
+                        "8fa22a75b14c72936d3e832b686eda58": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "8fa22a75b14c72936d3e832b686eda58",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
                                 }
                             }
                         }
@@ -225,7 +313,20 @@
                 "Child": {
                     "Key": "2ec8666161bb74001e2b5546fbb12b0e",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Clone",
@@ -293,6 +394,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -326,6 +439,18 @@
                                     "tdg-source-node": ""
                                 }
                             }
+                        },
+                        "cbbf192423101e2637d29f1e63ab02e8": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Boolean"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -347,7 +472,20 @@
                 "Child": {
                     "Key": "a17e1bfe06b48213f2958413accc4983",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "String",
@@ -364,7 +502,20 @@
                 "Child": {
                     "Key": "a72e06a0d4e89ad288c84b7fb4bd7e18",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Mapping\u003cany\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Mapping",
@@ -414,6 +565,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -433,7 +596,20 @@
                 "Child": {
                     "Key": "fe9d90a62b0b7d4b7636126d3afe1d55",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/srg/typeconstructor/tests/struct/success.json
+++ b/graphs/srg/typeconstructor/tests/struct/success.json
@@ -8,7 +8,20 @@
                 "Child": {
                     "Key": "0d8a2e47860790d4c94d800846f73e19",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "113cba3b25d50015bb269fc1c23619b0": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "113cba3b25d50015bb269fc1c23619b0",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",
@@ -44,7 +57,20 @@
                 "Child": {
                     "Key": "1cbf1531dcc5b9c5478d70b02edb0c69",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Mapping\u003cany\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Mapping",
@@ -62,6 +88,18 @@
                     "Key": "535cfc283646bb09bc9552d70a9069cc",
                     "Kind": 9,
                     "Children": {
+                        "113cba3b25d50015bb269fc1c23619b0": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "113cba3b25d50015bb269fc1c23619b0",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct\u003cT\u003e"
+                                }
+                            }
+                        },
                         "5f310277d8ba2f8c8f4095e2e4c166f8": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
@@ -127,6 +165,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -146,7 +196,20 @@
                 "Child": {
                     "Key": "a0a89f9c0d2b2dfefaa3f7c4345b2553",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "String",
@@ -194,6 +257,18 @@
                                     "tdg-source-node": ""
                                 }
                             }
+                        },
+                        "cbbf192423101e2637d29f1e63ab02e8": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Boolean"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -215,7 +290,20 @@
                 "Child": {
                     "Key": "e76e33e084cef89e97b897b6b471a0eb",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "113cba3b25d50015bb269fc1c23619b0": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "113cba3b25d50015bb269fc1c23619b0",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct\u003cT\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Clone",

--- a/graphs/srg/typeconstructor/tests/struct/tagged.json
+++ b/graphs/srg/typeconstructor/tests/struct/tagged.json
@@ -22,7 +22,20 @@
                 "Child": {
                     "Key": "0d797dc904056f893e4286fd092de96b",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "String",
@@ -99,6 +112,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -119,7 +144,20 @@
                 "Child": {
                     "Key": "5e8f937c66a2a1f4170846de9c1aef75",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Mapping\u003cany\u003e"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Mapping",
@@ -151,6 +189,18 @@
                                     "tdg-node-kind": "13|NodeType|tdg"
                                 }
                             }
+                        },
+                        "e77f6a250fab254ce775a6aa23617c22": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e77f6a250fab254ce775a6aa23617c22",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -170,7 +220,20 @@
                 "Child": {
                     "Key": "8fd83470aafb9adf553947c7b40d6bdb",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "Clone",
@@ -200,6 +263,18 @@
                                     "tdg-source-node": ""
                                 }
                             }
+                        },
+                        "cbbf192423101e2637d29f1e63ab02e8": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "Boolean"
+                                }
+                            }
                         }
                     },
                     "Predicates": {
@@ -221,7 +296,20 @@
                 "Child": {
                     "Key": "ae34aeed6a3fea0e764d61014bcef072",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-name": "new",
                         "tdg-member-promising": "1",

--- a/graphs/typegraph/internal_construction.go
+++ b/graphs/typegraph/internal_construction.go
@@ -234,7 +234,9 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 	if typeDecl.isConstructable() {
 		g.defineMember(typeDecl, "new", []string{}, func(decorator *MemberDecorator, generics map[string]TGGeneric) {
 			// The new constructor returns an instance of the type.
-			var memberType = g.FunctionTypeReference(g.NewInstanceTypeReference(typeDecl))
+			returnType := g.NewInstanceTypeReference(typeDecl)
+
+			var memberType = g.FunctionTypeReference(returnType)
 			for _, requiredMember := range typeDecl.RequiredFields() {
 				memberType = memberType.WithParameter(requiredMember.AssignableType())
 			}
@@ -245,6 +247,7 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 				ReadOnly(true).
 				MemberType(memberType).
 				MemberKind(ConstructorMemberSignature).
+				CreateReturnable(decorator.member.GraphNode, returnType).
 				Decorate()
 		})
 	}
@@ -253,7 +256,9 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 	if typeDecl.TypeKind() == StructType {
 		// constructor Parse<T : $parser>(value string)
 		g.defineMember(typeDecl, "Parse", []string{"T"}, func(decorator *MemberDecorator, generics map[string]TGGeneric) {
-			var memberType = g.FunctionTypeReference(g.NewInstanceTypeReference(typeDecl))
+			returnType := g.NewInstanceTypeReference(typeDecl)
+
+			var memberType = g.FunctionTypeReference(returnType)
 			memberType = memberType.WithParameter(g.StringTypeReference())
 
 			decorator.
@@ -264,6 +269,7 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 				ReadOnly(true).
 				MemberType(memberType).
 				MemberKind(ConstructorMemberSignature).
+				CreateReturnable(decorator.member.GraphNode, returnType).
 				Decorate()
 		})
 
@@ -279,12 +285,13 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 				Promising(MemberPromisingDynamic).
 				Exported(true).
 				MemberKind(OperatorMemberSignature).
+				CreateReturnable(decorator.member.GraphNode, g.BoolTypeReference()).
 				Decorate()
 		})
 
 		// function<string> Stringify<T : $stringifier>()
 		g.defineMember(typeDecl, "Stringify", []string{"T"}, func(decorator *MemberDecorator, generics map[string]TGGeneric) {
-			var memberType = g.FunctionTypeReference(g.StringTypeReference())
+			memberType := g.FunctionTypeReference(g.StringTypeReference())
 			decorator.
 				defineGenericConstraint(generics["T"].GraphNode, g.SerializationStringifier().GetTypeReference()).
 				Static(false).
@@ -293,12 +300,14 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 				ReadOnly(true).
 				MemberType(memberType).
 				MemberKind(FunctionMemberSignature).
+				CreateReturnable(decorator.member.GraphNode, g.StringTypeReference()).
 				Decorate()
 		})
 
 		// function<Mapping<any>> Mapping()
 		g.defineMember(typeDecl, "Mapping", []string{}, func(decorator *MemberDecorator, generics map[string]TGGeneric) {
-			var memberType = g.FunctionTypeReference(g.MappingTypeReference(g.AnyTypeReference()))
+			returnType := g.MappingTypeReference(g.AnyTypeReference())
+			memberType := g.FunctionTypeReference(returnType)
 			decorator.
 				Static(false).
 				Promising(MemberNotPromising).
@@ -306,12 +315,14 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 				ReadOnly(true).
 				MemberType(memberType).
 				MemberKind(FunctionMemberSignature).
+				CreateReturnable(decorator.member.GraphNode, returnType).
 				Decorate()
 		})
 
 		// function<ThisType> Clone()
 		g.defineMember(typeDecl, "Clone", []string{}, func(decorator *MemberDecorator, generics map[string]TGGeneric) {
-			var memberType = g.FunctionTypeReference(g.NewInstanceTypeReference(typeDecl))
+			returnType := g.NewInstanceTypeReference(typeDecl)
+			memberType := g.FunctionTypeReference(returnType)
 			decorator.
 				Static(false).
 				Promising(MemberNotPromising).
@@ -319,12 +330,13 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 				ReadOnly(true).
 				MemberType(memberType).
 				MemberKind(FunctionMemberSignature).
+				CreateReturnable(decorator.member.GraphNode, returnType).
 				Decorate()
 		})
 
 		// function<string> String()
 		g.defineMember(typeDecl, "String", []string{}, func(decorator *MemberDecorator, generics map[string]TGGeneric) {
-			var memberType = g.FunctionTypeReference(g.StringTypeReference())
+			memberType := g.FunctionTypeReference(g.StringTypeReference())
 			decorator.
 				Static(false).
 				Promising(MemberNotPromising).
@@ -332,6 +344,7 @@ func (g *TypeGraph) defineImplicitMembers(typeDecl TGTypeDecl) {
 				ReadOnly(true).
 				MemberType(memberType).
 				MemberKind(FunctionMemberSignature).
+				CreateReturnable(decorator.member.GraphNode, g.StringTypeReference()).
 				Decorate()
 		})
 	}

--- a/graphs/typegraph/typegraph_member.go
+++ b/graphs/typegraph/typegraph_member.go
@@ -5,9 +5,13 @@
 package typegraph
 
 import (
+	"fmt"
+
 	"github.com/serulian/compiler/compilergraph"
 	"github.com/serulian/compiler/graphs/typegraph/proto"
 )
+
+var _ = fmt.Printf
 
 // MemberPromisingOption defines the various states of promising for a member.
 type MemberPromisingOption int
@@ -189,6 +193,28 @@ func (tn TGMember) IsType() bool {
 // IsOperator returns whether this is an operator.
 func (tn TGMember) IsOperator() bool {
 	return tn.GraphNode.Kind() == NodeTypeOperator
+}
+
+// ConstructorType returns the type constructed by invoking this member,
+// if it is a constructor.
+func (tn TGMember) ConstructorType() (TypeReference, bool) {
+	// TODO: make this explicit?
+	if !tn.IsStatic() || tn.IsField() || !tn.IsReadOnly() {
+		return tn.tdg.AnyTypeReference(), false
+	}
+
+	returnType, hasReturnType := tn.ReturnType()
+	if !hasReturnType {
+		return tn.tdg.AnyTypeReference(), false
+	}
+
+	parentType, hasParentType := tn.ParentType()
+	if !hasParentType {
+		return tn.tdg.AnyTypeReference(), false
+	}
+
+	parentTypeRef := parentType.GetTypeReference()
+	return parentTypeRef, returnType == parentTypeRef
 }
 
 // IsField returns whether the member is a field.


### PR DESCRIPTION
Currently, agents can be constructed pretty much anywhere, which breaks the requirement that their `principal` back-reference is set immediately (which is done in the constructor of the composing type). As a result, this principal reference can currently be `null` which *breaks the type system guarantee*. Rather than making the `principal` reference nullable (which would make everything perfectly safe, but result in a degradation of code quality), this change restricts the cases in which an agent can be constructed to code in which we know the back-reference will be set immediately.

If we find in the future this code is insufficient or too limiting, we can revisit this decision, but at first design it appears to address all the common use cases of the new agent type kind, without forcing use to loosen the type on `principal`.