### PR TITLE
Change packageloader to support an Entrypoint type

### DIFF
--- a/graphs/scopegraph/scopegraph.go
+++ b/graphs/scopegraph/scopegraph.go
@@ -81,8 +81,8 @@ const (
 
 // Config defines the configuration for scoping.
 type Config struct {
-	// RootSourceFilePath is the root source file path from which to begin scoping.
-	RootSourceFilePath string
+	// Entrypoint is the entrypoint path from which to begin scoping.
+	Entrypoint packageloader.Entrypoint
 
 	// VCSDevelopmentDirectories are the paths to the development directories, if any, that
 	// override VCS imports.
@@ -102,7 +102,7 @@ type Config struct {
 // starting at the given root source file.
 func ParseAndBuildScopeGraph(rootSourceFilePath string, vcsDevelopmentDirectories []string, libraries ...packageloader.Library) Result {
 	result, err := ParseAndBuildScopeGraphWithConfig(Config{
-		RootSourceFilePath:        rootSourceFilePath,
+		Entrypoint:                packageloader.Entrypoint(rootSourceFilePath),
 		VCSDevelopmentDirectories: vcsDevelopmentDirectories,
 		Libraries:                 libraries,
 		Target:                    Compilation,
@@ -120,7 +120,7 @@ func ParseAndBuildScopeGraph(rootSourceFilePath string, vcsDevelopmentDirectorie
 // starting at the root source file specified in configuration. If an *internal error* occurs, it is
 // returned as the `err`. Parsing and scoping errors are returned in the Result.
 func ParseAndBuildScopeGraphWithConfig(config Config) (Result, error) {
-	graph, err := compilergraph.NewGraph(config.RootSourceFilePath)
+	graph, err := compilergraph.NewGraph(config.Entrypoint.Path())
 	if err != nil {
 		return Result{}, err
 	}
@@ -130,7 +130,7 @@ func ParseAndBuildScopeGraphWithConfig(config Config) (Result, error) {
 	webidlgraph := webidl.NewIRG(graph)
 
 	loader := packageloader.NewPackageLoader(packageloader.Config{
-		RootSourceFilePath:        config.RootSourceFilePath,
+		Entrypoint:                config.Entrypoint,
 		PathLoader:                config.PathLoader,
 		VCSDevelopmentDirectories: config.VCSDevelopmentDirectories,
 		AlwaysValidate:            config.Target == Tooling,

--- a/graphs/srg/testutil.go
+++ b/graphs/srg/testutil.go
@@ -27,7 +27,7 @@ func loadSRG(t *testing.T, path string, libPaths ...string) (*SRG, packageloader
 	testLoader := &testTypePackageLoader{graph}
 
 	loader := packageloader.NewPackageLoader(packageloader.Config{
-		RootSourceFilePath:        graph.RootSourceFilePath,
+		Entrypoint:                packageloader.Entrypoint(graph.RootSourceFilePath),
 		VCSDevelopmentDirectories: []string{},
 		SourceHandlers:            []packageloader.SourceHandler{testSRG.PackageLoaderHandler(), testLoader},
 	})

--- a/grok/completion_test.go
+++ b/grok/completion_test.go
@@ -191,7 +191,7 @@ var grokCompletionTests = []grokCompletionTest{
 func TestGrokCompletion(t *testing.T) {
 	for _, grokCompletionTest := range grokCompletionTests {
 		testSourcePath := "tests/" + grokCompletionTest.name + "/" + grokCompletionTest.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		groker := NewGroker(packageloader.Entrypoint(testSourcePath), []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
 		handle, err := groker.GetHandle()
 
 		// Ensure we have a valid groker.

--- a/grok/grok.go
+++ b/grok/grok.go
@@ -13,8 +13,8 @@ import (
 
 // Groker defines a toolkit for providing IDE tooling for Serulian projects.
 type Groker struct {
-	// rootSourceFilePath is the path of the root source file of the project being groked.
-	rootSourceFilePath string
+	// entrypoint is the entrypoint of the project being groked.
+	entrypoint packageloader.Entrypoint
 
 	// vcsDevelopmentDirectories defines the development directories (if any) to use.
 	vcsDevelopmentDirectories []string
@@ -29,15 +29,15 @@ type Groker struct {
 	pathLoader packageloader.PathLoader
 }
 
-// NewGroker returns a new Groker for the given root source file path.
-func NewGroker(rootSourceFilePath string, vcsDevelopmentDirectories []string, libraries []packageloader.Library) *Groker {
-	return NewGrokerWithPathLoader(rootSourceFilePath, vcsDevelopmentDirectories, libraries, packageloader.LocalFilePathLoader{})
+// NewGroker returns a new Groker for the given entrypoint file/directory path.
+func NewGroker(entrypointPath string, vcsDevelopmentDirectories []string, libraries []packageloader.Library) *Groker {
+	return NewGrokerWithPathLoader(entrypointPath, vcsDevelopmentDirectories, libraries, packageloader.LocalFilePathLoader{})
 }
 
-// NewGrokerWithPathLoader returns a new Groker for the given root source file path.
-func NewGrokerWithPathLoader(rootSourceFilePath string, vcsDevelopmentDirectories []string, libraries []packageloader.Library, pathLoader packageloader.PathLoader) *Groker {
+// NewGrokerWithPathLoader returns a new Groker for the given entrypoint file/directory path.
+func NewGrokerWithPathLoader(entrypointPath string, vcsDevelopmentDirectories []string, libraries []packageloader.Library, pathLoader packageloader.PathLoader) *Groker {
 	return &Groker{
-		rootSourceFilePath:        rootSourceFilePath,
+		entrypoint:                packageloader.Entrypoint(entrypointPath),
 		vcsDevelopmentDirectories: vcsDevelopmentDirectories,
 		libraries:                 libraries,
 		pathLoader:                pathLoader,
@@ -71,7 +71,7 @@ func (g *Groker) GetHandle() (Handle, error) {
 // root source file.
 func (g *Groker) refresh() (scopegraph.Result, error) {
 	config := scopegraph.Config{
-		RootSourceFilePath:        g.rootSourceFilePath,
+		Entrypoint:                g.entrypoint,
 		VCSDevelopmentDirectories: g.vcsDevelopmentDirectories,
 		Libraries:                 g.libraries,
 		Target:                    scopegraph.Tooling,

--- a/grok/range_test.go
+++ b/grok/range_test.go
@@ -124,7 +124,7 @@ var grokRangeTests = []grokRangeTest{
 func TestGrokRange(t *testing.T) {
 	for _, grokRangeTest := range grokRangeTests {
 		testSourcePath := "tests/" + grokRangeTest.name + "/" + grokRangeTest.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		groker := NewGroker(packageloader.Entrypoint(testSourcePath), []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
 		handle, err := groker.GetHandle()
 
 		// Ensure we have a valid groker.

--- a/grok/search_test.go
+++ b/grok/search_test.go
@@ -63,7 +63,7 @@ var searchTests = []searchTest{
 func TestSymbolSearch(t *testing.T) {
 	for _, test := range searchTests {
 		testSourcePath := "tests/" + test.name + "/" + test.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		groker := NewGroker(packageloader.Entrypoint(testSourcePath), []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
 		handle, err := groker.GetHandle()
 
 		// Ensure we have a valid groker.

--- a/packageloader/entrypoint.go
+++ b/packageloader/entrypoint.go
@@ -1,0 +1,54 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packageloader
+
+import "path"
+
+// Entrypoint defines an entrypoint for the package loader.
+type Entrypoint string
+
+// IsSourceFile returns true if the entrypoint is a source file (instead of a directory).
+func (e Entrypoint) IsSourceFile(pathloader PathLoader) bool {
+	return pathloader.IsSourceFile(string(e))
+}
+
+// Path returns the path that this entrypoint represents.
+func (e Entrypoint) Path() string {
+	return string(e)
+}
+
+// EntrypointPaths returns all paths for entrypoint source files under this entrypoint.
+// If the entrypoint is a single file, only that file is returned. Otherwise, all files
+// under the directory are returned.
+func (e Entrypoint) EntrypointPaths(pathloader PathLoader) ([]string, error) {
+	if e.IsSourceFile(pathloader) {
+		return []string{string(e)}, nil
+	}
+
+	entries, err := pathloader.LoadDirectory(string(e))
+	if err != nil {
+		return []string{}, err
+	}
+
+	var paths = make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDirectory {
+			continue
+		}
+		paths = append(paths, path.Join(string(e), entry.Name))
+	}
+	return paths, nil
+}
+
+// EntrypointDirectoryPath returns the directory under which all package resolution should occur.
+// If the entrypoint is a file, this will return its parent directory. If a directory, the entrypoint
+// itself will be returned.
+func (e Entrypoint) EntrypointDirectoryPath(pathloader PathLoader) string {
+	if e.IsSourceFile(pathloader) {
+		return path.Dir(string(e))
+	}
+
+	return string(e)
+}

--- a/packageloader/packageloader_test.go
+++ b/packageloader/packageloader_test.go
@@ -256,6 +256,28 @@ func TestLibraryPath(t *testing.T) {
 	assertFileImported(t, tt, "tests/libtest/libfile2.json")
 }
 
+func TestEntrypointDir(t *testing.T) {
+	tt := &testTracker{
+		pathsImported: cmap.New(),
+	}
+
+	loader := NewPackageLoader(Config{
+		Entrypoint:                Entrypoint("tests/libtest/"),
+		SourceHandlers:            []SourceHandler{tt.createHandler()},
+		VCSDevelopmentDirectories: []string{},
+		PathLoader:                LocalFilePathLoader{},
+	})
+
+	result := loader.Load()
+	if !result.Status || len(result.Errors) > 0 {
+		t.Errorf("Expected success, found: %v", result.Errors)
+		return
+	}
+
+	assertFileImported(t, tt, "tests/libtest/libfile1.json")
+	assertFileImported(t, tt, "tests/libtest/libfile2.json")
+}
+
 func assertFileImported(t *testing.T, tt *testTracker, filePath string) {
 	if !tt.pathsImported.Has(filePath) {
 		t.Errorf("Expected import of file %s", filePath)
@@ -293,7 +315,7 @@ func TestLocalLoader(t *testing.T) {
 	}
 
 	loader := NewPackageLoader(Config{
-		RootSourceFilePath:        "startingfile.json",
+		Entrypoint:                Entrypoint("startingfile.json"),
 		SourceHandlers:            []SourceHandler{tt.createHandler()},
 		VCSDevelopmentDirectories: []string{},
 		PathLoader:                TestPathLoader{},

--- a/packageloader/pathloader.go
+++ b/packageloader/pathloader.go
@@ -4,7 +4,10 @@
 
 package packageloader
 
-import "io/ioutil"
+import (
+	"io/ioutil"
+	"os"
+)
 
 // PathLoader defines the interface for loading source files (modules) and directories (packages) in
 // the package loader. Note that VCS checkout will still be done locally, regardless of the path
@@ -34,8 +37,19 @@ func (lfpl LocalFilePathLoader) LoadSourceFile(path string) ([]byte, error) {
 }
 
 func (lfpl LocalFilePathLoader) IsSourceFile(path string) bool {
-	ok, _ := exists(path)
-	return ok
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+
+	defer file.Close()
+
+	fi, err := file.Stat()
+	if err != nil {
+		return false
+	}
+
+	return !fi.IsDir()
 }
 
 func (lfpl LocalFilePathLoader) LoadDirectory(path string) ([]DirectoryEntry, error) {


### PR DESCRIPTION
This allows the entry point to be either a source file (in the compilation case) or a directory (in the workspace tooling case)