### PR TITLE
Add call signature lookup support to Grok

### DIFF
--- a/graphs/srg/typeconstructor/tests/agent/agent_shadowing.json
+++ b/graphs/srg/typeconstructor/tests/agent/agent_shadowing.json
@@ -9,14 +9,14 @@
                     "Key": "1b11f1a33e1b7d25c63126eb7043279f",
                     "Kind": 9,
                     "Children": {
-                        "94f2d3b164b8ebf12f5291dbf7a6f3cf": {
+                        "74e7e770db1cfb7f5f638a7b474e23ef": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "94f2d3b164b8ebf12f5291dbf7a6f3cf",
-                                "Kind": 12,
+                                "Key": "74e7e770db1cfb7f5f638a7b474e23ef",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherAgent"
                                 }
                             }
@@ -40,14 +40,14 @@
                     "Key": "f4b6e0a5144508a6e3addf274ef3033d",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -113,14 +113,14 @@
                     "Key": "3cd55724e87d3898ddc770c22f49bff4",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -147,14 +147,14 @@
                     "Key": "69a1330fa23b893b9106a36818fad07b",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -169,32 +169,6 @@
                         "tdg-member-static": "true",
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/agent/agent_shadowing.seru"
-                    }
-                }
-            },
-            "7e37b81b4c756957f5b187cbc68160bc": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "7e37b81b4c756957f5b187cbc68160bc",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "SomeAgent",
-                        "tdg-agent-type": "SomeAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
-                    }
-                }
-            },
-            "95116fe66a68d6e34634d516ac35b1db": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "95116fe66a68d6e34634d516ac35b1db",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "AnotherAgent",
-                        "tdg-agent-type": "AnotherAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
                     }
                 }
             },
@@ -231,6 +205,32 @@
                         "tdg-source-module": "tests/agent/agent_shadowing.seru"
                     }
                 }
+            },
+            "e0ddb80b7e02f21009088b59f86e223b": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "e0ddb80b7e02f21009088b59f86e223b",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "AnotherAgent",
+                        "tdg-agent-type": "AnotherAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
+                    }
+                }
+            },
+            "fb587f72875626e2798c5c052aaacd49": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "fb587f72875626e2798c5c052aaacd49",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "SomeAgent",
+                        "tdg-agent-type": "SomeAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
+                    }
+                }
             }
         },
         "Predicates": {
@@ -251,14 +251,14 @@
                     "Key": "ab66cfef80a602869d78146f752e8ccc",
                     "Kind": 9,
                     "Children": {
-                        "d92fea3634ac6f760e7b15994cfd018f": {
+                        "ddd492b95697b380468466309e9dd84a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
-                                "Kind": 12,
+                                "Key": "ddd492b95697b380468466309e9dd84a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/agent/agentmeetsprincipal.json
+++ b/graphs/srg/typeconstructor/tests/agent/agentmeetsprincipal.json
@@ -9,14 +9,14 @@
                     "Key": "02f488cd0b50eac75490a9733c23e55d",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -40,14 +40,14 @@
                     "Key": "3bb5c77224b2c74874a41569db814dc5",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -65,19 +65,6 @@
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/agent/agentmeetsprincipal.seru",
                         "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
-            "7e37b81b4c756957f5b187cbc68160bc": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "7e37b81b4c756957f5b187cbc68160bc",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "SomeAgent",
-                        "tdg-agent-type": "SomeAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
                     }
                 }
             },
@@ -111,6 +98,19 @@
                         "tdg-source-module": "tests/agent/agentmeetsprincipal.seru"
                     }
                 }
+            },
+            "fb587f72875626e2798c5c052aaacd49": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "fb587f72875626e2798c5c052aaacd49",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "SomeAgent",
+                        "tdg-agent-type": "SomeAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
+                    }
+                }
             }
         },
         "Predicates": {
@@ -131,14 +131,14 @@
                     "Key": "bb27e6728457da8cbce6e34b984a986b",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -196,14 +196,14 @@
                     "Key": "fde0d2a7602fc7aa6506f49bb1566db1",
                     "Kind": 9,
                     "Children": {
-                        "d92fea3634ac6f760e7b15994cfd018f": {
+                        "ddd492b95697b380468466309e9dd84a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
-                                "Kind": 12,
+                                "Key": "ddd492b95697b380468466309e9dd84a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/agent/basic.json
+++ b/graphs/srg/typeconstructor/tests/agent/basic.json
@@ -17,19 +17,6 @@
                     }
                 }
             },
-            "7e37b81b4c756957f5b187cbc68160bc": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "7e37b81b4c756957f5b187cbc68160bc",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "SomeAgent",
-                        "tdg-agent-type": "SomeAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
-                    }
-                }
-            },
             "893b7bcd753c4290ac4672c73bba2049": {
                 "Predicate": "tdg-node-member",
                 "Child": {
@@ -53,14 +40,14 @@
                     "Key": "b8c54c36dbc4521aeb8ce7b5e9194daa",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -75,6 +62,19 @@
                         "tdg-member-static": "true",
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/agent/basic.seru"
+                    }
+                }
+            },
+            "fb587f72875626e2798c5c052aaacd49": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "fb587f72875626e2798c5c052aaacd49",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "SomeAgent",
+                        "tdg-agent-type": "SomeAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
                     }
                 }
             }
@@ -109,14 +109,14 @@
                     "Key": "2be2c1a5cd525468bf7a8e172a474129",
                     "Kind": 9,
                     "Children": {
-                        "ee0836c2826d2b271d382b47cd83b1f7": {
+                        "aa294057ac2190eecbb5a52b4076c157": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ee0836c2826d2b271d382b47cd83b1f7",
-                                "Kind": 12,
+                                "Key": "aa294057ac2190eecbb5a52b4076c157",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -143,14 +143,14 @@
                     "Key": "4352a430a99e7220285c61ce3ec29c5c",
                     "Kind": 9,
                     "Children": {
-                        "d92fea3634ac6f760e7b15994cfd018f": {
+                        "ddd492b95697b380468466309e9dd84a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
-                                "Kind": 12,
+                                "Key": "ddd492b95697b380468466309e9dd84a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/agent/class_shadowing.json
+++ b/graphs/srg/typeconstructor/tests/agent/class_shadowing.json
@@ -9,14 +9,14 @@
                     "Key": "34bfac86f572b31d3d3a8d519903d213",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -34,33 +34,20 @@
                     }
                 }
             },
-            "7e37b81b4c756957f5b187cbc68160bc": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "7e37b81b4c756957f5b187cbc68160bc",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "SomeAgent",
-                        "tdg-agent-type": "SomeAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
-                    }
-                }
-            },
             "938d410c420dd34486ea37b1386d2bb2": {
                 "Predicate": "tdg-node-member",
                 "Child": {
                     "Key": "938d410c420dd34486ea37b1386d2bb2",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -111,6 +98,19 @@
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
+            },
+            "fb587f72875626e2798c5c052aaacd49": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "fb587f72875626e2798c5c052aaacd49",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "SomeAgent",
+                        "tdg-agent-type": "SomeAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
+                    }
+                }
             }
         },
         "Predicates": {
@@ -131,14 +131,14 @@
                     "Key": "25192dc28a914c373a700ba6bad18f9d",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -164,14 +164,14 @@
                     "Key": "9fdd1dccd9b9e73c748fc345e4ac1b96",
                     "Kind": 9,
                     "Children": {
-                        "d92fea3634ac6f760e7b15994cfd018f": {
+                        "ddd492b95697b380468466309e9dd84a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
-                                "Kind": 12,
+                                "Key": "ddd492b95697b380468466309e9dd84a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/agent/generic.json
+++ b/graphs/srg/typeconstructor/tests/agent/generic.json
@@ -23,14 +23,14 @@
                     "Key": "4b6204dd8f7ae8509756ecda5c7285e1",
                     "Kind": 9,
                     "Children": {
-                        "97824c6d47d2c4388f319a706bc6506a": {
+                        "cab9cdefe83639c60038d35492b56c61": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "97824c6d47d2c4388f319a706bc6506a",
-                                "Kind": 12,
+                                "Key": "cab9cdefe83639c60038d35492b56c61",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "T",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -57,14 +57,14 @@
                     "Key": "4d2f6be26ecdad7cb238f65d1bdfcb24",
                     "Kind": 9,
                     "Children": {
-                        "33a1f689b23bf0ffc8aadd1d6a697b01": {
+                        "3ff36d5b8fd43a5c2e0b9c7a60772d10": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "33a1f689b23bf0ffc8aadd1d6a697b01",
-                                "Kind": 12,
+                                "Key": "3ff36d5b8fd43a5c2e0b9c7a60772d10",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cQ\u003e"
                                 }
                             }
@@ -82,32 +82,32 @@
                     }
                 }
             },
-            "754fe23d336ccfe351b8f21f2391eb6e": {
+            "7afa2cde50aa814f5800b5f6e4e36e9c": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "754fe23d336ccfe351b8f21f2391eb6e",
-                    "Kind": 13,
+                    "Key": "7afa2cde50aa814f5800b5f6e4e36e9c",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "Q",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
             },
-            "7cd2a26445abbc043d2f28d3c7650686": {
+            "afbcb34d2fe9ec30359e0783f5bc20e1": {
                 "Predicate": "tdg-composed-agent",
                 "Child": {
-                    "Key": "7cd2a26445abbc043d2f28d3c7650686",
-                    "Kind": 14,
+                    "Key": "afbcb34d2fe9ec30359e0783f5bc20e1",
+                    "Kind": 15,
                     "Children": {},
                     "Predicates": {
                         "tdg-agent-composition-name": "SomeAgent",
                         "tdg-agent-type": "SomeAgent\u003cQ\u003e",
-                        "tdg-node-kind": "14|NodeType|tdg"
+                        "tdg-node-kind": "15|NodeType|tdg"
                     }
                 }
             },
@@ -166,14 +166,14 @@
                     "Key": "5ec85ea7bf19464940f449a62cab367c",
                     "Kind": 9,
                     "Children": {
-                        "f9424aed2e1f3e63b931820d5573bac5": {
+                        "b7b103e489e1b4147eb3e40a7a0656e1": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "f9424aed2e1f3e63b931820d5573bac5",
-                                "Kind": 12,
+                                "Key": "b7b103e489e1b4147eb3e40a7a0656e1",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent\u003cT\u003e"
                                 }
                             }
@@ -191,18 +191,18 @@
                     }
                 }
             },
-            "b18bbe3c9a23a967467e04815d331b84": {
+            "cf8d6d96d212e8121a701a339fd29eb0": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b18bbe3c9a23a967467e04815d331b84",
-                    "Kind": 13,
+                    "Key": "cf8d6d96d212e8121a701a339fd29eb0",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }

--- a/graphs/srg/typeconstructor/tests/agent/multiple.json
+++ b/graphs/srg/typeconstructor/tests/agent/multiple.json
@@ -9,14 +9,14 @@
                     "Key": "1dad25a345a56cbee6bf1be3e4281b09",
                     "Kind": 9,
                     "Children": {
-                        "94f2d3b164b8ebf12f5291dbf7a6f3cf": {
+                        "74e7e770db1cfb7f5f638a7b474e23ef": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "94f2d3b164b8ebf12f5291dbf7a6f3cf",
-                                "Kind": 12,
+                                "Key": "74e7e770db1cfb7f5f638a7b474e23ef",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherAgent"
                                 }
                             }
@@ -66,14 +66,14 @@
                     "Key": "09339c4559cf2d67dadd9f5abbc07565",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -105,32 +105,6 @@
                     }
                 }
             },
-            "7e37b81b4c756957f5b187cbc68160bc": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "7e37b81b4c756957f5b187cbc68160bc",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "SomeAgent",
-                        "tdg-agent-type": "SomeAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
-                    }
-                }
-            },
-            "95116fe66a68d6e34634d516ac35b1db": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "95116fe66a68d6e34634d516ac35b1db",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "AnotherAgent",
-                        "tdg-agent-type": "AnotherAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
-                    }
-                }
-            },
             "abd9e7efcdae63330b727b3205d67a63": {
                 "Predicate": "tdg-node-member",
                 "Child": {
@@ -148,6 +122,19 @@
                     }
                 }
             },
+            "e0ddb80b7e02f21009088b59f86e223b": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "e0ddb80b7e02f21009088b59f86e223b",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "AnotherAgent",
+                        "tdg-agent-type": "AnotherAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
+                    }
+                }
+            },
             "ef5d204f78b0ae81f4100074929672ba": {
                 "Predicate": "tdg-node-member",
                 "Child": {
@@ -162,6 +149,19 @@
                         "tdg-member-signature": "\n\u000canotheragent\u0010\u0005*\u000cAnotherAgent",
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/agent/multiple.seru"
+                    }
+                }
+            },
+            "fb587f72875626e2798c5c052aaacd49": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "fb587f72875626e2798c5c052aaacd49",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "SomeAgent",
+                        "tdg-agent-type": "SomeAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
                     }
                 }
             }
@@ -184,14 +184,14 @@
                     "Key": "9e2db38174690743204391c807a71cb4",
                     "Kind": 9,
                     "Children": {
-                        "d92fea3634ac6f760e7b15994cfd018f": {
+                        "ddd492b95697b380468466309e9dd84a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
-                                "Kind": 12,
+                                "Key": "ddd492b95697b380468466309e9dd84a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/agent/simplegeneric.json
+++ b/graphs/srg/typeconstructor/tests/agent/simplegeneric.json
@@ -17,18 +17,18 @@
                     }
                 }
             },
-            "2a34bbecdd7bf1c64ae1760e75331828": {
+            "5a3e2051a328d53a9fff72c64f40f16a": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "2a34bbecdd7bf1c64ae1760e75331828",
-                    "Kind": 13,
+                    "Key": "5a3e2051a328d53a9fff72c64f40f16a",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "1",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "Q",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -39,14 +39,14 @@
                     "Key": "ad3d25d4d725117c608c92196b1a1129",
                     "Kind": 9,
                     "Children": {
-                        "2d6718b793cfc4ee895ab88693a9d0a7": {
+                        "25656e560f652c498527afe263fa0b5c": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "2d6718b793cfc4ee895ab88693a9d0a7",
-                                "Kind": 12,
+                                "Key": "25656e560f652c498527afe263fa0b5c",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent\u003cT, Q\u003e"
                                 }
                             }
@@ -64,18 +64,18 @@
                     }
                 }
             },
-            "b18bbe3c9a23a967467e04815d331b84": {
+            "cf8d6d96d212e8121a701a339fd29eb0": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b18bbe3c9a23a967467e04815d331b84",
-                    "Kind": 13,
+                    "Key": "cf8d6d96d212e8121a701a339fd29eb0",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }

--- a/graphs/srg/typeconstructor/tests/agent/tree.json
+++ b/graphs/srg/typeconstructor/tests/agent/tree.json
@@ -17,33 +17,20 @@
                     }
                 }
             },
-            "95116fe66a68d6e34634d516ac35b1db": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "95116fe66a68d6e34634d516ac35b1db",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "AnotherAgent",
-                        "tdg-agent-type": "AnotherAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
-                    }
-                }
-            },
             "98f0a48534cbbef61049a1104276039c": {
                 "Predicate": "tdg-node-member",
                 "Child": {
                     "Key": "98f0a48534cbbef61049a1104276039c",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -77,6 +64,19 @@
                         "tdg-source-module": "tests/agent/tree.seru"
                     }
                 }
+            },
+            "e0ddb80b7e02f21009088b59f86e223b": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "e0ddb80b7e02f21009088b59f86e223b",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "AnotherAgent",
+                        "tdg-agent-type": "AnotherAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
+                    }
+                }
             }
         },
         "Predicates": {
@@ -97,14 +97,14 @@
                     "Key": "65fe52374020d8fa8f81a5f0e2cc2302",
                     "Kind": 9,
                     "Children": {
-                        "d92fea3634ac6f760e7b15994cfd018f": {
+                        "ddd492b95697b380468466309e9dd84a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "d92fea3634ac6f760e7b15994cfd018f",
-                                "Kind": 12,
+                                "Key": "ddd492b95697b380468466309e9dd84a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeAgent"
                                 }
                             }
@@ -148,33 +148,20 @@
         "Key": "ff08b2fff064bd3aa1f533506991a321",
         "Kind": 6,
         "Children": {
-            "7e37b81b4c756957f5b187cbc68160bc": {
-                "Predicate": "tdg-composed-agent",
-                "Child": {
-                    "Key": "7e37b81b4c756957f5b187cbc68160bc",
-                    "Kind": 14,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-agent-composition-name": "SomeAgent",
-                        "tdg-agent-type": "SomeAgent",
-                        "tdg-node-kind": "14|NodeType|tdg"
-                    }
-                }
-            },
             "cf134923639cfd1da5914c8ef7a119ba": {
                 "Predicate": "tdg-node-member",
                 "Child": {
                     "Key": "cf134923639cfd1da5914c8ef7a119ba",
                     "Kind": 9,
                     "Children": {
-                        "94f2d3b164b8ebf12f5291dbf7a6f3cf": {
+                        "74e7e770db1cfb7f5f638a7b474e23ef": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "94f2d3b164b8ebf12f5291dbf7a6f3cf",
-                                "Kind": 12,
+                                "Key": "74e7e770db1cfb7f5f638a7b474e23ef",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherAgent"
                                 }
                             }
@@ -206,6 +193,19 @@
                         "tdg-member-signature": "\n\tsomeagent\u0010\u0005*\tSomeAgent",
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/agent/tree.seru"
+                    }
+                }
+            },
+            "fb587f72875626e2798c5c052aaacd49": {
+                "Predicate": "tdg-composed-agent",
+                "Child": {
+                    "Key": "fb587f72875626e2798c5c052aaacd49",
+                    "Kind": 15,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-agent-composition-name": "SomeAgent",
+                        "tdg-agent-type": "SomeAgent",
+                        "tdg-node-kind": "15|NodeType|tdg"
                     }
                 }
             }

--- a/graphs/srg/typeconstructor/tests/complexgeneric/complexgeneric.json
+++ b/graphs/srg/typeconstructor/tests/complexgeneric/complexgeneric.json
@@ -9,14 +9,14 @@
                     "Key": "44c8f2a841a54b1b6ba4608563fe2875",
                     "Kind": 9,
                     "Children": {
-                        "9d366be668aecef79b006adcb03d11f2": {
+                        "4ef66ddcad7564c667753d466c496892": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "9d366be668aecef79b006adcb03d11f2",
-                                "Kind": 12,
+                                "Key": "4ef66ddcad7564c667753d466c496892",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "InnerClass"
                                 }
                             }
@@ -47,18 +47,18 @@
         "Key": "deef8e748e6aeb21eb42a80fcc6b0376",
         "Kind": 1,
         "Children": {
-            "182f6f13ba7d0607e1a5e90d4756b19c": {
+            "4619dec59c17974a7087cad8555a7a59": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "182f6f13ba7d0607e1a5e90d4756b19c",
-                    "Kind": 13,
+                    "Key": "4619dec59c17974a7087cad8555a7a59",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "1",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "Q",
                         "tdg-generic-subtype": "AnotherClass\u003cInnerClass\u003e?",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -69,14 +69,14 @@
                     "Key": "71263337571b28cfe6c332fba9581227",
                     "Kind": 9,
                     "Children": {
-                        "4f41ee3216ce8c395e499afc55c6b0cf": {
+                        "ee865f8c4248d7afe79388b04b6d87b6": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "4f41ee3216ce8c395e499afc55c6b0cf",
-                                "Kind": 12,
+                                "Key": "ee865f8c4248d7afe79388b04b6d87b6",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT, Q\u003e"
                                 }
                             }
@@ -108,18 +108,18 @@
                     }
                 }
             },
-            "b18bbe3c9a23a967467e04815d331b84": {
+            "cf8d6d96d212e8121a701a339fd29eb0": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b18bbe3c9a23a967467e04815d331b84",
-                    "Kind": 13,
+                    "Key": "cf8d6d96d212e8121a701a339fd29eb0",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -137,36 +137,20 @@
         "Key": "e8aa1db062465caf370f3346b64f883d",
         "Kind": 1,
         "Children": {
-            "b18bbe3c9a23a967467e04815d331b84": {
-                "Predicate": "tdg-declaration-generic",
-                "Child": {
-                    "Key": "b18bbe3c9a23a967467e04815d331b84",
-                    "Kind": 13,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-generic-index": "0",
-                        "tdg-generic-kind": "0",
-                        "tdg-generic-name": "T",
-                        "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
             "babbc047afc17f47223a26b53fa144e4": {
                 "Predicate": "tdg-node-member",
                 "Child": {
                     "Key": "babbc047afc17f47223a26b53fa144e4",
                     "Kind": 9,
                     "Children": {
-                        "3d9a18c17850718996979c1e14f38576": {
+                        "35784dcf0bd84edb223fa39a0cbe4d34": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "3d9a18c17850718996979c1e14f38576",
-                                "Kind": 12,
+                                "Key": "35784dcf0bd84edb223fa39a0cbe4d34",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass\u003cT\u003e"
                                 }
                             }
@@ -181,6 +165,22 @@
                         "tdg-member-static": "true",
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/complexgeneric/complexgeneric.seru"
+                    }
+                }
+            },
+            "cf8d6d96d212e8121a701a339fd29eb0": {
+                "Predicate": "tdg-declaration-generic",
+                "Child": {
+                    "Key": "cf8d6d96d212e8121a701a339fd29eb0",
+                    "Kind": 14,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-generic-index": "0",
+                        "tdg-generic-kind": "0",
+                        "tdg-generic-name": "T",
+                        "tdg-generic-subtype": "any",
+                        "tdg-node-kind": "14|NodeType|tdg",
+                        "tdg-source-node": "(NodeRef)"
                     }
                 }
             }

--- a/graphs/srg/typeconstructor/tests/doccomment/doccomment.json
+++ b/graphs/srg/typeconstructor/tests/doccomment/doccomment.json
@@ -9,14 +9,14 @@
                     "Key": "bbdafb33ec8e3ac51d50cfdef503289b",
                     "Kind": 9,
                     "Children": {
-                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                        "2887369ed13dc7668eb3ee303acc0fd3": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
-                                "Kind": 12,
+                                "Key": "2887369ed13dc7668eb3ee303acc0fd3",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ThirdClass"
                                 }
                             }
@@ -68,14 +68,14 @@
                     "Key": "3e646c7cab3252dbba3d20540240edba",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -102,14 +102,14 @@
                     "Key": "463ce4a3724a3466163fce55f3c1abdf",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -147,14 +147,14 @@
                     "Key": "2192fe716f65afd36b5f673f0b573c5c",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/generic/generic.json
+++ b/graphs/srg/typeconstructor/tests/generic/generic.json
@@ -9,14 +9,14 @@
                     "Key": "c225bb804ae8a730153e0824382d6201",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }
@@ -47,18 +47,18 @@
         "Key": "9a574f15193a94cdadee21f0275d36f6",
         "Kind": 1,
         "Children": {
-            "1d67578882b8e16125f294d13b65d337": {
+            "82ca672e925beb572f46d30017f2f726": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "1d67578882b8e16125f294d13b65d337",
-                    "Kind": 13,
+                    "Key": "82ca672e925beb572f46d30017f2f726",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "1",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "Q",
                         "tdg-generic-subtype": "AnotherClass",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -77,18 +77,18 @@
                     }
                 }
             },
-            "b18bbe3c9a23a967467e04815d331b84": {
+            "cf8d6d96d212e8121a701a339fd29eb0": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b18bbe3c9a23a967467e04815d331b84",
-                    "Kind": 13,
+                    "Key": "cf8d6d96d212e8121a701a339fd29eb0",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -99,14 +99,14 @@
                     "Key": "dec666ce20956f28c363efd094311ba4",
                     "Kind": 9,
                     "Children": {
-                        "4f41ee3216ce8c395e499afc55c6b0cf": {
+                        "ee865f8c4248d7afe79388b04b6d87b6": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "4f41ee3216ce8c395e499afc55c6b0cf",
-                                "Kind": 12,
+                                "Key": "ee865f8c4248d7afe79388b04b6d87b6",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT, Q\u003e"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/genericfunctionconstraint/example.json
+++ b/graphs/srg/typeconstructor/tests/genericfunctionconstraint/example.json
@@ -9,47 +9,47 @@
                     "Key": "26ed25c834a9080b93a9c7785ee8c640",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "Integer",
-                                    "tdg-source-node": "(NodeRef)"
-                                }
-                            }
-                        },
-                        "89af09d1221f2aefbaef8d97da77613f": {
+                        "0f76f768345385d43fdb9184f8d3a24a": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "89af09d1221f2aefbaef8d97da77613f",
-                                "Kind": 13,
+                                "Key": "0f76f768345385d43fdb9184f8d3a24a",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Q",
-                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-node-kind": "14|NodeType|tdg",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
                         },
-                        "dd8f40cabb634a4190ca1f1fba48042b": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "ce879d986d3e8f8954f9b2200cd96675": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "dd8f40cabb634a4190ca1f1fba48042b",
-                                "Kind": 13,
+                                "Key": "ce879d986d3e8f8954f9b2200cd96675",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "1",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "Q",
                                     "tdg-generic-subtype": "any",
-                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-node-kind": "14|NodeType|tdg",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -88,14 +88,14 @@
                     "Key": "a6e46366d46337b0138b84be3d7fba93",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/genericlocalconstraint/example.json
+++ b/graphs/srg/typeconstructor/tests/genericlocalconstraint/example.json
@@ -9,14 +9,14 @@
                     "Key": "0fcbb1a783ca14524f8a1a4a77fc63c1",
                     "Kind": 9,
                     "Children": {
-                        "4f41ee3216ce8c395e499afc55c6b0cf": {
+                        "ee865f8c4248d7afe79388b04b6d87b6": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "4f41ee3216ce8c395e499afc55c6b0cf",
-                                "Kind": 12,
+                                "Key": "ee865f8c4248d7afe79388b04b6d87b6",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT, Q\u003e"
                                 }
                             }
@@ -34,34 +34,18 @@
                     }
                 }
             },
-            "1d0fd2cfa98cae771394c5d56d326cf3": {
+            "1724cede7c2db0d97aa7c1597092a11b": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "1d0fd2cfa98cae771394c5d56d326cf3",
-                    "Kind": 13,
+                    "Key": "1724cede7c2db0d97aa7c1597092a11b",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "Q",
-                        "tdg-node-kind": "13|NodeType|tdg",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
-            "2a34bbecdd7bf1c64ae1760e75331828": {
-                "Predicate": "tdg-declaration-generic",
-                "Child": {
-                    "Key": "2a34bbecdd7bf1c64ae1760e75331828",
-                    "Kind": 13,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-generic-index": "1",
-                        "tdg-generic-kind": "0",
-                        "tdg-generic-name": "Q",
-                        "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -76,6 +60,22 @@
                         "tdg-module-name": "example.seru",
                         "tdg-node-kind": "7|NodeType|tdg",
                         "tdg-source-module": "tests/genericlocalconstraint/example.seru",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
+            "5a3e2051a328d53a9fff72c64f40f16a": {
+                "Predicate": "tdg-declaration-generic",
+                "Child": {
+                    "Key": "5a3e2051a328d53a9fff72c64f40f16a",
+                    "Kind": 14,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-generic-index": "1",
+                        "tdg-generic-kind": "0",
+                        "tdg-generic-name": "Q",
+                        "tdg-generic-subtype": "any",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/functiongeneric.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/functiongeneric.json
@@ -9,14 +9,14 @@
                     "Key": "92732245822061c49932c7ce9025ba13",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -40,31 +40,45 @@
                     "Key": "9b8a1648235e876e5887d0119542f16c",
                     "Kind": 9,
                     "Children": {
-                        "70d15ef967bf9bf3c024c53ae110d1f6": {
+                        "46a68bcb861bb8d34f6f20def4f02f4c": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "70d15ef967bf9bf3c024c53ae110d1f6",
-                                "Kind": 13,
+                                "Key": "46a68bcb861bb8d34f6f20def4f02f4c",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Integer",
-                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-node-kind": "14|NodeType|tdg",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
                         },
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4f75ab1e5b5aa6f2c9ab701761e485a4": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "4f75ab1e5b5aa6f2c9ab701761e485a4",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "T",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -116,31 +130,45 @@
                     "Key": "9b8a1648235e876e5887d0119542f16c",
                     "Kind": 9,
                     "Children": {
-                        "70d15ef967bf9bf3c024c53ae110d1f6": {
+                        "46a68bcb861bb8d34f6f20def4f02f4c": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "70d15ef967bf9bf3c024c53ae110d1f6",
-                                "Kind": 13,
+                                "Key": "46a68bcb861bb8d34f6f20def4f02f4c",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Integer",
-                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-node-kind": "14|NodeType|tdg",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
                         },
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4f75ab1e5b5aa6f2c9ab701761e485a4": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "4f75ab1e5b5aa6f2c9ab701761e485a4",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "T",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -195,14 +223,14 @@
                     "Key": "77b3c881c789d552adc9328676c3cb9b",
                     "Kind": 9,
                     "Children": {
-                        "d231ee6741b4360405aefafffb699f45": {
+                        "55f83fee09fb05cedbaeb9e9ea42b060": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "d231ee6741b4360405aefafffb699f45",
-                                "Kind": 12,
+                                "Key": "55f83fee09fb05cedbaeb9e9ea42b060",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Tester"
                                 }
                             }
@@ -239,14 +267,14 @@
                     "Key": "6fed0cd36669c0a935971699e1bada58",
                     "Kind": 9,
                     "Children": {
-                        "3d9a18c17850718996979c1e14f38576": {
+                        "35784dcf0bd84edb223fa39a0cbe4d34": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "3d9a18c17850718996979c1e14f38576",
-                                "Kind": 12,
+                                "Key": "35784dcf0bd84edb223fa39a0cbe4d34",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass\u003cT\u003e"
                                 }
                             }
@@ -264,18 +292,18 @@
                     }
                 }
             },
-            "b7f8c6181a119bb2f5d424d2b57a6efe": {
+            "8d4e4c675a4bd67010dd1840078f2702": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b7f8c6181a119bb2f5d424d2b57a6efe",
-                    "Kind": 13,
+                    "Key": "8d4e4c675a4bd67010dd1840078f2702",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "ISomeInterface",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/genericinterface.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/genericinterface.json
@@ -9,14 +9,14 @@
                     "Key": "8b668699168f3b3091beabc3911a650f",
                     "Kind": 9,
                     "Children": {
-                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                        "2887369ed13dc7668eb3ee303acc0fd3": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
-                                "Kind": 12,
+                                "Key": "2887369ed13dc7668eb3ee303acc0fd3",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ThirdClass"
                                 }
                             }
@@ -40,15 +40,43 @@
                     "Key": "b9f39b862cea90563fd5a9bf401b1838",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
-                            "Predicate": "tdg-member-returnable",
+                        "26848fa85bbfd4bab22337e70653e0ef": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "26848fa85bbfd4bab22337e70653e0ef",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "dea502ebd1dd8e390dcedaa441ffb29f": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "dea502ebd1dd8e390dcedaa441ffb29f",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "bar",
+                                    "tdg-parameter-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -86,14 +114,42 @@
                     "Key": "87aea08f2e644d3e681cd4ca79ff691d",
                     "Kind": 9,
                     "Children": {
-                        "97824c6d47d2c4388f319a706bc6506a": {
-                            "Predicate": "tdg-member-returnable",
+                        "47369943fc6b579b7236621ad49b8b59": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "97824c6d47d2c4388f319a706bc6506a",
-                                "Kind": 12,
+                                "Key": "47369943fc6b579b7236621ad49b8b59",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "bar",
+                                    "tdg-parameter-type": "T",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4f75ab1e5b5aa6f2c9ab701761e485a4": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "4f75ab1e5b5aa6f2c9ab701761e485a4",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "T",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "cab9cdefe83639c60038d35492b56c61": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cab9cdefe83639c60038d35492b56c61",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "T",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -113,18 +169,18 @@
                     }
                 }
             },
-            "b18bbe3c9a23a967467e04815d331b84": {
+            "cf8d6d96d212e8121a701a339fd29eb0": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b18bbe3c9a23a967467e04815d331b84",
-                    "Kind": 13,
+                    "Key": "cf8d6d96d212e8121a701a339fd29eb0",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -148,14 +204,14 @@
                     "Key": "8467380d718985f74a1cdb16e675f5d7",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }
@@ -209,14 +265,14 @@
                     "Key": "5ef273b9dfe5934f00478f38522735d3",
                     "Kind": 9,
                     "Children": {
-                        "e22eab3a9ec64e59c0293abd20190686": {
+                        "5a57002b14c03d63add3abdcdccdcabf": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e22eab3a9ec64e59c0293abd20190686",
-                                "Kind": 12,
+                                "Key": "5a57002b14c03d63add3abdcdccdcabf",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT\u003e"
                                 }
                             }
@@ -234,22 +290,6 @@
                     }
                 }
             },
-            "a36b739508dc1c519b4fda43c7b29701": {
-                "Predicate": "tdg-declaration-generic",
-                "Child": {
-                    "Key": "a36b739508dc1c519b4fda43c7b29701",
-                    "Kind": 13,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-generic-index": "0",
-                        "tdg-generic-kind": "0",
-                        "tdg-generic-name": "T",
-                        "tdg-generic-subtype": "ISomeInterface\u003cInteger\u003e",
-                        "tdg-node-kind": "13|NodeType|tdg",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
             "b912cdb035bec785a2920552a06f290c": {
                 "Predicate": "tdg-declaration-module",
                 "Child": {
@@ -260,6 +300,22 @@
                         "tdg-module-name": "genericinterface.seru",
                         "tdg-node-kind": "7|NodeType|tdg",
                         "tdg-source-module": "tests/interfaceconstraint/genericinterface.seru",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
+            "c64e6b1db9085b18d9849aa55fa94092": {
+                "Predicate": "tdg-declaration-generic",
+                "Child": {
+                    "Key": "c64e6b1db9085b18d9849aa55fa94092",
+                    "Kind": 14,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-generic-index": "0",
+                        "tdg-generic-kind": "0",
+                        "tdg-generic-name": "T",
+                        "tdg-generic-subtype": "ISomeInterface\u003cInteger\u003e",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/interface.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/interface.json
@@ -26,14 +26,14 @@
                     "Key": "d01fa4ce7f7efc6877c7903f82f861f1",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }
@@ -64,18 +64,18 @@
         "Key": "5da95350f30ce9007cea79df0b14c3d8",
         "Kind": 1,
         "Children": {
-            "b7f8c6181a119bb2f5d424d2b57a6efe": {
+            "8d4e4c675a4bd67010dd1840078f2702": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b7f8c6181a119bb2f5d424d2b57a6efe",
-                    "Kind": 13,
+                    "Key": "8d4e4c675a4bd67010dd1840078f2702",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "ISomeInterface",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -100,14 +100,14 @@
                     "Key": "d9bf4991d4b4ce89df626637815a3bc5",
                     "Kind": 9,
                     "Children": {
-                        "e22eab3a9ec64e59c0293abd20190686": {
+                        "5a57002b14c03d63add3abdcdccdcabf": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e22eab3a9ec64e59c0293abd20190686",
-                                "Kind": 12,
+                                "Key": "5a57002b14c03d63add3abdcdccdcabf",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT\u003e"
                                 }
                             }
@@ -144,15 +144,43 @@
                     "Key": "388df217f8ff5f13bbf3f2c39311e95c",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
-                            "Predicate": "tdg-member-returnable",
+                        "26848fa85bbfd4bab22337e70653e0ef": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "26848fa85bbfd4bab22337e70653e0ef",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "dea502ebd1dd8e390dcedaa441ffb29f": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "dea502ebd1dd8e390dcedaa441ffb29f",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "bar",
+                                    "tdg-parameter-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -190,14 +218,14 @@
                     "Key": "366220e7977d1347258dfb59ad4b1b82",
                     "Kind": 9,
                     "Children": {
-                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                        "2887369ed13dc7668eb3ee303acc0fd3": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
-                                "Kind": 12,
+                                "Key": "2887369ed13dc7668eb3ee303acc0fd3",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ThirdClass"
                                 }
                             }
@@ -221,15 +249,43 @@
                     "Key": "388df217f8ff5f13bbf3f2c39311e95c",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
-                            "Predicate": "tdg-member-returnable",
+                        "26848fa85bbfd4bab22337e70653e0ef": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "26848fa85bbfd4bab22337e70653e0ef",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "dea502ebd1dd8e390dcedaa441ffb29f": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "dea502ebd1dd8e390dcedaa441ffb29f",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "bar",
+                                    "tdg-parameter-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -254,14 +310,14 @@
                     "Key": "9025a980f75839bbd3af1b75fa9d3260",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/interfaceoperator.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/interfaceoperator.json
@@ -9,15 +9,43 @@
                     "Key": "af8990d86e69af5dbfe709cbda1bbde1",
                     "Kind": 10,
                     "Children": {
-                        "2307ac4f0f073d656d32d3d16858eb31": {
+                        "23ebacf14430bdce76ef29ec59b2f54c": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "2307ac4f0f073d656d32d3d16858eb31",
-                                "Kind": 12,
+                                "Key": "23ebacf14430bdce76ef29ec59b2f54c",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ISomeInterface",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "6783e90f9bef7f9ddce25ed806e49725": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "6783e90f9bef7f9ddce25ed806e49725",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "right",
+                                    "tdg-parameter-type": "ISomeInterface",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "903fe87863dd7f90e343be22469bef19": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "903fe87863dd7f90e343be22469bef19",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "left",
+                                    "tdg-parameter-type": "ISomeInterface",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -57,15 +85,43 @@
                     "Key": "8c2e097374e2561d4448e1950d598663",
                     "Kind": 10,
                     "Children": {
-                        "117786da46bf902eb75ea110a111954c": {
-                            "Predicate": "tdg-member-returnable",
+                        "465e896c0b0f38a2dea99ccb013f94d5": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "117786da46bf902eb75ea110a111954c",
-                                "Kind": 12,
+                                "Key": "465e896c0b0f38a2dea99ccb013f94d5",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "left",
+                                    "tdg-parameter-type": "ThirdClass",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "5e29fd0282b24f3bd81979310a37d2b6": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "5e29fd0282b24f3bd81979310a37d2b6",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ThirdClass",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "e1e4f9d546bf31832199a32feb49e9f7": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "e1e4f9d546bf31832199a32feb49e9f7",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "right",
+                                    "tdg-parameter-type": "ThirdClass",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -92,14 +148,14 @@
                     "Key": "b3d89d5e1b1a223db0901b8300590dc9",
                     "Kind": 9,
                     "Children": {
-                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                        "2887369ed13dc7668eb3ee303acc0fd3": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
-                                "Kind": 12,
+                                "Key": "2887369ed13dc7668eb3ee303acc0fd3",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ThirdClass"
                                 }
                             }
@@ -153,14 +209,14 @@
                     "Key": "ecab1c22a16d99f456909ae7403c624b",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }
@@ -211,14 +267,14 @@
                     "Key": "217320e6b58a41b48a828f811f4db0c6",
                     "Kind": 9,
                     "Children": {
-                        "e22eab3a9ec64e59c0293abd20190686": {
+                        "5a57002b14c03d63add3abdcdccdcabf": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e22eab3a9ec64e59c0293abd20190686",
-                                "Kind": 12,
+                                "Key": "5a57002b14c03d63add3abdcdccdcabf",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT\u003e"
                                 }
                             }
@@ -236,18 +292,18 @@
                     }
                 }
             },
-            "b7f8c6181a119bb2f5d424d2b57a6efe": {
+            "8d4e4c675a4bd67010dd1840078f2702": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b7f8c6181a119bb2f5d424d2b57a6efe",
-                    "Kind": 13,
+                    "Key": "8d4e4c675a4bd67010dd1840078f2702",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "ISomeInterface",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }

--- a/graphs/srg/typeconstructor/tests/interfaceconstraint/nullable.json
+++ b/graphs/srg/typeconstructor/tests/interfaceconstraint/nullable.json
@@ -9,14 +9,14 @@
                     "Key": "226989740197257e1f0235de86fb3aa5",
                     "Kind": 9,
                     "Children": {
-                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                        "2887369ed13dc7668eb3ee303acc0fd3": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
-                                "Kind": 12,
+                                "Key": "2887369ed13dc7668eb3ee303acc0fd3",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ThirdClass"
                                 }
                             }
@@ -40,15 +40,43 @@
                     "Key": "eae399cf3a6d8a89c313b4b350e13c12",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
-                            "Predicate": "tdg-member-returnable",
+                        "26848fa85bbfd4bab22337e70653e0ef": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "26848fa85bbfd4bab22337e70653e0ef",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "dea502ebd1dd8e390dcedaa441ffb29f": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "dea502ebd1dd8e390dcedaa441ffb29f",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "bar",
+                                    "tdg-parameter-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -86,14 +114,42 @@
                     "Key": "664b5a90cd32a01cbeaad4d80dec28ea",
                     "Kind": 9,
                     "Children": {
-                        "97824c6d47d2c4388f319a706bc6506a": {
-                            "Predicate": "tdg-member-returnable",
+                        "47369943fc6b579b7236621ad49b8b59": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "97824c6d47d2c4388f319a706bc6506a",
-                                "Kind": 12,
+                                "Key": "47369943fc6b579b7236621ad49b8b59",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "bar",
+                                    "tdg-parameter-type": "T",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "4f75ab1e5b5aa6f2c9ab701761e485a4": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "4f75ab1e5b5aa6f2c9ab701761e485a4",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "foo",
+                                    "tdg-parameter-type": "T",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "cab9cdefe83639c60038d35492b56c61": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "cab9cdefe83639c60038d35492b56c61",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "T",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -113,18 +169,18 @@
                     }
                 }
             },
-            "b18bbe3c9a23a967467e04815d331b84": {
+            "cf8d6d96d212e8121a701a339fd29eb0": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "b18bbe3c9a23a967467e04815d331b84",
-                    "Kind": 13,
+                    "Key": "cf8d6d96d212e8121a701a339fd29eb0",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "any",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -142,18 +198,18 @@
         "Key": "f3953d35557719c19eb3da0be6eefbf4",
         "Kind": 1,
         "Children": {
-            "43f93a903e421d1c9ef5ac2620454ddf": {
+            "3d0c1c3974387a8e62a53fc9ae48ecbe": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "43f93a903e421d1c9ef5ac2620454ddf",
-                    "Kind": 13,
+                    "Key": "3d0c1c3974387a8e62a53fc9ae48ecbe",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "ISomeInterface\u003cInteger\u003e?",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -178,14 +234,14 @@
                     "Key": "f1e23a9ca75c5a845d6952c1ed54474b",
                     "Kind": 9,
                     "Children": {
-                        "e22eab3a9ec64e59c0293abd20190686": {
+                        "5a57002b14c03d63add3abdcdccdcabf": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e22eab3a9ec64e59c0293abd20190686",
-                                "Kind": 12,
+                                "Key": "5a57002b14c03d63add3abdcdccdcabf",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT\u003e"
                                 }
                             }
@@ -222,14 +278,14 @@
                     "Key": "32de9f60151c37f1ac869ab0706ac038",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/interfaceop/success.json
+++ b/graphs/srg/typeconstructor/tests/interfaceop/success.json
@@ -9,14 +9,28 @@
                     "Key": "16a3c56c945980a7a8e4f9b9a65e2e55",
                     "Kind": 10,
                     "Children": {
-                        "429c06163dccb8df2d23a410fdb2bf44": {
-                            "Predicate": "tdg-member-returnable",
+                        "8ae3cd3f5552db3513ff05e3b675a629": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "429c06163dccb8df2d23a410fdb2bf44",
-                                "Kind": 12,
+                                "Key": "8ae3cd3f5552db3513ff05e3b675a629",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "index",
+                                    "tdg-parameter-type": "any",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "fedd62b9068d32ea10a64c780152338e": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "fedd62b9068d32ea10a64c780152338e",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "any",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -43,15 +57,43 @@
                     "Key": "8ce43b8750e490b7119a25a5e05e2960",
                     "Kind": 10,
                     "Children": {
-                        "f16ec07a909bced2a26e291dec2f92b5": {
-                            "Predicate": "tdg-member-returnable",
+                        "12532cbe9832c742b982054c8a50de99": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "f16ec07a909bced2a26e291dec2f92b5",
-                                "Kind": 12,
+                                "Key": "12532cbe9832c742b982054c8a50de99",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "right",
+                                    "tdg-parameter-type": "Foo",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "26902cdcfe4be8b4fc2ae03184e86817": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "26902cdcfe4be8b4fc2ae03184e86817",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Foo",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "6077164f662d636df9ffa5d1fa725467": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "6077164f662d636df9ffa5d1fa725467",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "left",
+                                    "tdg-parameter-type": "Foo",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/interfaceunexported/unexported.json
+++ b/graphs/srg/typeconstructor/tests/interfaceunexported/unexported.json
@@ -9,14 +9,14 @@
                     "Key": "1565bc9037e2f26b8e8ffad7ff87b5f5",
                     "Kind": 9,
                     "Children": {
-                        "e9ba28b09e703a885097fc3b04962f4b": {
+                        "b88c5b0996b8df7cbbecaba3f6a68e7d": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e9ba28b09e703a885097fc3b04962f4b",
-                                "Kind": 12,
+                                "Key": "b88c5b0996b8df7cbbecaba3f6a68e7d",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "GenericClass\u003cT\u003e"
                                 }
                             }
@@ -34,18 +34,18 @@
                     }
                 }
             },
-            "4a485353e8b6589a12d7ec145ec0b02e": {
+            "d043690c0ec0ed010388f609874aa8d0": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "4a485353e8b6589a12d7ec145ec0b02e",
-                    "Kind": 13,
+                    "Key": "d043690c0ec0ed010388f609874aa8d0",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "ISomething",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -83,14 +83,14 @@
                     "Key": "bcd4986683244ffb3355f1ebe4e76062",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -115,14 +115,14 @@
                     "Key": "dbe155d3dbe4de332f2123760b02ba24",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -159,14 +159,14 @@
                     "Key": "bcd4986683244ffb3355f1ebe4e76062",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -204,14 +204,14 @@
                     "Key": "63b51f25cddd5179230a777b4a019964",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/members/class.json
+++ b/graphs/srg/typeconstructor/tests/members/class.json
@@ -9,14 +9,14 @@
                     "Key": "65cde5840cde466c5f68b366ba54aefe",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }
@@ -53,14 +53,42 @@
                     "Key": "45c7427e20a142808e2bc3bb307fa2f5",
                     "Kind": 10,
                     "Children": {
-                        "d905ec842611e1d962d00736770c3897": {
-                            "Predicate": "tdg-member-returnable",
+                        "18e6081ec6496a927efee5f499c9b9c2": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "d905ec842611e1d962d00736770c3897",
-                                "Kind": 12,
+                                "Key": "18e6081ec6496a927efee5f499c9b9c2",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "right",
+                                    "tdg-parameter-type": "SomeClass",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "37c05e9efbecf19842298749a13b5415": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "37c05e9efbecf19842298749a13b5415",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "left",
+                                    "tdg-parameter-type": "SomeClass",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "d17271790715d342403fe73af63828c4": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d17271790715d342403fe73af63828c4",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -102,14 +130,14 @@
                     "Key": "6654ee462bc9f34ef231f4ccefd13c84",
                     "Kind": 9,
                     "Children": {
-                        "246681e20d0caed3c9d24594896bbf07": {
+                        "2a3a8465b5af3953cdb23fd739cbd525": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "246681e20d0caed3c9d24594896bbf07",
-                                "Kind": 12,
+                                "Key": "2a3a8465b5af3953cdb23fd739cbd525",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Slice\u003cInteger\u003e",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -153,14 +181,14 @@
                     "Key": "a53eaf550deafa3d49a1f1e566f34666",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }
@@ -184,14 +212,14 @@
                     "Key": "e1c8d26be9ab33485f8574bf227d61b9",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -218,15 +246,43 @@
                     "Key": "e254e0dda814017db90f99c70ba4468f",
                     "Kind": 9,
                     "Children": {
-                        "ccf0d15451797998e86194f221896e91": {
+                        "2169d55d5ca3c244a849e4b653d2a095": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ccf0d15451797998e86194f221896e91",
-                                "Kind": 12,
+                                "Key": "2169d55d5ca3c244a849e4b653d2a095",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "2269ff1e90c450bf086d40dae8376dec": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "2269ff1e90c450bf086d40dae8376dec",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "second",
+                                    "tdg-parameter-type": "AnotherClass",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "f2601b3d04d9a5b78a284c93009bbb19": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "f2601b3d04d9a5b78a284c93009bbb19",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "first",
+                                    "tdg-parameter-type": "ThirdClass",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -251,14 +307,14 @@
                     "Key": "f18d8bc593774bee4309631c86257027",
                     "Kind": 9,
                     "Children": {
-                        "6e42367c90399a327f5140f04dd42891": {
+                        "c8370e376e82bd6ac4578b2d41bb4998": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "6e42367c90399a327f5140f04dd42891",
-                                "Kind": 12,
+                                "Key": "c8370e376e82bd6ac4578b2d41bb4998",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -284,30 +340,44 @@
                     "Key": "f487ad9b0d9cbfe2dfae5b9b3ee12866",
                     "Kind": 9,
                     "Children": {
-                        "856d2600976c26d387bb71f93650e837": {
+                        "526f6de092a298466ab12273fa61b0db": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "856d2600976c26d387bb71f93650e837",
-                                "Kind": 13,
+                                "Key": "526f6de092a298466ab12273fa61b0db",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "C",
                                     "tdg-generic-subtype": "any",
-                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-node-kind": "14|NodeType|tdg",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
                         },
-                        "d905ec842611e1d962d00736770c3897": {
-                            "Predicate": "tdg-member-returnable",
+                        "8cccb7ecbf5e3b9dd8eb1a1136175f2c": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "d905ec842611e1d962d00736770c3897",
-                                "Kind": 12,
+                                "Key": "8cccb7ecbf5e3b9dd8eb1a1136175f2c",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "param",
+                                    "tdg-parameter-type": "C",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "d17271790715d342403fe73af63828c4": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "d17271790715d342403fe73af63828c4",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -347,14 +417,14 @@
                     "Key": "1ec2adf78c1bb17b9004ec3994721b1b",
                     "Kind": 9,
                     "Children": {
-                        "9fc2fd555054c445b1dcb0e738f6505c": {
+                        "2887369ed13dc7668eb3ee303acc0fd3": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "9fc2fd555054c445b1dcb0e738f6505c",
-                                "Kind": 12,
+                                "Key": "2887369ed13dc7668eb3ee303acc0fd3",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "ThirdClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/members/interface.json
+++ b/graphs/srg/typeconstructor/tests/members/interface.json
@@ -9,31 +9,45 @@
                     "Key": "09dad8e22a7d2853043ce3de39534319",
                     "Kind": 9,
                     "Children": {
-                        "22368ef7cbde68fe32afe68aeb60f186": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "22368ef7cbde68fe32afe68aeb60f186",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "SomeInterface",
-                                    "tdg-source-node": "(NodeRef)"
-                                }
-                            }
-                        },
-                        "856d2600976c26d387bb71f93650e837": {
+                        "526f6de092a298466ab12273fa61b0db": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "856d2600976c26d387bb71f93650e837",
-                                "Kind": 13,
+                                "Key": "526f6de092a298466ab12273fa61b0db",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "C",
                                     "tdg-generic-subtype": "any",
+                                    "tdg-node-kind": "14|NodeType|tdg",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "8cccb7ecbf5e3b9dd8eb1a1136175f2c": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "8cccb7ecbf5e3b9dd8eb1a1136175f2c",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "param",
+                                    "tdg-parameter-type": "C",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "e4aa70201f3e500c3be8e9b70115884f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e4aa70201f3e500c3be8e9b70115884f",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
                                     "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "SomeInterface",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -59,15 +73,43 @@
                     "Key": "89b3ebe14823239e7457a284c88f3482",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "33c6fbca269f1897d1605d80f1e9ba84": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "33c6fbca269f1897d1605d80f1e9ba84",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "second",
+                                    "tdg-parameter-type": "SomeClass",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "8165ea728a2fc7617717138213be10da": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "8165ea728a2fc7617717138213be10da",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "first",
+                                    "tdg-parameter-type": "SomeClass",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }
@@ -111,14 +153,42 @@
                     "Key": "e2e830d23bed34dd446e169246319579",
                     "Kind": 10,
                     "Children": {
-                        "22368ef7cbde68fe32afe68aeb60f186": {
-                            "Predicate": "tdg-member-returnable",
+                        "317a1449a1b61f9eb103ad6603b397f4": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "22368ef7cbde68fe32afe68aeb60f186",
-                                "Kind": 12,
+                                "Key": "317a1449a1b61f9eb103ad6603b397f4",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "right",
+                                    "tdg-parameter-type": "SomeInterface",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "a7470859d6c1eaafeeee01070557423a": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "a7470859d6c1eaafeeee01070557423a",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "left",
+                                    "tdg-parameter-type": "SomeInterface",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "e4aa70201f3e500c3be8e9b70115884f": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e4aa70201f3e500c3be8e9b70115884f",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeInterface",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -179,14 +249,14 @@
                     "Key": "a695a7a83db460b2b97f113d88ae77cc",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/modulelevel/module.json
+++ b/graphs/srg/typeconstructor/tests/modulelevel/module.json
@@ -9,14 +9,14 @@
                     "Key": "5245507d7fabdbbef61cac86597788c2",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -62,14 +62,14 @@
                     "Key": "d8786fc3c0d6e65911b4bf33ef767bcb",
                     "Kind": 9,
                     "Children": {
-                        "78bb9b144f2834343dc0c7f553626572": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "78bb9b144f2834343dc0c7f553626572",
-                                "Kind": 12,
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Integer",
                                     "tdg-source-node": "(NodeRef)"
                                 }

--- a/graphs/srg/typeconstructor/tests/nominal/success.json
+++ b/graphs/srg/typeconstructor/tests/nominal/success.json
@@ -9,14 +9,14 @@
                     "Key": "35d3e3149efac2f92bce3ff1b82fba14",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -56,14 +56,14 @@
                     "Key": "6dad5fc4fb6fea011ecb5dab4a1f1b91",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/simple/simple.json
+++ b/graphs/srg/typeconstructor/tests/simple/simple.json
@@ -35,14 +35,14 @@
                     "Key": "f933c2e300d40983c025997fe5e0040c",
                     "Kind": 9,
                     "Children": {
-                        "b945553b92023e4fd1ae23820ab04ff1": {
+                        "97fc37904d05ff89dff8d0f27758b7ac": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b945553b92023e4fd1ae23820ab04ff1",
-                                "Kind": 12,
+                                "Key": "97fc37904d05ff89dff8d0f27758b7ac",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/stream/stream.json
+++ b/graphs/srg/typeconstructor/tests/stream/stream.json
@@ -9,14 +9,14 @@
                     "Key": "62652f3829d2642a0a09a18d478aa1ae",
                     "Kind": 9,
                     "Children": {
-                        "b260da3385668751b37c86a31828c51f": {
+                        "a2322590426e79641949a5d5765810f0": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b260da3385668751b37c86a31828c51f",
-                                "Kind": 12,
+                                "Key": "a2322590426e79641949a5d5765810f0",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherClass"
                                 }
                             }
@@ -53,14 +53,14 @@
                     "Key": "130ccd57eeb8e7a227905262bd6dcda4",
                     "Kind": 9,
                     "Children": {
-                        "e22eab3a9ec64e59c0293abd20190686": {
+                        "5a57002b14c03d63add3abdcdccdcabf": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e22eab3a9ec64e59c0293abd20190686",
-                                "Kind": 12,
+                                "Key": "5a57002b14c03d63add3abdcdccdcabf",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeClass\u003cT\u003e"
                                 }
                             }
@@ -78,18 +78,18 @@
                     }
                 }
             },
-            "8da1dd71c16557115ac5cb8139b5450d": {
+            "a6937e3be6c7d293681afea0b64bc579": {
                 "Predicate": "tdg-declaration-generic",
                 "Child": {
-                    "Key": "8da1dd71c16557115ac5cb8139b5450d",
-                    "Kind": 13,
+                    "Key": "a6937e3be6c7d293681afea0b64bc579",
+                    "Kind": 14,
                     "Children": {},
                     "Predicates": {
                         "tdg-generic-index": "0",
                         "tdg-generic-kind": "0",
                         "tdg-generic-name": "T",
                         "tdg-generic-subtype": "Stream\u003cAnotherClass\u003e",
-                        "tdg-node-kind": "13|NodeType|tdg",
+                        "tdg-node-kind": "14|NodeType|tdg",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }

--- a/graphs/srg/typeconstructor/tests/struct/default.json
+++ b/graphs/srg/typeconstructor/tests/struct/default.json
@@ -9,14 +9,14 @@
                     "Key": "12e47f92fb855a86ff3b3aef6547333a",
                     "Kind": 9,
                     "Children": {
-                        "8fa22a75b14c72936d3e832b686eda58": {
+                        "312c46280ca1d8b3a27cc033167b8ef2": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "8fa22a75b14c72936d3e832b686eda58",
-                                "Kind": 12,
+                                "Key": "312c46280ca1d8b3a27cc033167b8ef2",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherStruct"
                                 }
                             }
@@ -40,14 +40,14 @@
                     "Key": "5d6d447eca22e735fbdb99c025a26e7a",
                     "Kind": 9,
                     "Children": {
-                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                        "02a3662275840704d6fe26a13a94dd24": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
-                                "Kind": 12,
+                                "Key": "02a3662275840704d6fe26a13a94dd24",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Mapping\u003cany\u003e"
                                 }
                             }
@@ -84,14 +84,14 @@
                     "Key": "729d01dbcd268db2194f6e5df9258cef",
                     "Kind": 9,
                     "Children": {
-                        "8fa22a75b14c72936d3e832b686eda58": {
+                        "312c46280ca1d8b3a27cc033167b8ef2": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "8fa22a75b14c72936d3e832b686eda58",
-                                "Kind": 12,
+                                "Key": "312c46280ca1d8b3a27cc033167b8ef2",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherStruct"
                                 }
                             }
@@ -114,27 +114,27 @@
                     "Key": "72fd11f71f84d729e79b9b494b943b4f",
                     "Kind": 10,
                     "Children": {
-                        "428a1a99abb7048eb198ba7b7c97ff8a": {
+                        "132658d8a8c88ea61e89db3da786bd2a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "428a1a99abb7048eb198ba7b7c97ff8a",
-                                "Kind": 12,
+                                "Key": "132658d8a8c88ea61e89db3da786bd2a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": ""
                                 }
                             }
                         },
-                        "cbbf192423101e2637d29f1e63ab02e8": {
+                        "4e2291b0e72cae9f4006eb11e75408bb": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
-                                "Kind": 12,
+                                "Key": "4e2291b0e72cae9f4006eb11e75408bb",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean"
                                 }
                             }
@@ -160,30 +160,30 @@
                     "Key": "8f6f1a6b43fa3d5391fdab28975f6d6c",
                     "Kind": 9,
                     "Children": {
-                        "33a9de0b5ddacfc06fa4ec56c686d853": {
+                        "189eee63b8118f1f87d469eef0867c11": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        },
+                        "59e64b992d674225480fb3b2ba4a801f": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "33a9de0b5ddacfc06fa4ec56c686d853",
-                                "Kind": 13,
+                                "Key": "59e64b992d674225480fb3b2ba4a801f",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Stringifier",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "e77f6a250fab254ce775a6aa23617c22": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "String"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -224,30 +224,30 @@
                     "Key": "a55c0e3809cf3922cc71e62c78a98219",
                     "Kind": 9,
                     "Children": {
-                        "5f310277d8ba2f8c8f4095e2e4c166f8": {
+                        "312c46280ca1d8b3a27cc033167b8ef2": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "312c46280ca1d8b3a27cc033167b8ef2",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
+                                }
+                            }
+                        },
+                        "acc39c6dda5e483cb4830c355259d349": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "5f310277d8ba2f8c8f4095e2e4c166f8",
-                                "Kind": 13,
+                                "Key": "acc39c6dda5e483cb4830c355259d349",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Parser",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "8fa22a75b14c72936d3e832b686eda58": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "8fa22a75b14c72936d3e832b686eda58",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "AnotherStruct"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -271,14 +271,14 @@
                     "Key": "cfc98e14051e3cb5802f7eca7c60d060",
                     "Kind": 9,
                     "Children": {
-                        "e77f6a250fab254ce775a6aa23617c22": {
+                        "189eee63b8118f1f87d469eef0867c11": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "String"
                                 }
                             }
@@ -354,27 +354,27 @@
                     "Key": "5350cf76f32bfb3b6869e29c8b1e96c7",
                     "Kind": 10,
                     "Children": {
-                        "428a1a99abb7048eb198ba7b7c97ff8a": {
+                        "132658d8a8c88ea61e89db3da786bd2a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "428a1a99abb7048eb198ba7b7c97ff8a",
-                                "Kind": 12,
+                                "Key": "132658d8a8c88ea61e89db3da786bd2a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": ""
                                 }
                             }
                         },
-                        "cbbf192423101e2637d29f1e63ab02e8": {
+                        "4e2291b0e72cae9f4006eb11e75408bb": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
-                                "Kind": 12,
+                                "Key": "4e2291b0e72cae9f4006eb11e75408bb",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean"
                                 }
                             }
@@ -400,14 +400,14 @@
                     "Key": "5d6d447eca22e735fbdb99c025a26e7a",
                     "Kind": 9,
                     "Children": {
-                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                        "02a3662275840704d6fe26a13a94dd24": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
-                                "Kind": 12,
+                                "Key": "02a3662275840704d6fe26a13a94dd24",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Mapping\u003cany\u003e"
                                 }
                             }
@@ -430,14 +430,14 @@
                     "Key": "63833049ab91b49fc1efaeea39c96916",
                     "Kind": 9,
                     "Children": {
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct"
                                 }
                             }
@@ -481,14 +481,14 @@
                     "Key": "71a390af2b226c2c749399b67c78f9ba",
                     "Kind": 9,
                     "Children": {
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct"
                                 }
                             }
@@ -511,30 +511,30 @@
                     "Key": "8f6f1a6b43fa3d5391fdab28975f6d6c",
                     "Kind": 9,
                     "Children": {
-                        "33a9de0b5ddacfc06fa4ec56c686d853": {
+                        "189eee63b8118f1f87d469eef0867c11": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        },
+                        "59e64b992d674225480fb3b2ba4a801f": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "33a9de0b5ddacfc06fa4ec56c686d853",
-                                "Kind": 13,
+                                "Key": "59e64b992d674225480fb3b2ba4a801f",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Stringifier",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "e77f6a250fab254ce775a6aa23617c22": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "String"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -557,30 +557,30 @@
                     "Key": "b83eb6a5f9e6e9d2843e82312a138624",
                     "Kind": 9,
                     "Children": {
-                        "5f310277d8ba2f8c8f4095e2e4c166f8": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        },
+                        "acc39c6dda5e483cb4830c355259d349": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "5f310277d8ba2f8c8f4095e2e4c166f8",
-                                "Kind": 13,
+                                "Key": "acc39c6dda5e483cb4830c355259d349",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Parser",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "SomeStruct"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -604,14 +604,14 @@
                     "Key": "cfc98e14051e3cb5802f7eca7c60d060",
                     "Kind": 9,
                     "Children": {
-                        "e77f6a250fab254ce775a6aa23617c22": {
+                        "189eee63b8118f1f87d469eef0867c11": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "String"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/struct/referenced.json
+++ b/graphs/srg/typeconstructor/tests/struct/referenced.json
@@ -9,30 +9,30 @@
                     "Key": "0e3c0d4c49baaf007fa793499bc247c7",
                     "Kind": 9,
                     "Children": {
-                        "5f310277d8ba2f8c8f4095e2e4c166f8": {
+                        "312c46280ca1d8b3a27cc033167b8ef2": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "312c46280ca1d8b3a27cc033167b8ef2",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "AnotherStruct"
+                                }
+                            }
+                        },
+                        "acc39c6dda5e483cb4830c355259d349": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "5f310277d8ba2f8c8f4095e2e4c166f8",
-                                "Kind": 13,
+                                "Key": "acc39c6dda5e483cb4830c355259d349",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Parser",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "8fa22a75b14c72936d3e832b686eda58": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "8fa22a75b14c72936d3e832b686eda58",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "AnotherStruct"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -74,14 +74,14 @@
                     "Key": "5966b214cacd22005c0707387d58493f",
                     "Kind": 9,
                     "Children": {
-                        "e77f6a250fab254ce775a6aa23617c22": {
+                        "189eee63b8118f1f87d469eef0867c11": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "String"
                                 }
                             }
@@ -104,14 +104,14 @@
                     "Key": "6f94febfd640111641cf061e1c3c13cf",
                     "Kind": 9,
                     "Children": {
-                        "8fa22a75b14c72936d3e832b686eda58": {
+                        "312c46280ca1d8b3a27cc033167b8ef2": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "8fa22a75b14c72936d3e832b686eda58",
-                                "Kind": 12,
+                                "Key": "312c46280ca1d8b3a27cc033167b8ef2",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherStruct"
                                 }
                             }
@@ -135,14 +135,14 @@
                     "Key": "71bc8658474914ec865b658d3107ae81",
                     "Kind": 9,
                     "Children": {
-                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                        "02a3662275840704d6fe26a13a94dd24": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
-                                "Kind": 12,
+                                "Key": "02a3662275840704d6fe26a13a94dd24",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Mapping\u003cany\u003e"
                                 }
                             }
@@ -165,27 +165,27 @@
                     "Key": "76ae64a3f10041b5e0386a4ba3086f8e",
                     "Kind": 10,
                     "Children": {
-                        "428a1a99abb7048eb198ba7b7c97ff8a": {
+                        "132658d8a8c88ea61e89db3da786bd2a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "428a1a99abb7048eb198ba7b7c97ff8a",
-                                "Kind": 12,
+                                "Key": "132658d8a8c88ea61e89db3da786bd2a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": ""
                                 }
                             }
                         },
-                        "cbbf192423101e2637d29f1e63ab02e8": {
+                        "4e2291b0e72cae9f4006eb11e75408bb": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
-                                "Kind": 12,
+                                "Key": "4e2291b0e72cae9f4006eb11e75408bb",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean"
                                 }
                             }
@@ -225,30 +225,30 @@
                     "Key": "f60a81ed4f196e2c065d2bdb839f47f0",
                     "Kind": 9,
                     "Children": {
-                        "33a9de0b5ddacfc06fa4ec56c686d853": {
+                        "189eee63b8118f1f87d469eef0867c11": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        },
+                        "59e64b992d674225480fb3b2ba4a801f": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "33a9de0b5ddacfc06fa4ec56c686d853",
-                                "Kind": 13,
+                                "Key": "59e64b992d674225480fb3b2ba4a801f",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Stringifier",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "e77f6a250fab254ce775a6aa23617c22": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "String"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -271,14 +271,14 @@
                     "Key": "f8a53eca192dcf11556bca212ee5cd13",
                     "Kind": 9,
                     "Children": {
-                        "8fa22a75b14c72936d3e832b686eda58": {
+                        "312c46280ca1d8b3a27cc033167b8ef2": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "8fa22a75b14c72936d3e832b686eda58",
-                                "Kind": 12,
+                                "Key": "312c46280ca1d8b3a27cc033167b8ef2",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "AnotherStruct"
                                 }
                             }
@@ -314,30 +314,30 @@
                     "Key": "0651b656186657d9a82f1404b10d7c7a",
                     "Kind": 9,
                     "Children": {
-                        "5f310277d8ba2f8c8f4095e2e4c166f8": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        },
+                        "acc39c6dda5e483cb4830c355259d349": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "5f310277d8ba2f8c8f4095e2e4c166f8",
-                                "Kind": 13,
+                                "Key": "acc39c6dda5e483cb4830c355259d349",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Parser",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "SomeStruct"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -361,27 +361,27 @@
                     "Key": "0fc84e0af4a522259fcd7ed8afc125ed",
                     "Kind": 10,
                     "Children": {
-                        "428a1a99abb7048eb198ba7b7c97ff8a": {
+                        "132658d8a8c88ea61e89db3da786bd2a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "428a1a99abb7048eb198ba7b7c97ff8a",
-                                "Kind": 12,
+                                "Key": "132658d8a8c88ea61e89db3da786bd2a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": ""
                                 }
                             }
                         },
-                        "cbbf192423101e2637d29f1e63ab02e8": {
+                        "4e2291b0e72cae9f4006eb11e75408bb": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
-                                "Kind": 12,
+                                "Key": "4e2291b0e72cae9f4006eb11e75408bb",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean"
                                 }
                             }
@@ -407,14 +407,14 @@
                     "Key": "1333232452a92aaf987873f57ce7cd2b",
                     "Kind": 9,
                     "Children": {
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct"
                                 }
                             }
@@ -455,14 +455,14 @@
                     "Key": "5966b214cacd22005c0707387d58493f",
                     "Kind": 9,
                     "Children": {
-                        "e77f6a250fab254ce775a6aa23617c22": {
+                        "189eee63b8118f1f87d469eef0867c11": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "String"
                                 }
                             }
@@ -503,14 +503,14 @@
                     "Key": "71bc8658474914ec865b658d3107ae81",
                     "Kind": 9,
                     "Children": {
-                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                        "02a3662275840704d6fe26a13a94dd24": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
-                                "Kind": 12,
+                                "Key": "02a3662275840704d6fe26a13a94dd24",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Mapping\u003cany\u003e"
                                 }
                             }
@@ -533,14 +533,14 @@
                     "Key": "bcd6d477115564e70524f01f66c8287b",
                     "Kind": 9,
                     "Children": {
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct"
                                 }
                             }
@@ -582,30 +582,30 @@
                     "Key": "f60a81ed4f196e2c065d2bdb839f47f0",
                     "Kind": 9,
                     "Children": {
-                        "33a9de0b5ddacfc06fa4ec56c686d853": {
+                        "189eee63b8118f1f87d469eef0867c11": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        },
+                        "59e64b992d674225480fb3b2ba4a801f": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "33a9de0b5ddacfc06fa4ec56c686d853",
-                                "Kind": 13,
+                                "Key": "59e64b992d674225480fb3b2ba4a801f",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Stringifier",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "e77f6a250fab254ce775a6aa23617c22": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "String"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }

--- a/graphs/srg/typeconstructor/tests/struct/success.json
+++ b/graphs/srg/typeconstructor/tests/struct/success.json
@@ -27,14 +27,14 @@
                     "Key": "15f6d6e49b26ee95cb20677d3b61dbca",
                     "Kind": 9,
                     "Children": {
-                        "113cba3b25d50015bb269fc1c23619b0": {
+                        "e30592790a93b1e014ba523ab33e45a5": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "113cba3b25d50015bb269fc1c23619b0",
-                                "Kind": 12,
+                                "Key": "e30592790a93b1e014ba523ab33e45a5",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct\u003cT\u003e"
                                 }
                             }
@@ -57,14 +57,14 @@
                     "Key": "38df282be226fc91252a629e1a1fbeb9",
                     "Kind": 9,
                     "Children": {
-                        "113cba3b25d50015bb269fc1c23619b0": {
+                        "e30592790a93b1e014ba523ab33e45a5": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "113cba3b25d50015bb269fc1c23619b0",
-                                "Kind": 12,
+                                "Key": "e30592790a93b1e014ba523ab33e45a5",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct\u003cT\u003e"
                                 }
                             }
@@ -88,30 +88,30 @@
                     "Key": "6a5d19434e9112927c125fdb3a494655",
                     "Kind": 9,
                     "Children": {
-                        "33a9de0b5ddacfc06fa4ec56c686d853": {
+                        "189eee63b8118f1f87d469eef0867c11": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        },
+                        "59e64b992d674225480fb3b2ba4a801f": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "33a9de0b5ddacfc06fa4ec56c686d853",
-                                "Kind": 13,
+                                "Key": "59e64b992d674225480fb3b2ba4a801f",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Stringifier",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "e77f6a250fab254ce775a6aa23617c22": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "String"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -128,49 +128,33 @@
                     }
                 }
             },
-            "717d7779ca270b6876fb79dccd1f0f32": {
-                "Predicate": "tdg-declaration-generic",
-                "Child": {
-                    "Key": "717d7779ca270b6876fb79dccd1f0f32",
-                    "Kind": 13,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-generic-index": "0",
-                        "tdg-generic-kind": "0",
-                        "tdg-generic-name": "T",
-                        "tdg-generic-subtype": "struct",
-                        "tdg-node-kind": "13|NodeType|tdg",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
             "97a883caf7c630ac706ed16692828796": {
                 "Predicate": "tdg-declaration-operator",
                 "Child": {
                     "Key": "97a883caf7c630ac706ed16692828796",
                     "Kind": 10,
                     "Children": {
-                        "428a1a99abb7048eb198ba7b7c97ff8a": {
+                        "132658d8a8c88ea61e89db3da786bd2a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "428a1a99abb7048eb198ba7b7c97ff8a",
-                                "Kind": 12,
+                                "Key": "132658d8a8c88ea61e89db3da786bd2a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": ""
                                 }
                             }
                         },
-                        "cbbf192423101e2637d29f1e63ab02e8": {
+                        "4e2291b0e72cae9f4006eb11e75408bb": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
-                                "Kind": 12,
+                                "Key": "4e2291b0e72cae9f4006eb11e75408bb",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean"
                                 }
                             }
@@ -208,36 +192,52 @@
                     }
                 }
             },
+            "b0b625f27fe23c45a372cd16817b00e6": {
+                "Predicate": "tdg-declaration-generic",
+                "Child": {
+                    "Key": "b0b625f27fe23c45a372cd16817b00e6",
+                    "Kind": 14,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-generic-index": "0",
+                        "tdg-generic-kind": "0",
+                        "tdg-generic-name": "T",
+                        "tdg-generic-subtype": "struct",
+                        "tdg-node-kind": "14|NodeType|tdg",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
             "bcb46a11214f5399132ab30e066172e4": {
                 "Predicate": "tdg-node-member",
                 "Child": {
                     "Key": "bcb46a11214f5399132ab30e066172e4",
                     "Kind": 9,
                     "Children": {
-                        "113cba3b25d50015bb269fc1c23619b0": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "113cba3b25d50015bb269fc1c23619b0",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "SomeStruct\u003cT\u003e"
-                                }
-                            }
-                        },
-                        "5f310277d8ba2f8c8f4095e2e4c166f8": {
+                        "acc39c6dda5e483cb4830c355259d349": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "5f310277d8ba2f8c8f4095e2e4c166f8",
-                                "Kind": 13,
+                                "Key": "acc39c6dda5e483cb4830c355259d349",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Parser",
-                                    "tdg-node-kind": "13|NodeType|tdg"
+                                    "tdg-node-kind": "14|NodeType|tdg"
+                                }
+                            }
+                        },
+                        "e30592790a93b1e014ba523ab33e45a5": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "e30592790a93b1e014ba523ab33e45a5",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct\u003cT\u003e"
                                 }
                             }
                         }
@@ -261,14 +261,14 @@
                     "Key": "ee53683ed0fb0f547cee3c1f44cf9c99",
                     "Kind": 9,
                     "Children": {
-                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                        "02a3662275840704d6fe26a13a94dd24": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
-                                "Kind": 12,
+                                "Key": "02a3662275840704d6fe26a13a94dd24",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Mapping\u003cany\u003e"
                                 }
                             }
@@ -291,14 +291,14 @@
                     "Key": "f0235e80c78979e037dbd5727689b851",
                     "Kind": 9,
                     "Children": {
-                        "e77f6a250fab254ce775a6aa23617c22": {
+                        "189eee63b8118f1f87d469eef0867c11": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "String"
                                 }
                             }
@@ -352,15 +352,29 @@
                     "Key": "fc20a804cfad84bd291082932dbaf962",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "8878847f1ec4344f1561ef5417ccf43e": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "8878847f1ec4344f1561ef5417ccf43e",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "s",
+                                    "tdg-parameter-type": "SomeStruct\u003cInteger\u003e",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/struct/tagged.json
+++ b/graphs/srg/typeconstructor/tests/struct/tagged.json
@@ -23,14 +23,14 @@
                     "Key": "1572fd0a04d59b5426d0e3038a008c21",
                     "Kind": 9,
                     "Children": {
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct"
                                 }
                             }
@@ -54,29 +54,29 @@
                     "Key": "2c3ebaeb1f6c7438ef4ed61a588c149b",
                     "Kind": 9,
                     "Children": {
-                        "999f8d1974b8ba125f306b15a5ea4613": {
+                        "2d8d9c04e0ffe46f6a0c8f5e44a5b5ce": {
                             "Predicate": "tdg-member-tag",
                             "Child": {
-                                "Key": "999f8d1974b8ba125f306b15a5ea4613",
-                                "Kind": 11,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-membertag-name": "anothertag",
-                                    "tdg-membertag-value": "anothervalue",
-                                    "tdg-node-kind": "11|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "b455c0a6b611342d80d9a0490598b8bc": {
-                            "Predicate": "tdg-member-tag",
-                            "Child": {
-                                "Key": "b455c0a6b611342d80d9a0490598b8bc",
-                                "Kind": 11,
+                                "Key": "2d8d9c04e0ffe46f6a0c8f5e44a5b5ce",
+                                "Kind": 12,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-membertag-name": "sometag",
                                     "tdg-membertag-value": "somevalue",
-                                    "tdg-node-kind": "11|NodeType|tdg"
+                                    "tdg-node-kind": "12|NodeType|tdg"
+                                }
+                            }
+                        },
+                        "49aeec3e804512fc1f732701157b2b36": {
+                            "Predicate": "tdg-member-tag",
+                            "Child": {
+                                "Key": "49aeec3e804512fc1f732701157b2b36",
+                                "Kind": 12,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-membertag-name": "anothertag",
+                                    "tdg-membertag-value": "anothervalue",
+                                    "tdg-node-kind": "12|NodeType|tdg"
                                 }
                             }
                         }
@@ -99,27 +99,27 @@
                     "Key": "4071cb27f6af14472fe3e417856a5a52",
                     "Kind": 10,
                     "Children": {
-                        "428a1a99abb7048eb198ba7b7c97ff8a": {
+                        "132658d8a8c88ea61e89db3da786bd2a": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "428a1a99abb7048eb198ba7b7c97ff8a",
-                                "Kind": 12,
+                                "Key": "132658d8a8c88ea61e89db3da786bd2a",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean",
                                     "tdg-source-node": ""
                                 }
                             }
                         },
-                        "cbbf192423101e2637d29f1e63ab02e8": {
+                        "4e2291b0e72cae9f4006eb11e75408bb": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "cbbf192423101e2637d29f1e63ab02e8",
-                                "Kind": 12,
+                                "Key": "4e2291b0e72cae9f4006eb11e75408bb",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Boolean"
                                 }
                             }
@@ -145,14 +145,14 @@
                     "Key": "538572c6a95a2f9618dccff2f32e1398",
                     "Kind": 9,
                     "Children": {
-                        "e77f6a250fab254ce775a6aa23617c22": {
+                        "189eee63b8118f1f87d469eef0867c11": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "String"
                                 }
                             }
@@ -175,14 +175,14 @@
                     "Key": "a84bc9118bfa866d5a86895fed8f6fff",
                     "Kind": 9,
                     "Children": {
-                        "b1bacc48f93ae6f709e25b26b5b3278b": {
+                        "02a3662275840704d6fe26a13a94dd24": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "b1bacc48f93ae6f709e25b26b5b3278b",
-                                "Kind": 12,
+                                "Key": "02a3662275840704d6fe26a13a94dd24",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Mapping\u003cany\u003e"
                                 }
                             }
@@ -205,30 +205,30 @@
                     "Key": "c521f8ff86091a6f897ed2514cbf8f60",
                     "Kind": 9,
                     "Children": {
-                        "33a9de0b5ddacfc06fa4ec56c686d853": {
+                        "189eee63b8118f1f87d469eef0867c11": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "189eee63b8118f1f87d469eef0867c11",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "String"
+                                }
+                            }
+                        },
+                        "59e64b992d674225480fb3b2ba4a801f": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "33a9de0b5ddacfc06fa4ec56c686d853",
-                                "Kind": 13,
+                                "Key": "59e64b992d674225480fb3b2ba4a801f",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Stringifier",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "e77f6a250fab254ce775a6aa23617c22": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "e77f6a250fab254ce775a6aa23617c22",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "String"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -251,30 +251,30 @@
                     "Key": "f94a80887627b9c274ffc630c4e585dc",
                     "Kind": 9,
                     "Children": {
-                        "5f310277d8ba2f8c8f4095e2e4c166f8": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "SomeStruct"
+                                }
+                            }
+                        },
+                        "acc39c6dda5e483cb4830c355259d349": {
                             "Predicate": "tdg-member-generic",
                             "Child": {
-                                "Key": "5f310277d8ba2f8c8f4095e2e4c166f8",
-                                "Kind": 13,
+                                "Key": "acc39c6dda5e483cb4830c355259d349",
+                                "Kind": 14,
                                 "Children": {},
                                 "Predicates": {
                                     "tdg-generic-index": "0",
                                     "tdg-generic-kind": "1",
                                     "tdg-generic-name": "T",
                                     "tdg-generic-subtype": "Parser",
-                                    "tdg-node-kind": "13|NodeType|tdg"
-                                }
-                            }
-                        },
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
-                            "Predicate": "tdg-member-returnable",
-                            "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
-                                    "tdg-return-type": "SomeStruct"
+                                    "tdg-node-kind": "14|NodeType|tdg"
                                 }
                             }
                         }
@@ -298,14 +298,14 @@
                     "Key": "fc6897ebf63977ceca750c19af0ec231",
                     "Kind": 9,
                     "Children": {
-                        "ae7b6aece3cb27019518ec1568b49bb9": {
+                        "205acd11a290ac94aaad6fe5ec2374ea": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "ae7b6aece3cb27019518ec1568b49bb9",
-                                "Kind": 12,
+                                "Key": "205acd11a290ac94aaad6fe5ec2374ea",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeStruct"
                                 }
                             }

--- a/graphs/srg/typeconstructor/tests/voidreturn/void.json
+++ b/graphs/srg/typeconstructor/tests/voidreturn/void.json
@@ -9,14 +9,14 @@
                     "Key": "4b0194ae7810fc492125821b3c0b74e2",
                     "Kind": 9,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
                                     "tdg-source-node": "(NodeRef)"
                                 }

--- a/graphs/typegraph/nodetype_string.go
+++ b/graphs/typegraph/nodetype_string.go
@@ -4,9 +4,9 @@ package typegraph
 
 import "fmt"
 
-const _NodeType_name = "NodeTypeErrorNodeTypeClassNodeTypeInterfaceNodeTypeExternalInterfaceNodeTypeNominalTypeNodeTypeStructNodeTypeAgentNodeTypeModuleNodeTypeAliasNodeTypeMemberNodeTypeOperatorNodeTypeMemberTagNodeTypeReturnableNodeTypeGenericNodeTypeAgentReferenceNodeTypeAttributeNodeTypeReportedIssueNodeTypeTagged"
+const _NodeType_name = "NodeTypeErrorNodeTypeClassNodeTypeInterfaceNodeTypeExternalInterfaceNodeTypeNominalTypeNodeTypeStructNodeTypeAgentNodeTypeModuleNodeTypeAliasNodeTypeMemberNodeTypeOperatorNodeTypeParameterNodeTypeMemberTagNodeTypeReturnableNodeTypeGenericNodeTypeAgentReferenceNodeTypeAttributeNodeTypeReportedIssueNodeTypeTagged"
 
-var _NodeType_index = [...]uint16{0, 13, 26, 43, 68, 87, 101, 114, 128, 141, 155, 171, 188, 206, 221, 243, 260, 281, 295}
+var _NodeType_index = [...]uint16{0, 13, 26, 43, 68, 87, 101, 114, 128, 141, 155, 171, 188, 205, 223, 238, 260, 277, 298, 312}
 
 func (i NodeType) String() string {
 	if i < 0 || i >= NodeType(len(_NodeType_index)-1) {

--- a/graphs/typegraph/typegraph_member.go
+++ b/graphs/typegraph/typegraph_member.go
@@ -309,6 +309,20 @@ func (tn TGMember) Generics() []TGGeneric {
 	return generics
 }
 
+// Parameters returns the parameters on this member.
+func (tn TGMember) Parameters() []TGParameter {
+	it := tn.GraphNode.StartQuery().
+		Out(NodePredicateMemberParameter).
+		BuildNodeIterator()
+
+	var parameters = make([]TGParameter, 0)
+	for it.Next() {
+		parameters = append(parameters, TGParameter{it.Node(), tn.tdg})
+	}
+
+	return parameters
+}
+
 // Parent returns the type or module containing this member.
 func (tn TGMember) Parent() TGTypeOrModule {
 	parentNode := tn.GraphNode.StartQuery().

--- a/graphs/typegraph/typegraph_parameter.go
+++ b/graphs/typegraph/typegraph_parameter.go
@@ -1,0 +1,34 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package typegraph
+
+import (
+	"fmt"
+
+	"github.com/serulian/compiler/compilergraph"
+)
+
+var _ = fmt.Printf
+
+// TGParameter represents a parameter under a type member.
+type TGParameter struct {
+	compilergraph.GraphNode
+	tdg *TypeGraph
+}
+
+// Name returns the name of the underlying parameter.
+func (tn TGParameter) Name() (string, bool) {
+	return tn.GraphNode.TryGet(NodePredicateParameterName)
+}
+
+// Documentation returns the documentation associated with this parameter, if any.
+func (tn TGParameter) Documentation() (string, bool) {
+	return tn.GraphNode.TryGet(NodePredicateParameterDocumentation)
+}
+
+// DeclaredType returns the type for this parameter.
+func (tn TGParameter) DeclaredType() TypeReference {
+	return tn.GraphNode.GetTagged(NodePredicateParameterType, tn.tdg.AnyTypeReference()).(TypeReference)
+}

--- a/graphs/typegraph/typegraph_testutil_construct.go
+++ b/graphs/typegraph/typegraph_testutil_construct.go
@@ -402,7 +402,7 @@ func (t *testTypeGraphConstructor) DefineMembers(builder GetMemberBuilder, repor
 		for _, genericInfo := range memberInfo.generics {
 			genericNode := t.CreateNode(fakeNodeTypeTagged)
 			t.genericMap[memberInfo.name+"::"+genericInfo.name] = genericNode
-			ib.WithGeneric(genericInfo.name, genericNode)
+			ib.WithGeneric(genericInfo.name, "", genericNode)
 		}
 
 		ib.Define()
@@ -421,7 +421,7 @@ func (t *testTypeGraphConstructor) DefineMembers(builder GetMemberBuilder, repor
 			for _, genericInfo := range memberInfo.generics {
 				genericNode := t.CreateNode(fakeNodeTypeTagged)
 				t.genericMap[typeInfo.name+"."+memberInfo.name+"::"+genericInfo.name] = genericNode
-				ib.WithGeneric(genericInfo.name, genericNode)
+				ib.WithGeneric(genericInfo.name, "", genericNode)
 			}
 
 			ib.Define()

--- a/graphs/typegraph/typegraph_types.go
+++ b/graphs/typegraph/typegraph_types.go
@@ -29,6 +29,9 @@ const (
 	NodeTypeMember   // A member of a type or module.
 	NodeTypeOperator // An operator defined on a type.
 
+	// Member parameters.
+	NodeTypeParameter // A parameter under a member.
+
 	// Member tags.
 	NodeTypeMemberTag
 
@@ -188,6 +191,9 @@ const (
 	// Marks a member with a generic.
 	NodePredicateMemberGeneric = "member-generic"
 
+	// Marks a member with a parameter.
+	NodePredicateMemberParameter = "member-parameter"
+
 	// Marks a member with its signature.
 	NodePredicateMemberSignature = "member-signature"
 
@@ -231,6 +237,19 @@ const (
 
 	// Marks an operator as being a call to a native (ES) operator.
 	NodePredicateOperatorNative = "operator-native"
+
+	//
+	// NodeTypeParameter
+	//
+
+	// Decorates a parameter with its name.
+	NodePredicateParameterName = "parameter-name"
+
+	// Decorates a parameter with its documentation.
+	NodePredicateParameterDocumentation = "parameter-documentation"
+
+	// Decorates a parameter with its type.
+	NodePredicateParameterType = "parameter-type"
 
 	//
 	// NodeTypeMemberTag

--- a/grok/expressionextractor.go
+++ b/grok/expressionextractor.go
@@ -65,7 +65,7 @@ func (ee *expressionExtractor) extract() (string, bool) {
 		closingRunes[closeRune] = true
 	}
 
-	afterSpaceStartIndex := 0
+	afterSeperatorStartIndex := 0
 	for index, char := range ee.inputString {
 		_, isOpenRune := nestingRunes[char]
 		_, isCloseRune := closingRunes[char]
@@ -108,9 +108,9 @@ func (ee *expressionExtractor) extract() (string, bool) {
 				return "", false
 			}
 
-		case char == ' ':
+		case char == ' ' || char == ',':
 			if ee.currentState == extractorStateNormal {
-				afterSpaceStartIndex = index + 1
+				afterSeperatorStartIndex = index + 1
 			}
 		}
 	}
@@ -120,11 +120,11 @@ func (ee *expressionExtractor) extract() (string, bool) {
 	}
 
 	// If we've reached this point, return the expression string found
-	// at the last nesting or the last space index.
+	// at the last nesting or the last separator index.
 	_, lastNestingStartIndex, _ := ee.nestingStack.topValue()
 	expressionStartIndex := lastNestingStartIndex + 1
-	if afterSpaceStartIndex > expressionStartIndex {
-		expressionStartIndex = afterSpaceStartIndex
+	if afterSeperatorStartIndex > expressionStartIndex {
+		expressionStartIndex = afterSeperatorStartIndex
 	}
 
 	return ee.inputString[expressionStartIndex:], true

--- a/grok/expressionextractor_test.go
+++ b/grok/expressionextractor_test.go
@@ -37,6 +37,8 @@ var expressionExtractorTests = []expressionExtractorTest{
 	expressionExtractorTest{"a(b(c(d", "d", true},
 	expressionExtractorTest{"if a(b(c(d", "d", true},
 	expressionExtractorTest{"a(b(c(d e", "e", true},
+	expressionExtractorTest{"a(b(c(d,e", "e", true},
+	expressionExtractorTest{"a(b(c(d,e,f", "f", true},
 
 	// Failure tests.
 	expressionExtractorTest{"'hello world", "", false},

--- a/grok/expressionextractor_test.go
+++ b/grok/expressionextractor_test.go
@@ -19,6 +19,13 @@ type expressionExtractorTest struct {
 	expectedResult     bool
 }
 
+type calledExtractorTest struct {
+	inputString        string
+	expectedExpression string
+	expectedIndex      int
+	expectedResult     bool
+}
+
 var expressionExtractorTests = []expressionExtractorTest{
 	// Success tests.
 	expressionExtractorTest{"1234", "1234", true},
@@ -53,6 +60,36 @@ func TestExpressionExtraction(t *testing.T) {
 			continue
 		}
 		if !assert.Equal(t, test.expectedExpression, expression, "Got mismatched expression for input string: %s", test.inputString) {
+			continue
+		}
+	}
+}
+
+var calledExtractorTests = []calledExtractorTest{
+	// Success tests.
+	calledExtractorTest{"a(", "a", 0, true},
+	calledExtractorTest{"a(b", "a", 0, true},
+	calledExtractorTest{"a(b,", "a", 1, true},
+	calledExtractorTest{"a(b,c", "a", 1, true},
+	calledExtractorTest{"a(b,c[", "c", 0, true},
+
+	// Failure tests.
+	calledExtractorTest{"a", "", -1, false},
+	calledExtractorTest{"'hello world", "", -1, false},
+	calledExtractorTest{"'hello world\"", "", -1, false},
+	calledExtractorTest{"a[1234)", "", -1, false},
+}
+
+func TestCalledExtraction(t *testing.T) {
+	for _, test := range calledExtractorTests {
+		expression, index, result := extractCalled(test.inputString)
+		if !assert.Equal(t, test.expectedResult, result, "Got mismatched result for input string: %s", test.inputString) {
+			continue
+		}
+		if !assert.Equal(t, test.expectedExpression, expression, "Got mismatched expression for input string: %s", test.inputString) {
+			continue
+		}
+		if !assert.Equal(t, test.expectedIndex, index, "Got mismatched index for input string: %s", test.inputString) {
 			continue
 		}
 	}

--- a/grok/handle_signatures.go
+++ b/grok/handle_signatures.go
@@ -1,0 +1,153 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grok
+
+import (
+	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/graphs/scopegraph/proto"
+	"github.com/serulian/compiler/packageloader"
+	"github.com/serulian/compiler/parser"
+)
+
+// GetSignatureForPosition returns the parameter signature information for the given activationString at the given position.
+// If the activation string does not end in a signature activation character, returns nothing.
+func (gh Handle) GetSignatureForPosition(activationString string, source compilercommon.InputSource, lineNumber int, colPosition int) (SignatureInformation, error) {
+	// Note: We cannot use PositionFromLineAndColumn here, as it will lookup the position in the *tracked* source, which
+	// may be different than the current live source.
+	liveRune, err := gh.scopeResult.SourceTracker.LineAndColToRunePosition(lineNumber, colPosition, source, compilercommon.SourceMapCurrent)
+	if err != nil {
+		return SignatureInformation{}, err
+	}
+
+	sourcePosition := source.PositionForRunePosition(liveRune, gh.scopeResult.SourceTracker)
+	return gh.GetSignature(activationString, sourcePosition)
+}
+
+// GetSignature returns the parameter signature information for the given activationString at the given position.
+// If the activation string does not end in a signature activation character, returns nothing.
+func (gh Handle) GetSignature(activationString string, sourcePosition compilercommon.SourcePosition) (SignatureInformation, error) {
+	updatedPosition, err := gh.scopeResult.SourceTracker.GetPositionOffset(sourcePosition, packageloader.CurrentFilePosition)
+	if err != nil {
+		return SignatureInformation{}, err
+	}
+
+	// Find the node or a nearby node at the position.
+	sourceGraph := gh.scopeResult.Graph.SourceGraph()
+	node, found := sourceGraph.FindNearbyNodeForPosition(updatedPosition)
+	if !found {
+		return SignatureInformation{}, nil
+	}
+
+	// Extract the expression over which we are activating and the parameter position.
+	expressionString, signatureIndex, ok := extractCalled(activationString)
+	if !ok {
+		return SignatureInformation{}, nil
+	}
+
+	// Parse the expression string into an expression.
+	source := compilercommon.InputSource(node.Get(parser.NodePredicateSource))
+	startRune := node.GetValue(parser.NodePredicateStartRune).Int()
+
+	parsed, ok := gh.scopeResult.Graph.SourceGraph().ParseExpression(expressionString, source, startRune)
+	if !ok {
+		return SignatureInformation{}, nil
+	}
+
+	parentImplementable, hasParentImplementable := gh.structureFinder.TryGetContainingImplemented(node)
+	if !hasParentImplementable {
+		return SignatureInformation{}, nil
+	}
+
+	// Scope the expression underneath the context of the node found.
+	scopeInfo, isValid := gh.scopeResult.Graph.BuildTransientScope(parsed, parentImplementable)
+	if !isValid {
+		return SignatureInformation{}, nil
+	}
+
+	// Find the parameter information for the scoped item, which must either refer to a type member
+	// with parameter types *or* must have type function.
+	var functionType = gh.scopeResult.Graph.TypeGraph().VoidTypeReference()
+
+	switch scopeInfo.Kind {
+	case proto.ScopeKind_VALUE:
+		functionType = scopeInfo.ResolvedTypeRef(gh.scopeResult.Graph.TypeGraph())
+
+	case proto.ScopeKind_STATIC:
+		return SignatureInformation{}, nil
+
+	case proto.ScopeKind_GENERIC:
+		return SignatureInformation{}, nil
+
+	default:
+		panic("Unknown scope kind")
+	}
+
+	// Check for a named reference. If we find a member, use its information directly. This allows
+	// us to get parameter names and documentation, in addition to just the type information.
+	// If a value referring to a type, then the access is treated as an indexer.
+	referencedName, isNamedScope := gh.scopeResult.Graph.GetReferencedName(scopeInfo)
+	if isNamedScope {
+		member, isMember := referencedName.Member()
+
+		if !isMember {
+			if functionType.IsNormal() {
+				member, isMember = functionType.ReferredType().GetOperator("index")
+			}
+		}
+
+		if isMember {
+			name := member.Name()
+			documentation, _ := member.Documentation()
+
+			parameters := member.Parameters()
+			parameterInfo := make([]ParameterInformation, len(parameters))
+			for index, parameter := range parameters {
+				parameterName, _ := parameter.Name()
+				parameterDocumentation, _ := parameter.Documentation()
+
+				parameterInfo[index] = ParameterInformation{
+					Name:          parameterName,
+					TypeReference: parameter.DeclaredType(),
+					Documentation: parameterDocumentation,
+				}
+			}
+
+			return SignatureInformation{
+				TypeReference:        functionType,
+				Name:                 name,
+				Documentation:        documentation,
+				ActiveParameterIndex: signatureIndex,
+				Member:               nil,
+				Parameters:           parameterInfo,
+			}, nil
+		}
+	}
+
+	// Otherwise, ensure we have a function type.
+	if !functionType.IsDirectReferenceTo(gh.scopeResult.Graph.TypeGraph().FunctionType()) {
+		// Not a function, so not callable.
+		return SignatureInformation{}, nil
+	}
+
+	// Generate signature information based on the type information found.
+	parameterTypes := functionType.Parameters()
+	parameterInfo := make([]ParameterInformation, len(parameterTypes))
+	for index, parameterType := range parameterTypes {
+		parameterInfo[index] = ParameterInformation{
+			Name:          "", // Anonymous
+			TypeReference: parameterType,
+			Documentation: "",
+		}
+	}
+
+	return SignatureInformation{
+		TypeReference:        functionType,
+		Name:                 "", // Anonymous
+		Documentation:        "",
+		ActiveParameterIndex: signatureIndex,
+		Member:               nil,
+		Parameters:           parameterInfo,
+	}, nil
+}

--- a/grok/nestingstack.go
+++ b/grok/nestingstack.go
@@ -12,9 +12,21 @@ type nestingStack struct {
 }
 
 type nestingElement struct {
-	openRune   rune
-	startIndex int
-	next       *nestingElement
+	openRune           rune
+	startIndex         int
+	commaCounter       int
+	lastSeparatorIndex int
+	next               *nestingElement
+}
+
+// expressionStartIndex returns the start index for the nested expression, based on the
+// start index of the nesting element and last encountered separator index.
+func (ne *nestingElement) expressionStartIndex() int {
+	startIndex := ne.startIndex + 1
+	if ne.lastSeparatorIndex+1 > startIndex {
+		return ne.lastSeparatorIndex + 1
+	}
+	return startIndex
 }
 
 func (s *nestingStack) topValue() (rune, int, bool) {
@@ -27,7 +39,7 @@ func (s *nestingStack) topValue() (rune, int, bool) {
 
 // Push pushes an opening rune onto the stack.
 func (s *nestingStack) push(openRune rune, startIndex int) {
-	s.top = &nestingElement{openRune, startIndex, s.top}
+	s.top = &nestingElement{openRune, startIndex, 0, -1, s.top}
 	s.size++
 }
 

--- a/grok/signatures_test.go
+++ b/grok/signatures_test.go
@@ -1,0 +1,190 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grok
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/packageloader"
+)
+
+var _ = fmt.Printf
+
+type grokSignaturesTest struct {
+	name     string
+	subtests []grokSignaturesSubTest
+}
+
+type grokSignaturesSubTest struct {
+	rangeName         string
+	activationString  string
+	expectedSignature expectedSignature
+}
+
+type expectedSignature struct {
+	name           string
+	doc            string
+	paramIndex     int
+	expectedParams []expectedParam
+}
+
+type expectedParam struct {
+	name      string
+	paramType string
+	doc       string
+}
+
+var grokSignaturesTests = []grokSignaturesTest{
+	grokSignaturesTest{"signatures",
+		[]grokSignaturesSubTest{
+			grokSignaturesSubTest{
+				"ids",
+				"SomeClass.CreateMe(",
+				expectedSignature{
+					"CreateMe",
+					"",
+					0,
+					[]expectedParam{},
+				},
+			},
+			grokSignaturesSubTest{
+				"ids",
+				"DoSomething(",
+				expectedSignature{
+					"DoSomething",
+					"DoSomething does something. When `someParam` is specified, good things happen. `anotherParam` controls other things.",
+					0,
+					[]expectedParam{
+						expectedParam{"someParam", "Integer", "When **someParam** is specified, good things happen"},
+						expectedParam{"anotherParam", "String", "**anotherParam** controls other things"},
+					},
+				},
+			},
+			grokSignaturesSubTest{
+				"ids",
+				"DoSomething(42,",
+				expectedSignature{
+					"DoSomething",
+					"DoSomething does something. When `someParam` is specified, good things happen. `anotherParam` controls other things.",
+					1,
+					[]expectedParam{
+						expectedParam{"someParam", "Integer", "When **someParam** is specified, good things happen"},
+						expectedParam{"anotherParam", "String", "**anotherParam** controls other things"},
+					},
+				},
+			},
+			grokSignaturesSubTest{
+				"ids",
+				"sc[",
+				expectedSignature{
+					"index",
+					"A cool indexer, that takes `index`.",
+					0,
+					[]expectedParam{
+						expectedParam{"index", "Integer", "A cool indexer, that takes **index**"},
+					},
+				},
+			},
+			grokSignaturesSubTest{
+				"ids",
+				"SomeClass[",
+				expectedSignature{
+					"",
+					"",
+					0,
+					[]expectedParam{},
+				},
+			},
+			grokSignaturesSubTest{
+				"ids",
+				"UnknownFunction(",
+				expectedSignature{
+					"",
+					"",
+					0,
+					[]expectedParam{},
+				},
+			},
+			grokSignaturesSubTest{
+				"ids",
+				"InvalidExpression",
+				expectedSignature{
+					"",
+					"",
+					0,
+					[]expectedParam{},
+				},
+			},
+		}},
+}
+
+func TestGrokSignatures(t *testing.T) {
+	for _, grokSignaturesTest := range grokSignaturesTests {
+		testSourcePath := "tests/" + grokSignaturesTest.name + "/" + grokSignaturesTest.name + ".seru"
+		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		handle, err := groker.GetHandle()
+
+		// Ensure we have a valid groker.
+		if !assert.Nil(t, err, "Expected no error for test %s", grokSignaturesTest.name) {
+			continue
+		}
+
+		// Find the ranges.
+		ranges, err := getAllNamedRanges(handle)
+		if !assert.Nil(t, err, "Error when looking up named ranges") {
+			continue
+		}
+
+		for _, grokSignaturesSubTest := range grokSignaturesTest.subtests {
+			// Find the named range.
+			testRange, ok := ranges[grokSignaturesSubTest.rangeName]
+			if !assert.True(t, ok, "Could not find range %s under signatures test %s", grokSignaturesSubTest.rangeName, grokSignaturesTest.name) {
+				continue
+			}
+
+			// Retrieve the signatures for the range's location.
+			pm := compilercommon.LocalFilePositionMapper{}
+			sourcePosition := compilercommon.InputSource(testSourcePath).PositionForRunePosition(testRange.startIndex, pm)
+			signatureInfo, err := handle.GetSignature(grokSignaturesSubTest.activationString, sourcePosition)
+			if !assert.Nil(t, err, "Error when looking up signatures: %s => %v", testRange.name, sourcePosition) {
+				continue
+			}
+
+			if !assert.Equal(t, grokSignaturesSubTest.expectedSignature.name, signatureInfo.Name, "Mismatch on signature name on test `%s` under range %s", grokSignaturesSubTest.activationString, grokSignaturesSubTest.rangeName) {
+				continue
+			}
+
+			if !assert.Equal(t, grokSignaturesSubTest.expectedSignature.doc, signatureInfo.Documentation, "Mismatch on signature documentation on test `%s` under range %s", grokSignaturesSubTest.activationString, grokSignaturesSubTest.rangeName) {
+				continue
+			}
+
+			if !assert.Equal(t, grokSignaturesSubTest.expectedSignature.paramIndex, signatureInfo.ActiveParameterIndex, "Mismatch on parameter index on test `%s` under range %s", grokSignaturesSubTest.activationString, grokSignaturesSubTest.rangeName) {
+				continue
+			}
+
+			if !assert.Equal(t, len(grokSignaturesSubTest.expectedSignature.expectedParams), len(signatureInfo.Parameters), "Mismatch on number of parameters on test `%s` under range %s", grokSignaturesSubTest.activationString, grokSignaturesSubTest.rangeName) {
+				continue
+			}
+
+			for index, expectedParameter := range grokSignaturesSubTest.expectedSignature.expectedParams {
+				if !assert.Equal(t, expectedParameter.name, signatureInfo.Parameters[index].Name, "Mismatch on parameter name for param %v on test `%s` under range %s", index, grokSignaturesSubTest.activationString, grokSignaturesSubTest.rangeName) {
+					continue
+				}
+
+				if !assert.Equal(t, expectedParameter.doc, signatureInfo.Parameters[index].Documentation, "Mismatch on parameter docs for param %v on test `%s` under range %s", index, grokSignaturesSubTest.activationString, grokSignaturesSubTest.rangeName) {
+					continue
+				}
+
+				if !assert.Equal(t, expectedParameter.paramType, signatureInfo.Parameters[index].TypeReference.String(), "Mismatch on parameter type for param %v on test `%s` under range %s", index, grokSignaturesSubTest.activationString, grokSignaturesSubTest.rangeName) {
+					continue
+				}
+			}
+		}
+	}
+}

--- a/grok/structs.go
+++ b/grok/structs.go
@@ -272,3 +272,37 @@ type Symbol struct {
 	// If the symbol is a module, the module.
 	Module *typegraph.TGModule
 }
+
+// SignatureInformation represents information about the signature of a function/operator
+// and its parameters.
+type SignatureInformation struct {
+	// Name is the name of the referenced function/operator.
+	Name string
+
+	// If the function is a member, the member.
+	Member *typegraph.TGMember
+
+	// The human readable documentation on the function/operator, if any.
+	Documentation string
+
+	// Parameters represents the parameters of the signature.
+	Parameters []ParameterInformation
+
+	// If >= 0, the active parameter for this signature when lookup occurred.
+	ActiveParameterIndex int
+
+	// TypeReference is the type of the entity being invoked. May be missing, in which case it will be void.
+	TypeReference typegraph.TypeReference
+}
+
+// ParameterInformation represents information about a single parameter in a signature.
+type ParameterInformation struct {
+	// Name is the name of the parameter.
+	Name string
+
+	// TypeReference is the type of the parameter. May be missing, in which case it will be void.
+	TypeReference typegraph.TypeReference
+
+	// The human readable documentation on the parameter, if any.
+	Documentation string
+}

--- a/grok/tests/signatures/signatures.seru
+++ b/grok/tests/signatures/signatures.seru
@@ -1,0 +1,18 @@
+class SomeClass {
+    // A cool indexer, that takes `index`.
+    operator<int> Index(index int) {
+        return index
+    }
+
+    constructor CreateMe() {
+        return SomeClass.new()
+    }
+}
+
+// DoSomething does something. When `someParam` is specified, good things happen. `anotherParam` controls other things.
+function<void> DoSomething(someParam int, anotherParam string) {
+    var sc = SomeClass.new()
+
+    /// [ids  ]
+    DoSomething
+}

--- a/webidl/typeconstructor/tests/basic.json
+++ b/webidl/typeconstructor/tests/basic.json
@@ -67,7 +67,22 @@
                 "Child": {
                     "Key": "b4bbd10b06021518d6bedab2d8c2141d",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "e4596b7d34177eb547e319b339d698e9": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "e4596b7d34177eb547e319b339d698e9",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "someparam",
+                                    "tdg-parameter-type": "Object",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "AnotherMember",

--- a/webidl/typeconstructor/tests/customop.json
+++ b/webidl/typeconstructor/tests/customop.json
@@ -3,15 +3,15 @@
         "Key": "0afacb500df23d576019168e5d740e4b",
         "Kind": 3,
         "Children": {
-            "47830255db406e0170a60d6159e02163": {
+            "613ee9436c9bee469ae906675f136bb7": {
                 "Predicate": "tdg-type-attribute",
                 "Child": {
-                    "Key": "47830255db406e0170a60d6159e02163",
-                    "Kind": 15,
+                    "Key": "613ee9436c9bee469ae906675f136bb7",
+                    "Kind": 16,
                     "Children": {},
                     "Predicates": {
                         "tdg-attribute-name": "serializable",
-                        "tdg-node-kind": "15|NodeType|tdg"
+                        "tdg-node-kind": "16|NodeType|tdg"
                     }
                 }
             }

--- a/webidl/typeconstructor/tests/indexer.json
+++ b/webidl/typeconstructor/tests/indexer.json
@@ -45,14 +45,28 @@
                     "Key": "0cafb9dfc8563d9a570fbd7a263582db",
                     "Kind": 10,
                     "Children": {
-                        "ec1431cb17a2a53947afec3c2cf726d0": {
-                            "Predicate": "tdg-member-returnable",
+                        "007ce2ceb013d11b4222fdaa26a9deec": {
+                            "Predicate": "tdg-member-parameter",
                             "Child": {
-                                "Key": "ec1431cb17a2a53947afec3c2cf726d0",
-                                "Kind": 12,
+                                "Key": "007ce2ceb013d11b4222fdaa26a9deec",
+                                "Kind": 11,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "propertyName",
+                                    "tdg-parameter-type": "First",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "45381c813be00e05316628fb7a7b343a": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "45381c813be00e05316628fb7a7b343a",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "Second",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -79,15 +93,43 @@
                     "Key": "d6275e240a384d282baa0cea757c467c",
                     "Kind": 10,
                     "Children": {
-                        "69c7dfb293b5923e5b91ad780ee76061": {
+                        "0ab7ff81f5d66766e19e204a04b5f724": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "69c7dfb293b5923e5b91ad780ee76061",
-                                "Kind": 12,
+                                "Key": "0ab7ff81f5d66766e19e204a04b5f724",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "void",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "305359f7457838a943fb448f09d279f5": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "305359f7457838a943fb448f09d279f5",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "propertyName",
+                                    "tdg-parameter-type": "Third",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "35b50e97e60e73eea9bc5d0aa5cff1ed": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "35b50e97e60e73eea9bc5d0aa5cff1ed",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "propertyValue",
+                                    "tdg-parameter-type": "Fourth",
                                     "tdg-source-node": "(NodeRef)"
                                 }
                             }

--- a/webidl/typeconstructor/tests/nativetypes.json
+++ b/webidl/typeconstructor/tests/nativetypes.json
@@ -38,7 +38,22 @@
                 "Child": {
                     "Key": "f18927d8e97826df280ac35141e4a1a7",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "43bddee5131f5667d682f192dfac7d19": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "43bddee5131f5667d682f192dfac7d19",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "someParam",
+                                    "tdg-parameter-type": "Number",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "SomeFunction",

--- a/webidl/typeconstructor/tests/operator.json
+++ b/webidl/typeconstructor/tests/operator.json
@@ -9,14 +9,14 @@
                     "Key": "07986046f92fee1efb279e9e858f7d11",
                     "Kind": 10,
                     "Children": {
-                        "22368ef7cbde68fe32afe68aeb60f186": {
+                        "e4aa70201f3e500c3be8e9b70115884f": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "22368ef7cbde68fe32afe68aeb60f186",
-                                "Kind": 12,
+                                "Key": "e4aa70201f3e500c3be8e9b70115884f",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeInterface",
                                     "tdg-source-node": "(NodeRef)"
                                 }
@@ -44,14 +44,14 @@
                     "Key": "bb6598f210190017a9e42302acfc3f5a",
                     "Kind": 10,
                     "Children": {
-                        "22368ef7cbde68fe32afe68aeb60f186": {
+                        "e4aa70201f3e500c3be8e9b70115884f": {
                             "Predicate": "tdg-member-returnable",
                             "Child": {
-                                "Key": "22368ef7cbde68fe32afe68aeb60f186",
-                                "Kind": 12,
+                                "Key": "e4aa70201f3e500c3be8e9b70115884f",
+                                "Kind": 13,
                                 "Children": {},
                                 "Predicates": {
-                                    "tdg-node-kind": "12|NodeType|tdg",
+                                    "tdg-node-kind": "13|NodeType|tdg",
                                     "tdg-return-type": "SomeInterface",
                                     "tdg-source-node": "(NodeRef)"
                                 }

--- a/webidl/typeconstructor/tests/optionalparam.json
+++ b/webidl/typeconstructor/tests/optionalparam.json
@@ -8,7 +8,64 @@
                 "Child": {
                     "Key": "31d6362ede827447c00ed6461603c40e",
                     "Kind": 9,
-                    "Children": {},
+                    "Children": {
+                        "6833a3464d1974be735ad93c78c377fc": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "6833a3464d1974be735ad93c78c377fc",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "first",
+                                    "tdg-parameter-type": "Foo",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "b9ef41cbf70f009ffc116a0ec760f2ab": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "b9ef41cbf70f009ffc116a0ec760f2ab",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "second",
+                                    "tdg-parameter-type": "Foo",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "de34f18f81c17364d237e7849096e2d0": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "de34f18f81c17364d237e7849096e2d0",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "third",
+                                    "tdg-parameter-type": "Foo?",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        },
+                        "e30b0678c29982f78d2fd003f4c19bc5": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "e30b0678c29982f78d2fd003f4c19bc5",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "fourth",
+                                    "tdg-parameter-type": "Foo?",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        }
+                    },
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-name": "SomeFunction",

--- a/webidl/typeconstructor/tests/serializable.json
+++ b/webidl/typeconstructor/tests/serializable.json
@@ -3,15 +3,15 @@
         "Key": "8758f5d8d63e606d5960b6fe6800d898",
         "Kind": 3,
         "Children": {
-            "47830255db406e0170a60d6159e02163": {
+            "613ee9436c9bee469ae906675f136bb7": {
                 "Predicate": "tdg-type-attribute",
                 "Child": {
-                    "Key": "47830255db406e0170a60d6159e02163",
-                    "Kind": 15,
+                    "Key": "613ee9436c9bee469ae906675f136bb7",
+                    "Kind": 16,
                     "Children": {},
                     "Predicates": {
                         "tdg-attribute-name": "serializable",
-                        "tdg-node-kind": "15|NodeType|tdg"
+                        "tdg-node-kind": "16|NodeType|tdg"
                     }
                 }
             }


### PR DESCRIPTION
Allows for looking up the function/indexer being called, along with its parameter information