### PR TITLE
Lock VCS write operations globally by path

### DIFF
--- a/compilerutil/lockmap.go
+++ b/compilerutil/lockmap.go
@@ -1,0 +1,37 @@
+// Copyright 2015 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package compilerutil
+
+import "sync"
+
+// LockMap defines a concurrent-safe map that returns a sync Mutex for each key. This is useful
+// when multiple resources are being loaded concurrently and locking is needed, but only on a
+// per-resource basis.
+type LockMap struct {
+	locks      map[string]*sync.Mutex
+	globalLock *sync.Mutex
+}
+
+// CreateLockMap returns a new LockMap.
+func CreateLockMap() LockMap {
+	return LockMap{
+		locks:      map[string]*sync.Mutex{},
+		globalLock: &sync.Mutex{},
+	}
+}
+
+// GetLock returns a lock for the given key.
+func (lm LockMap) GetLock(key string) *sync.Mutex {
+	lm.globalLock.Lock()
+	defer lm.globalLock.Unlock()
+
+	if lock, ok := lm.locks[key]; ok {
+		return lock
+	}
+
+	lock := &sync.Mutex{}
+	lm.locks[key] = lock
+	return lock
+}

--- a/compilerutil/pathwalker.go
+++ b/compilerutil/pathwalker.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/serulian/compiler/packageloader"
 )
 
 // RECURSIVE_PATTERN defines the pattern for recursively searching for files.
@@ -22,7 +20,7 @@ type PathHandler func(filePath string, info os.FileInfo) (bool, error)
 
 // WalkSourcePath walks the given source path, invoking the given handler for each file
 // found.
-func WalkSourcePath(path string, handler PathHandler) bool {
+func WalkSourcePath(path string, handler PathHandler, skipDirectories ...string) bool {
 	originalPath := path
 	isRecursive := strings.HasSuffix(path, RECURSIVE_PATTERN)
 	if isRecursive {
@@ -37,8 +35,10 @@ func WalkSourcePath(path string, handler PathHandler) bool {
 				return filepath.SkipDir
 			}
 
-			if info.Name() == packageloader.SerulianPackageDirectory {
-				return filepath.SkipDir
+			for _, skipDirectory := range skipDirectories {
+				if info.Name() == skipDirectory {
+					return filepath.SkipDir
+				}
 			}
 
 			return nil

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/serulian/compiler/compilercommon"
 	"github.com/serulian/compiler/compilerutil"
+	"github.com/serulian/compiler/packageloader"
 	"github.com/serulian/compiler/parser"
 
 	glob "github.com/ryanuber/go-glob"
@@ -153,7 +154,7 @@ func formatFiles(path string, importHandling importHandlingInfo, debug bool) boo
 		}
 
 		return true, parseAndFormatSourceFile(currentPath, info, importHandling)
-	})
+	}, packageloader.SerulianPackageDirectory)
 }
 
 // parseAndFormatSourceFile parses the source file at the given path (with associated file info),

--- a/packageloader/util.go
+++ b/packageloader/util.go
@@ -6,7 +6,6 @@ package packageloader
 
 import (
 	"os"
-	"sync"
 )
 
 // From: http://stackoverflow.com/questions/10510691/how-to-check-whether-a-file-or-directory-denoted-by-a-path-exists-in-golang
@@ -20,34 +19,4 @@ func exists(path string) (bool, error) {
 		return false, nil
 	}
 	return true, err
-}
-
-// lockMap defines a concurrent-safe map that returns a sync Mutex for each key. This is useful
-// when multiple resources are being loaded concurrently and locking is needed, but only on a
-// per-resource basis.
-type lockMap struct {
-	locks      map[string]*sync.Mutex
-	globalLock *sync.Mutex
-}
-
-// createLockMap returns a new lockMap.
-func createLockMap() lockMap {
-	return lockMap{
-		locks:      map[string]*sync.Mutex{},
-		globalLock: &sync.Mutex{},
-	}
-}
-
-// getLock returns a lock for the given key.
-func (lm lockMap) getLock(key string) *sync.Mutex {
-	lm.globalLock.Lock()
-	defer lm.globalLock.Unlock()
-
-	if lock, ok := lm.locks[key]; ok {
-		return lock
-	}
-
-	lock := &sync.Mutex{}
-	lm.locks[key] = lock
-	return lock
 }

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/serulian/compiler/compilerutil"
 	"github.com/serulian/compiler/generator/es5"
 	"github.com/serulian/compiler/graphs/scopegraph"
+	"github.com/serulian/compiler/packageloader"
 	"github.com/serulian/compiler/parser"
 
 	"github.com/fatih/color"
@@ -77,7 +78,7 @@ func runTestsViaRunner(runner TestRunner, path string) bool {
 		} else {
 			return true, fmt.Errorf("Failure in test of file %s", currentPath)
 		}
-	})
+	}, packageloader.SerulianPackageDirectory)
 }
 
 // buildAndRunTests builds the source found at the given path and then runs its tests via the runner.


### PR DESCRIPTION
This prevents any callers of the VCS library from accidentally starting multiple concurrent write operations in the same repository, which could be potentially disastrous