### PR TITLE
Allow the PathLoader to override the packages cache path

### DIFF
--- a/grok/handle_contextactions.go
+++ b/grok/handle_contextactions.go
@@ -7,7 +7,6 @@ package grok
 import (
 	"fmt"
 	"log"
-	"path"
 
 	"github.com/serulian/compiler/compilercommon"
 	"github.com/serulian/compiler/compilerutil"
@@ -244,7 +243,7 @@ func (gh Handle) getInspectInfo(importSource string, source compilercommon.Input
 	}
 
 	// If not found, retrieve it via the VCS engine.
-	dirPath := path.Join(path.Dir(string(source)), packageloader.SerulianPackageDirectory)
+	dirPath := gh.groker.pathLoader.VCSPackageDirectory(gh.groker.entrypoint)
 	inspectInfo, err, _ := vcs.PerformVCSCheckoutAndInspect(importSource, dirPath, vcs.VCSAlwaysUseCache)
 	if err != nil {
 		return vcs.InspectInfo{}, nil

--- a/packageloader/packageloader.go
+++ b/packageloader/packageloader.go
@@ -359,8 +359,7 @@ func (p *PackageLoader) packageInfoForPackageDirectory(packagePath string, sourc
 
 // getVCSDirectoryForPath returns the directory on disk where the given VCS path will be placed, if any.
 func (p *PackageLoader) getVCSDirectoryForPath(vcsPath string) (string, error) {
-	rootDirectory := p.entrypoint.EntrypointDirectoryPath(p.pathLoader)
-	pkgDirectory := path.Join(rootDirectory, SerulianPackageDirectory)
+	pkgDirectory := p.pathLoader.VCSPackageDirectory(p.entrypoint)
 	return vcs.GetVCSCheckoutDirectory(vcsPath, pkgDirectory, p.vcsDevelopmentDirectories...)
 }
 
@@ -448,15 +447,13 @@ func (p *PackageLoader) loadVCSPackage(packagePath pathInformation) {
 		}
 	}
 
-	rootDirectory := p.entrypoint.EntrypointDirectoryPath(p.pathLoader)
-	pkgDirectory := path.Join(rootDirectory, SerulianPackageDirectory)
-
 	// Perform the checkout of the VCS package.
 	var cacheOption = vcs.VCSFollowNormalCacheRules
 	if p.skipVCSRefresh {
 		cacheOption = vcs.VCSAlwaysUseCache
 	}
 
+	pkgDirectory := p.pathLoader.VCSPackageDirectory(p.entrypoint)
 	checkoutDirectory, err, warning := vcs.PerformVCSCheckout(packagePath.path, pkgDirectory, cacheOption, p.vcsDevelopmentDirectories...)
 	if err != nil {
 		p.vcsPathsLoaded.Set(packagePath.path, "")

--- a/packageloader/pathloader.go
+++ b/packageloader/pathloader.go
@@ -7,6 +7,7 @@ package packageloader
 import (
 	"io/ioutil"
 	"os"
+	"path"
 )
 
 // PathLoader defines the interface for loading source files (modules) and directories (packages) in
@@ -26,6 +27,9 @@ type PathLoader interface {
 
 	// LoadDirectory returns the files and sub-directories in the directory at the given path.
 	LoadDirectory(path string) ([]DirectoryEntry, error)
+
+	// VCSPackageDirectory returns the directory into which VCS packages will be loaded.
+	VCSPackageDirectory(entrypoint Entrypoint) string
 }
 
 // DirectoryEntry represents a single entry under a directory.
@@ -35,6 +39,11 @@ type DirectoryEntry struct {
 }
 
 type LocalFilePathLoader struct{}
+
+func (lfpl LocalFilePathLoader) VCSPackageDirectory(entrypoint Entrypoint) string {
+	rootDirectory := entrypoint.EntrypointDirectoryPath(lfpl)
+	return path.Join(rootDirectory, SerulianPackageDirectory)
+}
 
 func (lfpl LocalFilePathLoader) LoadSourceFile(path string) ([]byte, error) {
 	return ioutil.ReadFile(path)


### PR DESCRIPTION
This allows tooling to share the packages cache, which should make loading files faster