### PR TITLE
Remove param documentation formatting

### DIFF
--- a/graphs/srg/comments.go
+++ b/graphs/srg/comments.go
@@ -253,6 +253,6 @@ func documentationForParameter(commentValue string, paramName string) (string, b
 	}
 
 	sort.Sort(byLocation{tickedSentences, tickedParam})
-	paramComment := strings.TrimSpace(strings.Replace(tickedSentences[0], tickedParam, fmt.Sprintf("**%s**", paramName), 1))
+	paramComment := strings.TrimSpace(tickedSentences[0])
 	return paramComment, true
 }

--- a/grok/signatures_test.go
+++ b/grok/signatures_test.go
@@ -61,8 +61,8 @@ var grokSignaturesTests = []grokSignaturesTest{
 					"DoSomething does something. When `someParam` is specified, good things happen. `anotherParam` controls other things.",
 					0,
 					[]expectedParam{
-						expectedParam{"someParam", "Integer", "When **someParam** is specified, good things happen"},
-						expectedParam{"anotherParam", "String", "**anotherParam** controls other things"},
+						expectedParam{"someParam", "Integer", "When `someParam` is specified, good things happen"},
+						expectedParam{"anotherParam", "String", "`anotherParam` controls other things"},
 					},
 				},
 			},
@@ -74,8 +74,8 @@ var grokSignaturesTests = []grokSignaturesTest{
 					"DoSomething does something. When `someParam` is specified, good things happen. `anotherParam` controls other things.",
 					1,
 					[]expectedParam{
-						expectedParam{"someParam", "Integer", "When **someParam** is specified, good things happen"},
-						expectedParam{"anotherParam", "String", "**anotherParam** controls other things"},
+						expectedParam{"someParam", "Integer", "When `someParam` is specified, good things happen"},
+						expectedParam{"anotherParam", "String", "`anotherParam` controls other things"},
 					},
 				},
 			},
@@ -87,7 +87,7 @@ var grokSignaturesTests = []grokSignaturesTest{
 					"A cool indexer, that takes `index`.",
 					0,
 					[]expectedParam{
-						expectedParam{"index", "Integer", "A cool indexer, that takes **index**"},
+						expectedParam{"index", "Integer", "A cool indexer, that takes `index`"},
 					},
 				},
 			},


### PR DESCRIPTION
Tools should be able to decide how to format param documentation