### PR TITLE
Fix bug in optimizing binary expression operators

### DIFF
--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -173,6 +173,7 @@ var generationTests = []generationTest{
 	generationTest{"full lambda expression", "lambdaexpr", "full", integrationTestSuccessExpected, ""},
 	generationTest{"mini lambda expression", "lambdaexpr", "mini", integrationTestSuccessExpected, ""},
 
+	generationTest{"simple plus op expression", "opexpr", "plus", integrationTestSuccessExpected, ""},
 	generationTest{"null comparison short circuit", "opexpr", "nullcomparecall", integrationTestSuccessExpected, ""},
 	generationTest{"null comparison", "opexpr", "nullcompare", integrationTestSuccessExpected, ""},
 	generationTest{"async null comparison", "opexpr", "asyncnullcompare", integrationTestSuccessExpected, ""},

--- a/generator/es5/tests/agent/basic.js
+++ b/generator/es5/tests/agent/basic.js
@@ -56,7 +56,7 @@ $module('basic', function () {
     };
     $instance.GetMainValue = function () {
       var $this = this;
-      return $t.fastbox($this.$principal.GetValue().$wrapped + 10, $g.____testlib.basictypes.Boolean);
+      return $t.fastbox($this.$principal.GetValue().$wrapped + 10, $g.____testlib.basictypes.Integer);
     };
     this.$typesig = function () {
       if (this.$cachedtypesig) {

--- a/generator/es5/tests/generator/nested.js
+++ b/generator/es5/tests/generator/nested.js
@@ -127,7 +127,7 @@ $module('nested', function () {
             break;
 
           case 4:
-            v = $t.fastbox(v.$wrapped + value.$wrapped, $g.____testlib.basictypes.Boolean);
+            v = $t.fastbox(v.$wrapped + value.$wrapped, $g.____testlib.basictypes.Integer);
             $current = 2;
             $continue($resolve, $reject);
             return;

--- a/generator/es5/tests/generator/resource.js
+++ b/generator/es5/tests/generator/resource.js
@@ -104,7 +104,7 @@ $module('resource', function () {
             break;
 
           case 4:
-            counter = $t.fastbox(counter.$wrapped + i.$wrapped, $g.____testlib.basictypes.Boolean);
+            counter = $t.fastbox(counter.$wrapped + i.$wrapped, $g.____testlib.basictypes.Integer);
             $current = 2;
             $continue($resolve, $reject);
             return;

--- a/generator/es5/tests/literals/asynctaggedtemplatestr.js
+++ b/generator/es5/tests/literals/asynctaggedtemplatestr.js
@@ -11,7 +11,7 @@ $module('asynctaggedtemplatestr', function () {
         switch ($current) {
           case 0:
             $promise.translate($g.asynctaggedtemplatestr.DoSomethingAsync()).then(function ($result0) {
-              $result = $t.fastbox(($t.cast(values.$index($t.fastbox(0, $g.____testlib.basictypes.Integer)), $g.____testlib.basictypes.Integer, false).$wrapped + values.Length().$wrapped) + $result0.$wrapped, $g.____testlib.basictypes.Boolean);
+              $result = $t.fastbox(($t.cast(values.$index($t.fastbox(0, $g.____testlib.basictypes.Integer)), $g.____testlib.basictypes.Integer, false).$wrapped + values.Length().$wrapped) + $result0.$wrapped, $g.____testlib.basictypes.Integer);
               $current = 1;
               $continue($resolve, $reject);
               return;

--- a/generator/es5/tests/literals/structfunction.js
+++ b/generator/es5/tests/literals/structfunction.js
@@ -5,7 +5,7 @@ $module('structfunction', function () {
       return $t.fastbox(0, $g.____testlib.basictypes.Integer);
     }).$wrapped + $t.syncnullcompare(theMap.$index($t.fastbox("Bar", $g.____testlib.basictypes.String)), function () {
       return $t.fastbox(0, $g.____testlib.basictypes.Integer);
-    }).$wrapped, $g.____testlib.basictypes.Boolean);
+    }).$wrapped, $g.____testlib.basictypes.Integer);
   };
   $static.TEST = function () {
     var result;

--- a/generator/es5/tests/literals/taggedtemplatestr.js
+++ b/generator/es5/tests/literals/taggedtemplatestr.js
@@ -1,7 +1,7 @@
 $module('taggedtemplatestr', function () {
   var $static = this;
   $static.myFunction = function (pieces, values) {
-    return $t.fastbox($t.cast(values.$index($t.fastbox(0, $g.____testlib.basictypes.Integer)), $g.____testlib.basictypes.Integer, false).$wrapped + values.Length().$wrapped, $g.____testlib.basictypes.Boolean);
+    return $t.fastbox($t.cast(values.$index($t.fastbox(0, $g.____testlib.basictypes.Integer)), $g.____testlib.basictypes.Integer, false).$wrapped + values.Length().$wrapped, $g.____testlib.basictypes.Integer);
   };
   $static.TEST = function () {
     var a;

--- a/generator/es5/tests/loopexpr/basic.js
+++ b/generator/es5/tests/loopexpr/basic.js
@@ -41,7 +41,7 @@ $module('basic', function () {
         switch ($current) {
           case 0:
             s = $g.____testlib.basictypes.MapStream($g.____testlib.basictypes.Integer, $g.____testlib.basictypes.Integer)($g.basic.SomeGenerator(), function (s) {
-              return $t.fastbox(s.$wrapped + 1, $g.____testlib.basictypes.Boolean);
+              return $t.fastbox(s.$wrapped + 1, $g.____testlib.basictypes.Integer);
             });
             counter = $t.fastbox(0, $g.____testlib.basictypes.Integer);
             $current = 1;
@@ -81,7 +81,7 @@ $module('basic', function () {
             break;
 
           case 4:
-            counter = $t.fastbox(counter.$wrapped + entry.$wrapped, $g.____testlib.basictypes.Boolean);
+            counter = $t.fastbox(counter.$wrapped + entry.$wrapped, $g.____testlib.basictypes.Integer);
             $current = 2;
             $continue($resolve, $reject);
             return;

--- a/generator/es5/tests/opexpr/plus.js
+++ b/generator/es5/tests/opexpr/plus.js
@@ -1,0 +1,9 @@
+$module('plus', function () {
+  var $static = this;
+  $static.SomeFunction = function () {
+    return $t.fastbox(1 + 2, $g.____testlib.basictypes.Integer);
+  };
+  $static.TEST = function () {
+    return $t.fastbox($g.plus.SomeFunction().$wrapped == 3, $g.____testlib.basictypes.Boolean);
+  };
+});

--- a/generator/es5/tests/opexpr/plus.seru
+++ b/generator/es5/tests/opexpr/plus.seru
@@ -1,0 +1,7 @@
+function<int> SomeFunction() {
+    return 1 + 2
+}
+
+function<bool> TEST() {
+    return SomeFunction() == 3
+}

--- a/generator/es5/tests/sml/asyncchildren.js
+++ b/generator/es5/tests/sml/asyncchildren.js
@@ -49,7 +49,7 @@ $module('asyncchildren', function () {
             break;
 
           case 4:
-            counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.____testlib.basictypes.Boolean);
+            counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.____testlib.basictypes.Integer);
             $current = 2;
             $continue($resolve, $reject);
             return;
@@ -67,7 +67,7 @@ $module('asyncchildren', function () {
     return $promise.new($continue);
   });
   $static.DoSomethingAsync = $t.workerwrap('a6e86a18', function (i) {
-    return $t.fastbox(i.$wrapped + 1, $g.____testlib.basictypes.Boolean);
+    return $t.fastbox(i.$wrapped + 1, $g.____testlib.basictypes.Integer);
   });
   $static.GetSomething = $t.markpromising(function (i) {
     var $result;

--- a/generator/es5/tests/sml/children.js
+++ b/generator/es5/tests/sml/children.js
@@ -49,7 +49,7 @@ $module('children', function () {
             break;
 
           case 4:
-            counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.____testlib.basictypes.Boolean);
+            counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.____testlib.basictypes.Integer);
             $current = 2;
             $continue($resolve, $reject);
             return;

--- a/generator/es5/tests/sml/decorator.js
+++ b/generator/es5/tests/sml/decorator.js
@@ -4,10 +4,10 @@ $module('decorator', function () {
     return $t.fastbox(10, $g.____testlib.basictypes.Integer);
   };
   $static.First = function (decorated, value) {
-    return $t.fastbox(decorated.$wrapped + value.$wrapped, $g.____testlib.basictypes.Boolean);
+    return $t.fastbox(decorated.$wrapped + value.$wrapped, $g.____testlib.basictypes.Integer);
   };
   $static.Second = function (decorated, value) {
-    return $t.fastbox(decorated.$wrapped - value.$wrapped, $g.____testlib.basictypes.Boolean);
+    return $t.fastbox(decorated.$wrapped - value.$wrapped, $g.____testlib.basictypes.Integer);
   };
   $static.Check = function (decorated, value) {
     return $t.fastbox(value.$wrapped && (decorated.$wrapped == 15), $g.____testlib.basictypes.Boolean);

--- a/generator/es5/tests/sml/streamchild.js
+++ b/generator/es5/tests/sml/streamchild.js
@@ -49,7 +49,7 @@ $module('streamchild', function () {
             break;
 
           case 4:
-            counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.____testlib.basictypes.Boolean);
+            counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.____testlib.basictypes.Integer);
             $current = 2;
             $continue($resolve, $reject);
             return;
@@ -102,7 +102,7 @@ $module('streamchild', function () {
         switch ($current) {
           case 0:
             $promise.maybe($g.streamchild.SimpleFunction($g.____testlib.basictypes.Mapping($g.____testlib.basictypes.String).Empty(), $g.____testlib.basictypes.MapStream($g.____testlib.basictypes.Integer, $g.____testlib.basictypes.Integer)($g.streamchild.GetValues(), function (value) {
-              return $t.fastbox(value.$wrapped + 1, $g.____testlib.basictypes.Boolean);
+              return $t.fastbox(value.$wrapped + 1, $g.____testlib.basictypes.Integer);
             }))).then(function ($result0) {
               $result = $result0;
               $current = 1;

--- a/generator/es5/tests/sourcemapping/basic.js
+++ b/generator/es5/tests/sourcemapping/basic.js
@@ -866,7 +866,7 @@ this.Serulian = function ($global) {
 
             case 1:
               t = /*#Tuple<int, bool>.Build(this.current, true)#*/$g.____testlib.basictypes.Tuple(/*#int, bool>.Build(this.current, true)#*/$g.____testlib.basictypes.Integer, /*#bool>.Build(this.current, true)#*/$g.____testlib.basictypes.Boolean).Build(/*#this.current, true)#*/$this.current, /*#true)#*/$t.fastbox(/*#true)#*/true, /*#true)#*/$g.____testlib.basictypes.Boolean));
-/*#this.current = this.current + 1#*/              $this.current = /*#this.current + 1#*/$t.fastbox(/*#this.current + 1#*/$this.current.$wrapped + /*#this.current + 1#*/1, /*#this.current + 1#*/$g.____testlib.basictypes.Boolean);
+/*#this.current = this.current + 1#*/              $this.current = /*#this.current + 1#*/$t.fastbox(/*#this.current + 1#*/$this.current.$wrapped + /*#this.current + 1#*/1, /*#this.current + 1#*/$g.____testlib.basictypes.Integer);
               return t;
 
             case 2:
@@ -948,7 +948,7 @@ this.Serulian = function ($global) {
               break;
 
             case 1:
-/*#start = start + this.Count#*/              start = /*#start + this.Count#*/$t.fastbox(/*#start + this.Count#*/start.$wrapped + /*#this.Count#*/$this.Count().$wrapped, /*#start + this.Count#*/$g.____testlib.basictypes.Boolean);
+/*#start = start + this.Count#*/              start = /*#start + this.Count#*/$t.fastbox(/*#start + this.Count#*/start.$wrapped + /*#this.Count#*/$this.Count().$wrapped, /*#start + this.Count#*/$g.____testlib.basictypes.Integer);
               $current = 2;
               continue syncloop;
 
@@ -963,7 +963,7 @@ this.Serulian = function ($global) {
               break;
 
             case 3:
-/*#end = end + this.Count#*/              end = /*#end + this.Count#*/$t.fastbox(/*#end + this.Count#*/end.$wrapped + /*#this.Count#*/$this.Count().$wrapped, /*#end + this.Count#*/$g.____testlib.basictypes.Boolean);
+/*#end = end + this.Count#*/              end = /*#end + this.Count#*/$t.fastbox(/*#end + this.Count#*/end.$wrapped + /*#this.Count#*/$this.Count().$wrapped, /*#end + this.Count#*/$g.____testlib.basictypes.Integer);
               $current = 4;
               continue syncloop;
 
@@ -1029,7 +1029,7 @@ this.Serulian = function ($global) {
               continue syncloop;
 
             case 1:
-              $temp1 = /*#0..(len - 1) {#*/$g.____testlib.basictypes.Integer.$range(/*#0..(len - 1) {#*/$t.fastbox(/*#0..(len - 1) {#*/0, /*#0..(len - 1) {#*/$g.____testlib.basictypes.Integer), /*#len - 1) {#*/$t.fastbox(/*#len - 1) {#*/len.$wrapped - /*#len - 1) {#*/1, /*#len - 1) {#*/$g.____testlib.basictypes.Boolean));
+              $temp1 = /*#0..(len - 1) {#*/$g.____testlib.basictypes.Integer.$range(/*#0..(len - 1) {#*/$t.fastbox(/*#0..(len - 1) {#*/0, /*#0..(len - 1) {#*/$g.____testlib.basictypes.Integer), /*#len - 1) {#*/$t.fastbox(/*#len - 1) {#*/len.$wrapped - /*#len - 1) {#*/1, /*#len - 1) {#*/$g.____testlib.basictypes.Integer));
               $current = 2;
               continue syncloop;
 
@@ -1378,7 +1378,7 @@ this.Serulian = function ($global) {
               break;
 
             case 1:
-/*#start = start + this.Length#*/              start = /*#start + this.Length#*/$t.fastbox(/*#start + this.Length#*/start.$wrapped + /*#this.Length#*/$this.Length().$wrapped, /*#start + this.Length#*/$g.____testlib.basictypes.Boolean);
+/*#start = start + this.Length#*/              start = /*#start + this.Length#*/$t.fastbox(/*#start + this.Length#*/start.$wrapped + /*#this.Length#*/$this.Length().$wrapped, /*#start + this.Length#*/$g.____testlib.basictypes.Integer);
               $current = 2;
               continue syncloop;
 
@@ -1393,7 +1393,7 @@ this.Serulian = function ($global) {
               break;
 
             case 3:
-/*#end = end + this.Length#*/              end = /*#end + this.Length#*/$t.fastbox(/*#end + this.Length#*/end.$wrapped + /*#this.Length#*/$this.Length().$wrapped, /*#end + this.Length#*/$g.____testlib.basictypes.Boolean);
+/*#end = end + this.Length#*/              end = /*#end + this.Length#*/$t.fastbox(/*#end + this.Length#*/end.$wrapped + /*#this.Length#*/$this.Length().$wrapped, /*#end + this.Length#*/$g.____testlib.basictypes.Integer);
               $current = 4;
               continue syncloop;
 
@@ -1641,7 +1641,7 @@ this.Serulian = function ($global) {
             continue syncloop;
 
           case 1:
-            $temp1 = /*#0 .. (pieces.Length - 1) {#*/$g.____testlib.basictypes.Integer.$range(/*#0 .. (pieces.Length - 1) {#*/$t.fastbox(/*#0 .. (pieces.Length - 1) {#*/0, /*#0 .. (pieces.Length - 1) {#*/$g.____testlib.basictypes.Integer), /*#pieces.Length - 1) {#*/$t.fastbox(/*#pieces.Length - 1) {#*/pieces.Length().$wrapped - /*#pieces.Length - 1) {#*/1, /*#pieces.Length - 1) {#*/$g.____testlib.basictypes.Boolean));
+            $temp1 = /*#0 .. (pieces.Length - 1) {#*/$g.____testlib.basictypes.Integer.$range(/*#0 .. (pieces.Length - 1) {#*/$t.fastbox(/*#0 .. (pieces.Length - 1) {#*/0, /*#0 .. (pieces.Length - 1) {#*/$g.____testlib.basictypes.Integer), /*#pieces.Length - 1) {#*/$t.fastbox(/*#pieces.Length - 1) {#*/pieces.Length().$wrapped - /*#pieces.Length - 1) {#*/1, /*#pieces.Length - 1) {#*/$g.____testlib.basictypes.Integer));
             $current = 2;
             continue syncloop;
 

--- a/generator/es5/tests/sync/loop.js
+++ b/generator/es5/tests/sync/loop.js
@@ -1,7 +1,7 @@
 $module('loop', function () {
   var $static = this;
   $static.DoSomething = function (i) {
-    return $t.fastbox(i.$wrapped + 1, $g.____testlib.basictypes.Boolean);
+    return $t.fastbox(i.$wrapped + 1, $g.____testlib.basictypes.Integer);
   };
   $static.TEST = function () {
     var counter;
@@ -37,7 +37,7 @@ $module('loop', function () {
         case 4:
           counter = $t.fastbox(counter.$wrapped + $g.loop.DoSomething($t.syncnullcompare(result.First, function () {
             return $t.fastbox(0, $g.____testlib.basictypes.Integer);
-          })).$wrapped, $g.____testlib.basictypes.Boolean);
+          })).$wrapped, $g.____testlib.basictypes.Integer);
           $current = 1;
           continue syncloop;
 


### PR DESCRIPTION
We were accidentally always boxing back to a boolean, rather than the proper return type