### PR TITLE
Prevent PrincipalType from panicing

### DIFF
--- a/graphs/scopegraph/scope_literal_expr.go
+++ b/graphs/scopegraph/scope_literal_expr.go
@@ -590,9 +590,14 @@ func (sb *scopeBuilder) scopePrincipalLiteralExpression(node compilergraph.Graph
 		return newScope().Invalid().GetScope()
 	}
 
+	principalType, hasPrincipalType := tgType.PrincipalType()
+	if !hasPrincipalType {
+		principalType = sb.sg.tdg.AnyTypeReference()
+	}
+
 	return newScope().
 		Valid().
-		Resolving(tgType.PrincipalType()).
+		Resolving(principalType).
 		GetScope()
 }
 

--- a/graphs/typegraph/internal_construction.go
+++ b/graphs/typegraph/internal_construction.go
@@ -112,7 +112,15 @@ func (g *TypeGraph) validatePrincipals() bool {
 				continue
 			}
 
-			principalTypeRef := agentTypeRef.ReferredType().PrincipalType()
+			principalTypeRef, hasPrincipalType := agentTypeRef.ReferredType().PrincipalType()
+			if !hasPrincipalType {
+				status = false
+				g.decorateWithError(
+					modifier.Modify(typeDecl.GraphNode),
+					"Type '%s' is an agent type but is missing a defined principal type", typeDecl.Name())
+				continue
+			}
+
 			if serr := typeDecl.GetTypeReference().CheckSubTypeOf(principalTypeRef); serr != nil {
 				status = false
 				g.decorateWithError(


### PR DESCRIPTION
It won't be present on some partial graphs, and it is more idiomatic to return false if it isn't present