### PR TITLE
Start work on allowing for formal integration of other languages and services into Serulian

### DIFF
--- a/generator/es5/es5.go
+++ b/generator/es5/es5.go
@@ -34,7 +34,7 @@ func generateModules(sg *scopegraph.ScopeGraph) map[typegraph.TGModule]esbuilder
 		graph:      sg.SourceGraph().Graph,
 		scopegraph: sg,
 		templater:  shared.NewTemplater(),
-		pather:     shared.NewPather(sg.SourceGraph().Graph),
+		pather:     shared.NewPather(sg),
 	}
 
 	// Generate the builder for each of the modules.
@@ -46,11 +46,11 @@ func GenerateES5(sg *scopegraph.ScopeGraph, generatedFilePath string, sourceRoot
 	generated := generateModules(sg)
 
 	// Order the modules by their paths.
-	pather := shared.NewPather(sg.SourceGraph().Graph)
+	pather := shared.NewPather(sg)
 	modulePathMap := map[string]esbuilder.SourceBuilder{}
 
 	var modulePathList = make([]string, 0)
-	for module, _ := range generated {
+	for module := range generated {
 		path := pather.GetModulePath(module)
 		modulePathList = append(modulePathList, path)
 		modulePathMap[path] = generated[module]

--- a/generator/es5/expressiongenerator/expressiongenerator.go
+++ b/generator/es5/expressiongenerator/expressiongenerator.go
@@ -37,7 +37,7 @@ func GenerateExpression(expression codedom.Expression, asyncOption AsyncOption, 
 	generator := &expressionGenerator{
 		scopegraph:     scopegraph,
 		machineBuilder: machineBuilder,
-		pather:         shared.NewPather(scopegraph.SourceGraph().Graph),
+		pather:         shared.NewPather(scopegraph),
 		wrappers:       make([]*expressionWrapper, 0),
 		variables:      make([]string, 0),
 	}

--- a/generator/es5/statemachine/stategenerator.go
+++ b/generator/es5/statemachine/stategenerator.go
@@ -45,7 +45,7 @@ const (
 // buildGenerator builds a new state machine generator.
 func buildGenerator(scopegraph *scopegraph.ScopeGraph, templater *shared.Templater, funcTraits shared.StateFunctionTraits) *stateGenerator {
 	generator := &stateGenerator{
-		pather:    shared.NewPather(scopegraph.SourceGraph().Graph),
+		pather:    shared.NewPather(scopegraph),
 		templater: templater,
 
 		scopegraph: scopegraph,

--- a/graphs/scopegraph/construction.go
+++ b/graphs/scopegraph/construction.go
@@ -12,6 +12,7 @@ import (
 	"github.com/serulian/compiler/graphs/srg"
 	"github.com/serulian/compiler/graphs/srg/typerefresolver"
 	"github.com/serulian/compiler/graphs/typegraph"
+	"github.com/serulian/compiler/integration"
 	"github.com/serulian/compiler/packageloader"
 
 	"github.com/cevaris/ordered_map"
@@ -168,14 +169,20 @@ func checkInitializationCycles(builder *scopeBuilder) {
 	builder.saveScopes()
 }
 
-func buildScopeGraphWithResolver(srg *srg.SRG, tdg *typegraph.TypeGraph,
+func buildScopeGraphWithResolver(srg *srg.SRG, tdg *typegraph.TypeGraph, integrations []integration.LanguageIntegration,
 	resolver *typerefresolver.TypeReferenceResolver, packageLoader *packageloader.PackageLoader) Result {
+
+	integrationsMap := map[string]integration.LanguageIntegration{}
+	for _, integration := range integrations {
+		integrationsMap[integration.SourceHandler().Kind()] = integration
+	}
 
 	scopeGraph := &ScopeGraph{
 		srg:                   srg,
 		tdg:                   tdg,
 		graph:                 srg.Graph,
 		packageLoader:         packageLoader,
+		integrations:          integrationsMap,
 		srgRefResolver:        resolver,
 		dynamicPromisingNames: map[string]bool{},
 		layer: srg.Graph.NewGraphLayer("sig", NodeTypeTagged),

--- a/graphs/scopegraph/construction.go
+++ b/graphs/scopegraph/construction.go
@@ -13,7 +13,6 @@ import (
 	"github.com/serulian/compiler/graphs/srg/typerefresolver"
 	"github.com/serulian/compiler/graphs/typegraph"
 	"github.com/serulian/compiler/packageloader"
-	"github.com/serulian/compiler/webidl"
 
 	"github.com/cevaris/ordered_map"
 )
@@ -169,13 +168,12 @@ func checkInitializationCycles(builder *scopeBuilder) {
 	builder.saveScopes()
 }
 
-func buildScopeGraphWithResolver(srg *srg.SRG, irg *webidl.WebIRG, tdg *typegraph.TypeGraph,
+func buildScopeGraphWithResolver(srg *srg.SRG, tdg *typegraph.TypeGraph,
 	resolver *typerefresolver.TypeReferenceResolver, packageLoader *packageloader.PackageLoader) Result {
 
 	scopeGraph := &ScopeGraph{
 		srg:                   srg,
 		tdg:                   tdg,
-		irg:                   irg,
 		graph:                 srg.Graph,
 		packageLoader:         packageLoader,
 		srgRefResolver:        resolver,

--- a/graphs/scopegraph/scopegraph.go
+++ b/graphs/scopegraph/scopegraph.go
@@ -167,7 +167,7 @@ func ParseAndBuildScopeGraphWithConfig(config Config) (Result, error) {
 	resolver.FreezeCache()
 
 	// Construct the scope graph.
-	scopeResult := buildScopeGraphWithResolver(sourcegraph, webidlgraph, typeResult.Graph, resolver, loader)
+	scopeResult := buildScopeGraphWithResolver(sourcegraph, typeResult.Graph, resolver, loader)
 	return Result{
 		Status:        scopeResult.Status && typeResult.Status && loaderResult.Status,
 		Errors:        combineErrors(loaderResult.Errors, typeResult.Errors, scopeResult.Errors),

--- a/graphs/scopegraph/scopegraph.go
+++ b/graphs/scopegraph/scopegraph.go
@@ -138,8 +138,8 @@ func ParseAndBuildScopeGraphWithConfig(config Config) (Result, error) {
 		SkipVCSRefresh:            config.Target == Tooling,
 
 		SourceHandlers: []packageloader.SourceHandler{
-			sourcegraph.PackageLoaderHandler(),
-			webidlgraph.PackageLoaderHandler()},
+			sourcegraph.SourceHandler(),
+			webidlgraph.SourceHandler()},
 	})
 
 	loaderResult := loader.Load(config.Libraries...)

--- a/graphs/srg/srg.go
+++ b/graphs/srg/srg.go
@@ -73,8 +73,8 @@ func (g *SRG) TryGetNode(nodeId compilergraph.GraphNodeId) (compilergraph.GraphN
 	return g.layer.TryGetNode(nodeId)
 }
 
-// PackageLoaderHandler returns a SourceHandler for populating the SRG via a package loader.
-func (g *SRG) PackageLoaderHandler() packageloader.SourceHandler {
+// SourceHandler returns a SourceHandler for populating the SRG via a package loader.
+func (g *SRG) SourceHandler() packageloader.SourceHandler {
 	return &srgSourceHandler{g, g.layer.NewModifier()}
 }
 

--- a/graphs/srg/testutil.go
+++ b/graphs/srg/testutil.go
@@ -29,7 +29,7 @@ func loadSRG(t *testing.T, path string, libPaths ...string) (*SRG, packageloader
 	loader := packageloader.NewPackageLoader(packageloader.Config{
 		Entrypoint:                packageloader.Entrypoint(graph.RootSourceFilePath),
 		VCSDevelopmentDirectories: []string{},
-		SourceHandlers:            []packageloader.SourceHandler{testSRG.PackageLoaderHandler(), testLoader},
+		SourceHandlers:            []packageloader.SourceHandler{testSRG.SourceHandler(), testLoader},
 	})
 
 	result := loader.Load(libraries...)

--- a/graphs/srg/typeconstructor/typeconstructor_test.go
+++ b/graphs/srg/typeconstructor/typeconstructor_test.go
@@ -124,7 +124,7 @@ func TestGraphs(t *testing.T) {
 		testIDL := webidl.NewIRG(graph)
 
 		loader := packageloader.NewPackageLoader(
-			packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.PackageLoaderHandler(), testIDL.PackageLoaderHandler()))
+			packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.SourceHandler(), testIDL.SourceHandler()))
 
 		srgResult := loader.Load(packageloader.Library{TESTLIB_PATH, false, ""})
 
@@ -173,7 +173,7 @@ func TestLookupReturnType(t *testing.T) {
 	testSRG := srg.NewSRG(graph)
 	testIDL := webidl.NewIRG(graph)
 
-	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.PackageLoaderHandler(), testIDL.PackageLoaderHandler()))
+	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.SourceHandler(), testIDL.SourceHandler()))
 
 	srgResult := loader.Load(packageloader.Library{TESTLIB_PATH, false, ""})
 	if !assert.True(t, srgResult.Status, "Got error for SRG construction: %v", srgResult.Errors) {

--- a/graphs/srg/typeconstructor/typeconstructor_test.go
+++ b/graphs/srg/typeconstructor/typeconstructor_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/serulian/compiler/graphs/typegraph"
 	"github.com/serulian/compiler/packageloader"
 	"github.com/serulian/compiler/webidl"
-	webidltc "github.com/serulian/compiler/webidl/typeconstructor"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,7 +120,7 @@ func TestGraphs(t *testing.T) {
 		}
 
 		testSRG := srg.NewSRG(graph)
-		testIDL := webidl.NewIRG(graph)
+		testIDL := webidl.WebIDLProvider(graph)
 
 		loader := packageloader.NewPackageLoader(
 			packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.SourceHandler(), testIDL.SourceHandler()))
@@ -134,7 +133,7 @@ func TestGraphs(t *testing.T) {
 		}
 
 		// Construct the type graph.
-		result := typegraph.BuildTypeGraph(testSRG.Graph, webidltc.GetConstructor(testIDL), GetConstructor(testSRG))
+		result := typegraph.BuildTypeGraph(testSRG.Graph, testIDL.TypeConstructor(), GetConstructor(testSRG))
 
 		if test.expectedError == "" {
 			// Make sure we had no errors during construction.
@@ -171,7 +170,7 @@ func TestLookupReturnType(t *testing.T) {
 	}
 
 	testSRG := srg.NewSRG(graph)
-	testIDL := webidl.NewIRG(graph)
+	testIDL := webidl.WebIDLProvider(graph)
 
 	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.SourceHandler(), testIDL.SourceHandler()))
 
@@ -181,7 +180,7 @@ func TestLookupReturnType(t *testing.T) {
 	}
 
 	// Construct the type graph.
-	result := typegraph.BuildTypeGraph(testSRG.Graph, webidltc.GetConstructor(testIDL), GetConstructor(testSRG))
+	result := typegraph.BuildTypeGraph(testSRG.Graph, testIDL.TypeConstructor(), GetConstructor(testSRG))
 	if !assert.True(t, result.Status, "Got error for TypeGraph construction: %v", result.Errors) {
 		return
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -27,4 +27,20 @@ type LanguageIntegration interface {
 	// TypeConstructor returns the type constructor used to construct the types and members that
 	// should be added to the type system by the integrated language or system.
 	TypeConstructor() typegraph.TypeGraphConstructor
+
+	// PathHandler returns a handler for translating generated paths to those provided by the integration.
+	// If the integration returns nil, then no translation is done.
+	PathHandler() PathHandler
+}
+
+// PathHandler translates various paths encountered during code generation into those provided by the integration,
+// if any.
+type PathHandler interface {
+	// GetStaticMemberPath returns the global path for the given statically defined type member. If the handler
+	// returns empty string, the default path will be used.
+	GetStaticMemberPath(member typegraph.TGMember, referenceType typegraph.TypeReference) string
+
+	// GetModulePath returns the global path for the given module. If the handler
+	// returns empty string, the default path will be used.
+	GetModulePath(module typegraph.TGModule) string
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -1,0 +1,30 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package integration defines interfaces and helpers for writing language integrations with Serulian.
+package integration
+
+import (
+	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/graphs/typegraph"
+	"github.com/serulian/compiler/packageloader"
+)
+
+// LanguageIntegrationProvider defines an interface for providing a LanguageIntegration implementation
+// over a Serulian graph.
+type LanguageIntegrationProvider interface {
+	// GetIntegration returns a new LanguageIntegration instance over the given graph.
+	GetIntegration(graph *compilergraph.SerulianGraph) LanguageIntegration
+}
+
+// LanguageIntegration defines an integration of an external language or system into Serulian.
+type LanguageIntegration interface {
+	// SourceHandler returns the source handler used to load, parse and validate the input
+	// source file(s) for the integrated language or system.
+	SourceHandler() packageloader.SourceHandler
+
+	// TypeConstructor returns the type constructor used to construct the types and members that
+	// should be added to the type system by the integrated language or system.
+	TypeConstructor() typegraph.TypeGraphConstructor
+}

--- a/packageloader/sourcehandler.go
+++ b/packageloader/sourcehandler.go
@@ -18,14 +18,18 @@ type SourceHandler interface {
 	// handler under packages.
 	PackageFileExtension() string
 
-	// Parse parses the given source file.
+	// Parse parses the given source file, typically applying the AST to the underlying
+	// graph being constructed by this handler. importHandler should be invoked for any
+	// imports found, to indicate to the package loader that the imports should be followed
+	// and themselves loaded.
 	Parse(source compilercommon.InputSource, input string, importHandler ImportHandler)
 
 	// Apply performs final application of all changes in the source handler. This method is called
 	// synchronously, and is typically used to apply the parsed structure to the underlying graph.
 	Apply(packageMap LoadedPackageMap, sourceTracker SourceTracker)
 
-	// Verify performs verification of the loaded source.
+	// Verify performs verification of the loaded source. Any errors or warnings encountered
+	// should be reported via the given reporter callbacks.
 	Verify(errorReporter ErrorReporter, warningReporter WarningReporter)
 }
 

--- a/webidl/graph/annotation.go
+++ b/webidl/graph/annotation.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"github.com/serulian/compiler/compilercommon"

--- a/webidl/graph/ast_node.go
+++ b/webidl/graph/ast_node.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"github.com/serulian/compiler/compilergraph"

--- a/webidl/graph/declaration.go
+++ b/webidl/graph/declaration.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"github.com/serulian/compiler/compilercommon"

--- a/webidl/graph/globals.go
+++ b/webidl/graph/globals.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 // GLOBAL_CONTEXT_ANNOTATIONS are the annotations that mark an interface as being a global context
 // (e.g. Window) in WebIDL.

--- a/webidl/graph/member.go
+++ b/webidl/graph/member.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"bytes"

--- a/webidl/graph/module.go
+++ b/webidl/graph/module.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"path"

--- a/webidl/graph/parameter.go
+++ b/webidl/graph/parameter.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"github.com/serulian/compiler/compilercommon"

--- a/webidl/graph/sourcehandler.go
+++ b/webidl/graph/sourcehandler.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"github.com/serulian/compiler/compilercommon"

--- a/webidl/graph/typecollapser.go
+++ b/webidl/graph/typecollapser.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"github.com/serulian/compiler/compilercommon"

--- a/webidl/graph/webidl.go
+++ b/webidl/graph/webidl.go
@@ -1,0 +1,112 @@
+// Copyright 2015 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package graph defines the graph for the WebIDL integration.
+package graph
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+
+	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/compilergraph"
+
+	"github.com/serulian/compiler/packageloader"
+	"github.com/serulian/compiler/webidl/parser"
+)
+
+// WebIRG defines an interface representation graph for the supported subset of WebIDL.
+type WebIRG struct {
+	graph *compilergraph.SerulianGraph // The root graph.
+
+	layer          *compilergraph.GraphLayer // The IRG layer in the graph.
+	rootModuleNode compilergraph.GraphNode   // The root module node.
+
+	packageMap    map[string]packageloader.PackageInfo // Map from package internal ID to info.
+	sourceTracker packageloader.SourceTracker          // The source tracker.
+
+	typeCollapser *TypeCollapser
+}
+
+// NewIRG returns a new IRG for populating the graph with parsed source.
+func NewIRG(graph *compilergraph.SerulianGraph) *WebIRG {
+	irg := &WebIRG{
+		graph: graph,
+		layer: graph.NewGraphLayer("webirg", parser.NodeTypeTagged),
+	}
+
+	modifier := irg.layer.NewModifier()
+	defer modifier.Apply()
+
+	irg.rootModuleNode = modifier.CreateNode(parser.NodeTypeGlobalModule).AsNode()
+	return irg
+}
+
+// GetUniqueId returns a unique hash ID for the IRG node that is stable across compilations.
+func GetUniqueId(irgNode compilergraph.GraphNode) string {
+	hashBytes := []byte(irgNode.Get(parser.NodePredicateSource) + ":" + strconv.Itoa(irgNode.GetValue(parser.NodePredicateStartRune).Int()))
+	sha256bytes := sha256.Sum256(hashBytes)
+	return hex.EncodeToString(sha256bytes[:])[0:8]
+}
+
+// TypeCollapser returns the type collapser for this graph. Will not exist until after source
+// has been loaded into the graph.
+func (g *WebIRG) TypeCollapser() *TypeCollapser {
+	return g.typeCollapser
+}
+
+// RootModuleNode returns the node for the root module containing all the collapsed types.
+func (g *WebIRG) RootModuleNode() compilergraph.GraphNode {
+	return g.rootModuleNode
+}
+
+// SourceHandler returns a SourceHandler for populating the IRG via a package loader.
+func (g *WebIRG) SourceHandler() packageloader.SourceHandler {
+	return &irgSourceHandler{g, g.layer.NewModifier()}
+}
+
+// findAllNodes starts a new query over the IRG from nodes of the given type.
+func (g *WebIRG) findAllNodes(nodeTypes ...parser.NodeType) compilergraph.GraphQuery {
+	var nodeTypesTagged []compilergraph.TaggedValue = make([]compilergraph.TaggedValue, len(nodeTypes))
+	for index, nodeType := range nodeTypes {
+		nodeTypesTagged[index] = nodeType
+	}
+
+	return g.layer.FindNodesOfKind(nodeTypesTagged...)
+}
+
+// GetNode returns the node with the given ID in this layer or panics.
+func (g *WebIRG) GetNode(nodeId compilergraph.GraphNodeId) compilergraph.GraphNode {
+	return g.layer.GetNode(nodeId)
+}
+
+// TryGetNode attempts to return the node with the given ID in this layer, if any.
+func (g *WebIRG) TryGetNode(nodeId compilergraph.GraphNodeId) (compilergraph.GraphNode, bool) {
+	return g.layer.TryGetNode(nodeId)
+}
+
+// SourceRangesOf returns the source ranges of the given IRG node.
+func (g *WebIRG) SourceRangesOf(node compilergraph.GraphNode) []compilercommon.SourceRange {
+	sourceRange, hasSourceRange := g.SourceRangeOf(node)
+	if !hasSourceRange {
+		return []compilercommon.SourceRange{}
+	}
+
+	return []compilercommon.SourceRange{sourceRange}
+}
+
+// SourceRangeOf returns the source range of the given IRG node.
+func (g *WebIRG) SourceRangeOf(node compilergraph.GraphNode) (compilercommon.SourceRange, bool) {
+	startRune, hasStartRune := node.TryGetValue(parser.NodePredicateStartRune)
+	endRune, hasEndRune := node.TryGetValue(parser.NodePredicateEndRune)
+	sourcePath, hasSource := node.TryGet(parser.NodePredicateSource)
+
+	if !hasStartRune || !hasEndRune || !hasSource {
+		return nil, false
+	}
+
+	source := compilercommon.InputSource(sourcePath)
+	return source.RangeForRunePositions(startRune.Int(), endRune.Int(), g.sourceTracker), true
+}

--- a/webidl/graph/webidl_test.go
+++ b/webidl/graph/webidl_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package webidl
+package graph
 
 import (
 	"fmt"
@@ -32,7 +32,7 @@ func getIRG(t *testing.T, path string) *WebIRG {
 }
 
 func TestBasicLoading(t *testing.T) {
-	testIRG := getIRG(t, "tests/basic.webidl")
+	testIRG := getIRG(t, "../tests/basic.webidl")
 	decl := testIRG.Declarations()
 
 	if !assert.Equal(t, 1, len(decl), "Expected 1 declaration") {
@@ -110,7 +110,7 @@ func TestBasicLoading(t *testing.T) {
 }
 
 func TestParsingIssue(t *testing.T) {
-	graph, err := compilergraph.NewGraph("tests/parseissue.webidl")
+	graph, err := compilergraph.NewGraph("../tests/parseissue.webidl")
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/webidl/typeconstructor/typeconstructor.go
+++ b/webidl/typeconstructor/typeconstructor.go
@@ -11,7 +11,7 @@ import (
 	"github.com/serulian/compiler/compilercommon"
 	"github.com/serulian/compiler/compilergraph"
 	"github.com/serulian/compiler/graphs/typegraph"
-	"github.com/serulian/compiler/webidl"
+	webidl "github.com/serulian/compiler/webidl/graph"
 )
 
 // GetConstructor returns a TypeGraph constructor for the given IRG.

--- a/webidl/typeconstructor/typeconstructor_test.go
+++ b/webidl/typeconstructor/typeconstructor_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/serulian/compiler/compilergraph"
 	"github.com/serulian/compiler/graphs/typegraph"
 	"github.com/serulian/compiler/packageloader"
-	"github.com/serulian/compiler/webidl"
+	webidl "github.com/serulian/compiler/webidl/graph"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/webidl/typeconstructor/typeconstructor_test.go
+++ b/webidl/typeconstructor/typeconstructor_test.go
@@ -89,7 +89,7 @@ func TestGraphs(t *testing.T) {
 
 		testIRG := webidl.NewIRG(graph)
 
-		loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testIRG.PackageLoaderHandler()))
+		loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testIRG.SourceHandler()))
 
 		secondaryLibs := make([]packageloader.Library, 0)
 		if _, err := os.Stat("tests/" + test.entrypoint + "/"); err == nil {

--- a/webidl/webidl.go
+++ b/webidl/webidl.go
@@ -1,111 +1,33 @@
-// Copyright 2015 The Serulian Authors. All rights reserved.
+// Copyright 2017 The Serulian Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package webidl defines the WebIDL integration for Serulian. WebIDL allows for type-safe invocation
+// and reference of native environment-defined types and functions.
 package webidl
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"strconv"
-
-	"github.com/serulian/compiler/compilercommon"
 	"github.com/serulian/compiler/compilergraph"
-
+	"github.com/serulian/compiler/graphs/typegraph"
 	"github.com/serulian/compiler/packageloader"
-	"github.com/serulian/compiler/webidl/parser"
+
+	irg "github.com/serulian/compiler/webidl/graph"
+	irgtc "github.com/serulian/compiler/webidl/typeconstructor"
 )
 
-// WebIRG defines an interface representation graph for the supported subset of WebIDL.
-type WebIRG struct {
-	graph *compilergraph.SerulianGraph // The root graph.
-
-	layer          *compilergraph.GraphLayer // The IRG layer in the graph.
-	rootModuleNode compilergraph.GraphNode   // The root module node.
-
-	packageMap    map[string]packageloader.PackageInfo // Map from package internal ID to info.
-	sourceTracker packageloader.SourceTracker          // The source tracker.
-
-	typeCollapser *TypeCollapser
+type webidlProvider struct {
+	irg *irg.WebIRG
 }
 
-// NewIRG returns a new IRG for populating the graph with parsed source.
-func NewIRG(graph *compilergraph.SerulianGraph) *WebIRG {
-	irg := &WebIRG{
-		graph: graph,
-		layer: graph.NewGraphLayer("webirg", parser.NodeTypeTagged),
-	}
-
-	modifier := irg.layer.NewModifier()
-	defer modifier.Apply()
-
-	irg.rootModuleNode = modifier.CreateNode(parser.NodeTypeGlobalModule).AsNode()
-	return irg
+// WebIDLProvider returns a provider of a WebIDL integration.
+func WebIDLProvider(graph *compilergraph.SerulianGraph) webidlProvider {
+	return webidlProvider{irg.NewIRG(graph)}
 }
 
-// GetUniqueId returns a unique hash ID for the IRG node that is stable across compilations.
-func GetUniqueId(irgNode compilergraph.GraphNode) string {
-	hashBytes := []byte(irgNode.Get(parser.NodePredicateSource) + ":" + strconv.Itoa(irgNode.GetValue(parser.NodePredicateStartRune).Int()))
-	sha256bytes := sha256.Sum256(hashBytes)
-	return hex.EncodeToString(sha256bytes[:])[0:8]
+func (p webidlProvider) SourceHandler() packageloader.SourceHandler {
+	return p.irg.SourceHandler()
 }
 
-// TypeCollapser returns the type collapser for this graph. Will not exist until after source
-// has been loaded into the graph.
-func (g *WebIRG) TypeCollapser() *TypeCollapser {
-	return g.typeCollapser
-}
-
-// RootModuleNode returns the node for the root module containing all the collapsed types.
-func (g *WebIRG) RootModuleNode() compilergraph.GraphNode {
-	return g.rootModuleNode
-}
-
-// SourceHandler returns a SourceHandler for populating the IRG via a package loader.
-func (g *WebIRG) SourceHandler() packageloader.SourceHandler {
-	return &irgSourceHandler{g, g.layer.NewModifier()}
-}
-
-// findAllNodes starts a new query over the IRG from nodes of the given type.
-func (g *WebIRG) findAllNodes(nodeTypes ...parser.NodeType) compilergraph.GraphQuery {
-	var nodeTypesTagged []compilergraph.TaggedValue = make([]compilergraph.TaggedValue, len(nodeTypes))
-	for index, nodeType := range nodeTypes {
-		nodeTypesTagged[index] = nodeType
-	}
-
-	return g.layer.FindNodesOfKind(nodeTypesTagged...)
-}
-
-// GetNode returns the node with the given ID in this layer or panics.
-func (g *WebIRG) GetNode(nodeId compilergraph.GraphNodeId) compilergraph.GraphNode {
-	return g.layer.GetNode(nodeId)
-}
-
-// TryGetNode attempts to return the node with the given ID in this layer, if any.
-func (g *WebIRG) TryGetNode(nodeId compilergraph.GraphNodeId) (compilergraph.GraphNode, bool) {
-	return g.layer.TryGetNode(nodeId)
-}
-
-// SourceRangesOf returns the source ranges of the given IRG node.
-func (g *WebIRG) SourceRangesOf(node compilergraph.GraphNode) []compilercommon.SourceRange {
-	sourceRange, hasSourceRange := g.SourceRangeOf(node)
-	if !hasSourceRange {
-		return []compilercommon.SourceRange{}
-	}
-
-	return []compilercommon.SourceRange{sourceRange}
-}
-
-// SourceRangeOf returns the source range of the given IRG node.
-func (g *WebIRG) SourceRangeOf(node compilergraph.GraphNode) (compilercommon.SourceRange, bool) {
-	startRune, hasStartRune := node.TryGetValue(parser.NodePredicateStartRune)
-	endRune, hasEndRune := node.TryGetValue(parser.NodePredicateEndRune)
-	sourcePath, hasSource := node.TryGet(parser.NodePredicateSource)
-
-	if !hasStartRune || !hasEndRune || !hasSource {
-		return nil, false
-	}
-
-	source := compilercommon.InputSource(sourcePath)
-	return source.RangeForRunePositions(startRune.Int(), endRune.Int(), g.sourceTracker), true
+func (p webidlProvider) TypeConstructor() typegraph.TypeGraphConstructor {
+	return irgtc.GetConstructor(p.irg)
 }

--- a/webidl/webidl.go
+++ b/webidl/webidl.go
@@ -7,8 +7,11 @@
 package webidl
 
 import (
+	"fmt"
+
 	"github.com/serulian/compiler/compilergraph"
 	"github.com/serulian/compiler/graphs/typegraph"
+	"github.com/serulian/compiler/integration"
 	"github.com/serulian/compiler/packageloader"
 
 	irg "github.com/serulian/compiler/webidl/graph"
@@ -30,4 +33,25 @@ func (p webidlProvider) SourceHandler() packageloader.SourceHandler {
 
 func (p webidlProvider) TypeConstructor() typegraph.TypeGraphConstructor {
 	return irgtc.GetConstructor(p.irg)
+}
+
+func (p webidlProvider) PathHandler() integration.PathHandler {
+	return pathHandler{p.irg}
+}
+
+type pathHandler struct {
+	irg *irg.WebIRG
+}
+
+func (p pathHandler) GetStaticMemberPath(member typegraph.TGMember, referenceType typegraph.TypeReference) string {
+	if member.Name() == "new" {
+		parentType, _ := member.ParentType()
+		return fmt.Sprintf("$t.nativenew($global.%s)", parentType.Name())
+	}
+
+	return "" // Use the default.
+}
+
+func (p pathHandler) GetModulePath(module typegraph.TGModule) string {
+	return "$global"
 }

--- a/webidl/webidl.go
+++ b/webidl/webidl.go
@@ -61,8 +61,8 @@ func (g *WebIRG) RootModuleNode() compilergraph.GraphNode {
 	return g.rootModuleNode
 }
 
-// PackageLoaderHandler returns a SourceHandler for populating the IRG via a package loader.
-func (g *WebIRG) PackageLoaderHandler() packageloader.SourceHandler {
+// SourceHandler returns a SourceHandler for populating the IRG via a package loader.
+func (g *WebIRG) SourceHandler() packageloader.SourceHandler {
 	return &irgSourceHandler{g, g.layer.NewModifier()}
 }
 

--- a/webidl/webidl_test.go
+++ b/webidl/webidl_test.go
@@ -22,7 +22,7 @@ func getIRG(t *testing.T, path string) *WebIRG {
 	}
 
 	testIRG := NewIRG(graph)
-	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testIRG.PackageLoaderHandler()))
+	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testIRG.SourceHandler()))
 	result := loader.Load()
 	if !result.Status {
 		t.Errorf("Failed to load IRG: %v", result.Errors)
@@ -116,7 +116,7 @@ func TestParsingIssue(t *testing.T) {
 	}
 
 	testIRG := NewIRG(graph)
-	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testIRG.PackageLoaderHandler()))
+	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testIRG.SourceHandler()))
 	result := loader.Load()
 	assert.False(t, result.Status, "Expected parsing issue")
 }


### PR DESCRIPTION
This first set of changes defines the proper interfaces and extracts the remaining WebIDL-specific pieces from all locations except initialization. The followup PR will add support for loading additional integrations via the Go plugin system.