### PR TITLE
Formal support for language integration plugins

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -90,7 +90,11 @@ func BuildSource(rootSourceFilePath string, debug bool, vcsDevelopmentDirectorie
 	// Build a scope graph for the project. This will conduct parsing and type graph
 	// construction on our behalf.
 	log.Println("Starting build")
-	scopeResult := scopegraph.ParseAndBuildScopeGraph(rootSourceFilePath, vcsDevelopmentDirectories, CORE_LIBRARY)
+	scopeResult, err := scopegraph.ParseAndBuildScopeGraph(rootSourceFilePath, vcsDevelopmentDirectories, CORE_LIBRARY)
+	if err != nil {
+		compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil, "%s", err.Error())
+		return false
+	}
 
 	outputWarnings(scopeResult.Warnings)
 	if !scopeResult.Status {

--- a/compilerutil/console.go
+++ b/compilerutil/console.go
@@ -59,6 +59,14 @@ func LogToConsole(level ConsoleLogLevel, sourceRange compilercommon.SourceRange,
 		prefixText = "ERROR: "
 	}
 
+	formattedMessage := fmt.Sprintf(message, args...)
+
+	if sourceRange == nil {
+		prefixColor.Print(prefixText)
+		messageColor.Printf("%s\n", formattedMessage)
+		return
+	}
+
 	startLine, startCol, err := sourceRange.Start().LineAndColumn()
 	if err != nil {
 		startLine = 0
@@ -72,7 +80,6 @@ func LogToConsole(level ConsoleLogLevel, sourceRange compilercommon.SourceRange,
 	}
 
 	locationText := fmt.Sprintf("%v:%v:%v:", sourceRange.Source(), startLine+1, startCol+1)
-	formattedMessage := fmt.Sprintf(message, args...)
 
 	// If the text will go past the terminal width, then make it multiline and add extra whitespace
 	// after it.

--- a/developer/transaction.go
+++ b/developer/transaction.go
@@ -82,9 +82,14 @@ func (dt *developTransaction) Start(w http.ResponseWriter, r *http.Request) {
 func (dt *developTransaction) Build(w http.ResponseWriter, r *http.Request) {
 	// Build a scope graph for the project. This will conduct parsing and type graph
 	// construction on our behalf.
-	scopeResult := scopegraph.ParseAndBuildScopeGraph(dt.rootSourceFilePath,
+	scopeResult, err := scopegraph.ParseAndBuildScopeGraph(dt.rootSourceFilePath,
 		dt.vcsDevelopmentDirectories,
 		builder.CORE_LIBRARY)
+
+	if err != nil {
+		dt.emitInfo(w, "Build failed: %s", err)
+		dt.closeGroup(w)
+	}
 
 	if !scopeResult.Status {
 		dt.sourceMap = sourcemap.NewSourceMap(dt.name+".develop.js", "source/")

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -303,7 +303,7 @@ func TestGenerator(t *testing.T) {
 
 		fmt.Printf("Running test %v...\n", test.name)
 
-		result := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		result, _ := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
 		if !assert.True(t, result.Status, "Got error for ScopeGraph construction %v: %s", test.name, result.Errors) {
 			continue
 		}
@@ -512,7 +512,7 @@ func TestSourceMapping(t *testing.T) {
 
 		// Parse and scope.
 		fmt.Printf("Running mapping test %v...\n", test.name)
-		scopeResult := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		scopeResult, _ := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
 		if !assert.True(t, scopeResult.Status, "Got error for ScopeGraph construction %v: %s", test.name, scopeResult.Errors) {
 			continue
 		}

--- a/graphs/scopegraph/promise_labeler_test.go
+++ b/graphs/scopegraph/promise_labeler_test.go
@@ -223,7 +223,7 @@ func TestPromisingLabels(t *testing.T) {
 		fmt.Printf("Running promise label test: %v\n", test.name)
 
 		entrypointFile := "tests/promising/" + test.entrypoint + ".seru"
-		result := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
 		if !assert.True(t, result.Status, "Expected success in scoping on test: %v\n%v\n%v", test.name, result.Errors, result.Warnings) {
 			continue
 		}

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1572,7 +1572,7 @@ func TestGraphs(t *testing.T) {
 		fmt.Printf("Running test: %v\n", test.name)
 
 		entrypointFile := "tests/" + test.input + "/" + test.entrypoint + ".seru"
-		result := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
 
 		if test.expectedError != "" {
 			if !assert.False(t, result.Status, "Expected failure in scoping on test : %v", test.name) {
@@ -1646,7 +1646,7 @@ var transientScopeTests = []transientScopeTest{
 
 func TestBuildTransientScope(t *testing.T) {
 	entrypointFile := "tests/transient/transient.seru"
-	result := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+	result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
 	if !assert.True(t, result.Status, "Expected success in transient scope test") {
 		return
 	}

--- a/integration/loader.go
+++ b/integration/loader.go
@@ -1,0 +1,78 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"plugin"
+	"strings"
+
+	"github.com/phayes/permbits"
+)
+
+// PROVIDER_SYMBOL_NAME defines the name of the symbol to be exported by dynamic language integration provider
+// plugins.
+const PROVIDER_SYMBOL_NAME = "Provider"
+
+// LoadLanguageIntegrationProviders loads all the language integration providers found under the given
+// path. *All* files in the directory without an extension will be treated as a potential provider, so
+// callers should make sure that the directory is clean otherwise. Note that if the path does not exist,
+// the list returned will be *empty*.
+func LoadLanguageIntegrationProviders(providerDirPath string) ([]LanguageIntegrationProvider, error) {
+	_, err := os.Stat(providerDirPath)
+	if os.IsNotExist(err) {
+		return []LanguageIntegrationProvider{}, nil
+	}
+
+	if err != nil {
+		return []LanguageIntegrationProvider{}, err
+	}
+
+	// Iterate the directory, finding all binaries and trying to load the integrations found within.
+	files, err := ioutil.ReadDir(providerDirPath)
+	if err != nil {
+		return []LanguageIntegrationProvider{}, err
+	}
+
+	if len(files) == 0 {
+		return []LanguageIntegrationProvider{}, nil
+	}
+
+	providers := make([]LanguageIntegrationProvider, 0, len(files))
+	for _, f := range files {
+		if f.Mode().IsRegular() && !strings.Contains(f.Name(), ".") {
+			fullPath := path.Join(providerDirPath, f.Name())
+			permissions, err := permbits.Stat(fullPath)
+			if err != nil {
+				return []LanguageIntegrationProvider{}, err
+			}
+
+			if permissions.UserExecute() || permissions.GroupExecute() || permissions.OtherExecute() {
+				// Found a binary. Attempt to load the provider from it.
+				p, err := plugin.Open(fullPath)
+				if err != nil {
+					return []LanguageIntegrationProvider{}, err
+				}
+
+				providerSymbol, err := p.Lookup(PROVIDER_SYMBOL_NAME)
+				if err != nil {
+					return []LanguageIntegrationProvider{}, err
+				}
+
+				provider, castOk := providerSymbol.(LanguageIntegrationProvider)
+				if !castOk {
+					return []LanguageIntegrationProvider{}, fmt.Errorf("Could find language integration provider in plugin `%s`", f.Name())
+				}
+
+				providers = append(providers, provider)
+			}
+		}
+	}
+
+	return providers, nil
+}

--- a/packageloader/packageloader.go
+++ b/packageloader/packageloader.go
@@ -586,7 +586,7 @@ func (p *PackageLoader) handleImport(sourceKind string, importPath string, impor
 
 	handler, hasHandler := p.handlers[importInformation.Kind]
 	if !hasHandler {
-		p.errors <- compilercommon.SourceErrorf(importInformation.SourceRange, "Unknown kind of import '%s'", importInformation.Kind)
+		p.errors <- compilercommon.SourceErrorf(importInformation.SourceRange, "Unknown kind of import '%s'. Did you forgot to install a source plugin?", importInformation.Kind)
 		return ""
 	}
 

--- a/tester/runner.go
+++ b/tester/runner.go
@@ -87,9 +87,14 @@ func buildAndRunTests(filePath string, runner TestRunner) (bool, error) {
 
 	filename := path.Base(filePath)
 
-	scopeResult := scopegraph.ParseAndBuildScopeGraph(filePath,
+	scopeResult, err := scopegraph.ParseAndBuildScopeGraph(filePath,
 		[]string{},
 		builder.CORE_LIBRARY)
+
+	if err != nil {
+		// TODO: better output
+		return false, fmt.Errorf("Error running test %s: %v", filePath, err)
+	}
 
 	if !scopeResult.Status {
 		// TODO: better output


### PR DESCRIPTION
This change allows for placement of language plugins in a subdirectory named `.langext`. All plugins found within will be loaded when the toolchain runs.