### PR TITLE
Fix handling of non-promising dynamic accesses

### DIFF
--- a/generator/es5/dombuilder/build_access_expr.go
+++ b/generator/es5/dombuilder/build_access_expr.go
@@ -29,7 +29,8 @@ func (db *domBuilder) buildNamedAccess(node compilergraph.GraphNode, name string
 
 	// Reference to an unknown name must be a dynamic access.
 	if !hasNamedReference {
-		return codedom.DynamicAccess(db.buildExpression(*childExprNode), name /* possibly promising */, true, node)
+		isPossiblyPromising := db.scopegraph.IsDynamicPromisingName(name)
+		return codedom.DynamicAccess(db.buildExpression(*childExprNode), name, isPossiblyPromising, node)
 	}
 
 	// Reference to a local name is a var or parameter.

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -293,6 +293,7 @@ var generationTests = []generationTest{
 	generationTest{"sml async children test", "sml", "asyncchildren", integrationTestSuccessExpected, ""},
 
 	generationTest{"native new integration test", "nativenew", "nativenew", integrationTestSuccessExpected, ""},
+	generationTest{"dynamic access non-promising test", "dynamicaccess", "nonpromising", integrationTestSuccessExpected, ""},
 }
 
 func TestGenerator(t *testing.T) {

--- a/generator/es5/tests/accessexpr/dynamicprop.js
+++ b/generator/es5/tests/accessexpr/dynamicprop.js
@@ -28,41 +28,12 @@ $module('dynamicprop', function () {
     };
   });
 
-  $static.TEST = $t.markpromising(function () {
-    var $result;
+  $static.TEST = function () {
     var sc;
     var sca;
-    var $current = 0;
-    var $continue = function ($resolve, $reject) {
-      while (true) {
-        switch ($current) {
-          case 0:
-            sc = $g.dynamicprop.SomeClass.new();
-            sc.set$SomeProp($t.fastbox(123, $g.________testlib.basictypes.Integer));
-            sca = sc;
-            $t.dynamicaccess(sca, 'SomeProp', true).then(function ($result1) {
-              return $promise.resolve($t.cast($result1, $g.________testlib.basictypes.Integer, false).$wrapped == 123).then(function ($result0) {
-                $result = $t.fastbox($result0 && (sc.SomeProp().$wrapped == 123), $g.________testlib.basictypes.Boolean);
-                $current = 1;
-                $continue($resolve, $reject);
-                return;
-              });
-            }).catch(function (err) {
-              $reject(err);
-              return;
-            });
-            return;
-
-          case 1:
-            $resolve($result);
-            return;
-
-          default:
-            $resolve();
-            return;
-        }
-      }
-    };
-    return $promise.new($continue);
-  });
+    sc = $g.dynamicprop.SomeClass.new();
+    sc.set$SomeProp($t.fastbox(123, $g.________testlib.basictypes.Integer));
+    sca = sc;
+    return $t.fastbox(($t.cast($t.dynamicaccess(sca, 'SomeProp', false), $g.________testlib.basictypes.Integer, false).$wrapped == 123) && (sc.SomeProp().$wrapped == 123), $g.________testlib.basictypes.Boolean);
+  };
 });

--- a/generator/es5/tests/dynamicaccess/nonpromising.js
+++ b/generator/es5/tests/dynamicaccess/nonpromising.js
@@ -1,0 +1,46 @@
+$module('nonpromising', function () {
+  var $static = this;
+  this.$struct('5d13a931', 'SomeStruct', false, '', function () {
+    var $static = this;
+    var $instance = this.prototype;
+    $static.new = function (field) {
+      var instance = new $static();
+      instance[BOXED_DATA_PROPERTY] = {
+        field: field,
+      };
+      instance.$markruntimecreated();
+      return instance;
+    };
+    $static.$fields = [];
+    $t.defineStructField($static, 'field', 'field', function () {
+      return $g.________testlib.basictypes.Integer;
+    }, function () {
+      return $g.________testlib.basictypes.Integer;
+    }, false);
+    this.$typesig = function () {
+      if (this.$cachedtypesig) {
+        return this.$cachedtypesig;
+      }
+      var computed = {
+        "Parse|1|fd8bc7c9<5d13a931>": true,
+        "equals|4|fd8bc7c9<9706e8ab>": true,
+        "Stringify|2|fd8bc7c9<268aa058>": true,
+        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
+        "Clone|2|fd8bc7c9<5d13a931>": true,
+        "String|2|fd8bc7c9<268aa058>": true,
+      };
+      return this.$cachedtypesig = computed;
+    };
+  });
+
+  $static.doSomething = function () {
+    var ss;
+    var ssa;
+    ss = $g.nonpromising.SomeStruct.new($t.fastbox(42, $g.________testlib.basictypes.Integer));
+    ssa = ss;
+    return $t.cast($t.dynamicaccess(ssa, 'field', false), $g.________testlib.basictypes.Integer, false);
+  };
+  $static.TEST = function () {
+    return $t.fastbox($g.nonpromising.doSomething().$wrapped == 42, $g.________testlib.basictypes.Boolean);
+  };
+});

--- a/generator/es5/tests/dynamicaccess/nonpromising.seru
+++ b/generator/es5/tests/dynamicaccess/nonpromising.seru
@@ -1,0 +1,16 @@
+struct SomeStruct {
+    field int
+}
+
+function<int> doSomething() {
+    ss := SomeStruct{
+        field: 42,
+    }
+
+    var<any> ssa = ss
+    return ssa->field.(int)
+}
+
+function<any> TEST() {
+    return doSomething() == 42
+}

--- a/graphs/scopegraph/promise_labeler_test.go
+++ b/graphs/scopegraph/promise_labeler_test.go
@@ -58,6 +58,12 @@ var promisingLabelTests = []promisingLabelTest{
 		},
 	},
 
+	promisingLabelTest{"dynamic access field promise test", "dynamicaccessfield",
+		[]expectedPromiseLabel{
+			expectedPromiseLabel{"doSomething", proto.ScopeLabel_SML_PROMISING_NO},
+		},
+	},
+
 	promisingLabelTest{"unknown function called maybe promise test", "unknownfunc",
 		[]expectedPromiseLabel{
 			expectedPromiseLabel{"CallsUnknownFunc", proto.ScopeLabel_SML_PROMISING_MAYBE},

--- a/graphs/scopegraph/scopegraph.go
+++ b/graphs/scopegraph/scopegraph.go
@@ -284,6 +284,13 @@ func (sg *ScopeGraph) ResolveSRGTypeRef(srgTypeRef srg.SRGTypeRef) (typegraph.Ty
 	return sg.srgRefResolver.ResolveTypeRef(srgTypeRef, sg.tdg)
 }
 
+// IsDynamicPromisingName returns true if the given name is considered dynamically promising in the graph.
+// Such a name, when accessed dynamically, *may* return a promise.
+func (sg *ScopeGraph) IsDynamicPromisingName(name string) bool {
+	_, exists := sg.dynamicPromisingNames[name]
+	return exists
+}
+
 // IsPromisingMember returns whether the member, when accessed via the given access type, returns a promise.
 func (sg *ScopeGraph) IsPromisingMember(member typegraph.TGMember, accessType PromisingAccessType) bool {
 	// If this member is not implicitly called and we are asking for implicit access information, then

--- a/graphs/scopegraph/tests/promising/dynamicaccessfield.seru
+++ b/graphs/scopegraph/tests/promising/dynamicaccessfield.seru
@@ -1,0 +1,12 @@
+struct SomeStruct {
+    field int
+}
+
+function<int> doSomething() {
+    ss := SomeStruct{
+        field: 42,
+    }
+
+    var<any> ssa = ss
+    return ssa->field.(int)
+}


### PR DESCRIPTION
We were forgetting to check if the name had the potential to promise