### PR TITLE
Change ES5 state machine generation to use a continue where possible

### DIFF
--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -160,6 +160,7 @@ var generationTests = []generationTest{
 	generationTest{"async conditional expression", "condexpr", "async", integrationTestSuccessExpected, ""},
 
 	generationTest{"loop expression", "loopexpr", "basic", integrationTestSuccessExpected, ""},
+	generationTest{"loop numeric async expression", "loopexpr", "numeric", integrationTestSuccessExpected, ""},
 
 	generationTest{"generic specifier expression", "accessexpr", "genericspecifier", integrationTestSuccessExpected, ""},
 	generationTest{"cast expression", "accessexpr", "cast", integrationTestSuccessExpected, ""},

--- a/generator/es5/statemachine/generators.go
+++ b/generator/es5/statemachine/generators.go
@@ -36,7 +36,7 @@ func (sg *stateGenerator) generateUnconditionalJump(jump *codedom.UnconditionalJ
 	targetState := sg.generateStates(jump.Target, generateNewState)
 
 	templateStr := `
-		{{ .Snippets.SetStateAndContinue .Item }}
+		{{ .Snippets.SetStateAndContinue .Item false }}
 	`
 
 	template := esbuilder.Template("unconditionaljump", templateStr, generatingItem{targetState, sg})
@@ -65,9 +65,9 @@ func (sg *stateGenerator) generateConditionalJump(jump *codedom.ConditionalJumpN
 
 	templateStr := `
 		if ({{ emit .Item.Expression }}) {
-			{{ .Snippets.SetStateAndContinue .Item.TrueState }}
+			{{ .Snippets.SetStateAndContinue .Item.TrueState false }}
 		} else {
-			{{ .Snippets.SetStateAndContinue .Item.FalseState }}
+			{{ .Snippets.SetStateAndContinue .Item.FalseState false }}
 		}
 	`
 
@@ -227,11 +227,11 @@ func (sg *stateGenerator) generateArrowPromise(arrowPromise *codedom.ArrowPromis
 				{{ emit .Item.ResolutionAssignment }}
 			{{ end }}
 
-			{{ .Snippets.SetStateAndContinue .Item.TargetState }}
+			{{ .Snippets.SetStateAndContinue .Item.TargetState true }}
 		}).catch(function(rejected) {
 			{{ if .Item.RejectionAssignment }}
 				{{ emit .Item.RejectionAssignment }}
-				{{ .Snippets.SetStateAndContinue .Item.TargetState }}
+				{{ .Snippets.SetStateAndContinue .Item.TargetState true }}
 			{{ else }}
 				{{ .Snippets.Reject "rejected" }}
 			{{ end }}
@@ -296,7 +296,7 @@ func (sg *stateGenerator) generateSyncResolveExpression(resolveExpression *coded
 			{{ end }}
 		}
 
-		{{ .Snippets.SetStateAndContinue .TargetState }}
+		{{ .Snippets.SetStateAndContinue .TargetState false }}
 	`
 
 	currentState.pushBuilt(esbuilder.Template("resolvesyncwrap", wrapTemplateStr, wrappedData))
@@ -344,7 +344,7 @@ func (sg *stateGenerator) generateAsyncResolveExpression(resolveExpression *code
 		{{ .Data.RejectionName }} = null;
 		{{ end }}
 
-		{{ .Data.Snippets.SetStateAndContinue .Data.TargetState }}
+		{{ .Data.Snippets.SetStateAndContinue .Data.TargetState true }}
 	`
 
 	promise := result.BuildWrapped(wrappingTemplateStr, resolveData)
@@ -368,7 +368,7 @@ func (sg *stateGenerator) generateAsyncResolveExpression(resolveExpression *code
 			{{ .ResolutionName }} = null;
 			{{ end }}
 
-			{{ .Snippets.SetStateAndContinue .TargetState }}
+			{{ .Snippets.SetStateAndContinue .TargetState true }}
 		});
 		return;
 	`

--- a/generator/es5/statemachine/snippets.go
+++ b/generator/es5/statemachine/snippets.go
@@ -84,7 +84,7 @@ func (s snippets) Reject(value string) string {
 	return s.templater.Execute("reject", template, value)
 }
 
-func (s snippets) Continue() string {
+func (s snippets) Continue(isUnderPromise bool) string {
 	var template = ""
 	switch s.functionTraits.Type() {
 	case shared.StateFunctionNormalSync:
@@ -93,10 +93,16 @@ func (s snippets) Continue() string {
 		`
 
 	case shared.StateFunctionNormalAsync:
-		template = `
-			$continue($resolve, $reject);
-			return;
-		`
+		if isUnderPromise {
+			template = `
+				$continue($resolve, $reject);
+				return;
+			`
+		} else {
+			template = `				
+				continue localasyncloop;
+			`
+		}
 
 	case shared.StateFunctionSyncOrAsyncGenerator:
 		template = `
@@ -150,6 +156,6 @@ func (s snippets) SetStateAndBreak(state *state) string {
 	return s.setState(state.ID, "return")
 }
 
-func (s snippets) SetStateAndContinue(state *state) string {
-	return s.setState(state.ID, s.Continue())
+func (s snippets) SetStateAndContinue(state *state, isUnderPromise bool) string {
+	return s.setState(state.ID, s.Continue(isUnderPromise))
 }

--- a/generator/es5/statemachine/stategenerator.go
+++ b/generator/es5/statemachine/stategenerator.go
@@ -104,7 +104,7 @@ func (sg *stateGenerator) generateStates(statement codedom.Statement, option gen
 		// for jumping "in between" and otherwise single state. Therefore, control flow must immediately
 		// go from the existing state to the new state (as it would normally naturally flow)
 		if statement.IsReferenceable() {
-			currentState.pushSnippet(sg.snippets().SetStateAndContinue(newState))
+			currentState.pushSnippet(sg.snippets().SetStateAndContinue(newState, false))
 		}
 	}
 
@@ -274,7 +274,7 @@ func (sg *stateGenerator) addTopLevelExpression(expression codedom.Expression) e
 
 		wrappingTemplateStr := `
 			$result = {{ emit .ResultExpr }};
-			{{ .Data.Snippets.SetStateAndContinue .Data.ResolutionState }}
+			{{ .Data.Snippets.SetStateAndContinue .Data.ResolutionState true }}
 		`
 		promise := result.BuildWrapped(wrappingTemplateStr, data)
 
@@ -410,7 +410,7 @@ const asyncStateMachineTemplateStr = `
 			{{ .Snippets.Resolve "" }}
 		{{ else }}
 		{{ $parent := . }}
-		while (true) {
+		localasyncloop: while (true) {
 			switch ($current) {
 				{{range .States }}
 				case {{ .ID }}:

--- a/generator/es5/tests/accessexpr/asyncnullaccess.js
+++ b/generator/es5/tests/accessexpr/asyncnullaccess.js
@@ -12,7 +12,7 @@ $module('asyncnullaccess', function () {
       var $result;
       var $current = 0;
       var $continue = function ($resolve, $reject) {
-        while (true) {
+        localasyncloop: while (true) {
           switch ($current) {
             case 0:
               $promise.translate($g.asyncnullaccess.DoSomethingAsync()).then(function ($result0) {
@@ -57,7 +57,7 @@ $module('asyncnullaccess', function () {
     var sc;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             sc = $g.asyncnullaccess.SomeClass.new();

--- a/generator/es5/tests/accessexpr/funcref.js
+++ b/generator/es5/tests/accessexpr/funcref.js
@@ -31,7 +31,7 @@ $module('funcref', function () {
     var sc;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             sc = $g.funcref.SomeClass.new($t.fastbox(true, $g.________testlib.basictypes.Boolean));

--- a/generator/es5/tests/arrowexpr/arrow.js
+++ b/generator/es5/tests/arrowexpr/arrow.js
@@ -32,7 +32,7 @@ $module('arrow', function () {
     var somebool;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             somebool = null;
@@ -63,7 +63,7 @@ $module('arrow', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.arrow.DoSomething($g.arrow.SomePromise.new())).then(function ($result0) {

--- a/generator/es5/tests/arrowexpr/await.js
+++ b/generator/es5/tests/arrowexpr/await.js
@@ -32,7 +32,7 @@ $module('await', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate(p).then(function ($result0) {
@@ -62,7 +62,7 @@ $module('await', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.await.DoSomething($g.await.SomePromise.new())).then(function ($result0) {

--- a/generator/es5/tests/arrowexpr/multiawait.js
+++ b/generator/es5/tests/arrowexpr/multiawait.js
@@ -25,7 +25,7 @@ $module('multiawait', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate(p).then(function ($result0) {

--- a/generator/es5/tests/async/async.js
+++ b/generator/es5/tests/async/async.js
@@ -7,7 +7,7 @@ $module('async', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate($g.async.DoSomethingAsync($t.fastbox(3, $g.________testlib.basictypes.Integer))).then(function ($result0) {

--- a/generator/es5/tests/async/asyncstruct.js
+++ b/generator/es5/tests/async/asyncstruct.js
@@ -47,7 +47,7 @@ $module('asyncstruct', function () {
     var vle;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate($g.asyncstruct.DoSomethingAsync($g.asyncstruct.SomeStruct.new($t.fastbox(1, $g.________testlib.basictypes.Integer), $t.fastbox(2, $g.________testlib.basictypes.Integer)))).then(function ($result0) {

--- a/generator/es5/tests/condexpr/async.js
+++ b/generator/es5/tests/condexpr/async.js
@@ -7,7 +7,7 @@ $module('async', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate($g.async.DoSomethingAsync()).then(function ($result1) {

--- a/generator/es5/tests/generator/async.js
+++ b/generator/es5/tests/generator/async.js
@@ -46,13 +46,12 @@ $module('async', function () {
     var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             v = null;
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $promise.maybe($g.async.SomeGenerator()).then(function ($result0) {
@@ -69,8 +68,7 @@ $module('async', function () {
           case 2:
             $temp1 = $result;
             $current = 3;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 3:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -89,20 +87,17 @@ $module('async', function () {
             value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 6;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 5:
             v = value;
             $current = 3;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 6:
             $resolve(v);

--- a/generator/es5/tests/generator/nested.js
+++ b/generator/es5/tests/generator/nested.js
@@ -86,19 +86,17 @@ $module('nested', function () {
     var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             v = $t.fastbox(0, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = $g.nested.SomeGenerator();
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -117,20 +115,17 @@ $module('nested', function () {
             value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             v = $t.fastbox(v.$wrapped + value.$wrapped, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve($t.fastbox(v.$wrapped == 12, $g.________testlib.basictypes.Boolean));

--- a/generator/es5/tests/generator/resource.js
+++ b/generator/es5/tests/generator/resource.js
@@ -62,20 +62,18 @@ $module('resource', function () {
     var sr;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             sr = $g.resource.SomeResource.new();
             counter = $t.fastbox(0, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = $g.resource.SomeGenerator(sr);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -94,20 +92,17 @@ $module('resource', function () {
             i = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             counter = $t.fastbox(counter.$wrapped + i.$wrapped, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve($t.fastbox(sr.released.$wrapped && (counter.$wrapped == 42), $g.________testlib.basictypes.Boolean));

--- a/generator/es5/tests/generator/simple.js
+++ b/generator/es5/tests/generator/simple.js
@@ -31,19 +31,17 @@ $module('simple', function () {
     var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             v = null;
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = $g.simple.SomeGenerator();
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -62,20 +60,17 @@ $module('simple', function () {
             value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             v = value;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve(v);

--- a/generator/es5/tests/interface/interfaceprop.js
+++ b/generator/es5/tests/interface/interfaceprop.js
@@ -44,7 +44,7 @@ $module('interfaceprop', function () {
       var $result;
       var $current = 0;
       var $continue = function ($resolve, $reject) {
-        while (true) {
+        localasyncloop: while (true) {
           switch ($current) {
             case 0:
               $promise.translate($g.interfaceprop.DoSomethingAsync()).then(function ($result0) {
@@ -103,7 +103,7 @@ $module('interfaceprop', function () {
     var si2;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             si = $g.interfaceprop.SomeClass.new();

--- a/generator/es5/tests/literals/asynctaggedtemplatestr.js
+++ b/generator/es5/tests/literals/asynctaggedtemplatestr.js
@@ -7,7 +7,7 @@ $module('asynctaggedtemplatestr', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate($g.asynctaggedtemplatestr.DoSomethingAsync()).then(function ($result0) {
@@ -40,7 +40,7 @@ $module('asynctaggedtemplatestr', function () {
     var result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             a = $t.fastbox(10, $g.________testlib.basictypes.Integer);

--- a/generator/es5/tests/loopexpr/basic.js
+++ b/generator/es5/tests/loopexpr/basic.js
@@ -37,7 +37,7 @@ $module('basic', function () {
     var s;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             s = $g.________testlib.basictypes.MapStream($g.________testlib.basictypes.Integer, $g.________testlib.basictypes.Integer)($g.basic.SomeGenerator(), function (s) {
@@ -45,14 +45,12 @@ $module('basic', function () {
             });
             counter = $t.fastbox(0, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = s;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -71,20 +69,17 @@ $module('basic', function () {
             entry = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             counter = $t.fastbox(counter.$wrapped + entry.$wrapped, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve($t.fastbox(counter.$wrapped == 9, $g.________testlib.basictypes.Boolean));

--- a/generator/es5/tests/loopexpr/numeric.js
+++ b/generator/es5/tests/loopexpr/numeric.js
@@ -1,0 +1,70 @@
+$module('numeric', function () {
+  var $static = this;
+  $static.doSomething = function () {
+    (function () {
+      return;
+    })();
+    return;
+  };
+  $static.TEST = $t.markpromising(function () {
+    var $result;
+    var $temp0;
+    var $temp1;
+    var counter;
+    var i;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            counter = $t.fastbox(0, $g.________testlib.basictypes.Integer);
+            $current = 1;
+            continue localasyncloop;
+
+          case 1:
+            $temp1 = $g.________testlib.basictypes.Integer.$range($t.fastbox(0, $g.________testlib.basictypes.Integer), $t.fastbox(2, $g.________testlib.basictypes.Integer));
+            $current = 2;
+            continue localasyncloop;
+
+          case 2:
+            $temp0 = $temp1.Next();
+            i = $temp0.First;
+            if ($temp0.Second.$wrapped) {
+              $current = 3;
+              continue localasyncloop;
+            } else {
+              $current = 5;
+              continue localasyncloop;
+            }
+            break;
+
+          case 3:
+            counter = $t.fastbox(counter.$wrapped + i.$wrapped, $g.________testlib.basictypes.Integer);
+            $promise.maybe($g.numeric.doSomething()).then(function ($result0) {
+              $result = $result0;
+              $current = 4;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 4:
+            $current = 2;
+            continue localasyncloop;
+
+          case 5:
+            $resolve($t.fastbox(counter.$wrapped == 3, $g.________testlib.basictypes.Boolean));
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+});

--- a/generator/es5/tests/loopexpr/numeric.seru
+++ b/generator/es5/tests/loopexpr/numeric.seru
@@ -1,0 +1,13 @@
+function<void> doSomething() {
+    (function() {})()
+}
+
+function<any> TEST() {
+    var<int> counter = 0
+    for i in 0..2 {
+        counter = counter + i
+        doSomething()
+    }
+
+    return counter == 3
+}

--- a/generator/es5/tests/opexpr/asyncfunctioncallnullable.js
+++ b/generator/es5/tests/opexpr/asyncfunctioncallnullable.js
@@ -12,7 +12,7 @@ $module('asyncfunctioncallnullable', function () {
       var $result;
       var $current = 0;
       var $continue = function ($resolve, $reject) {
-        while (true) {
+        localasyncloop: while (true) {
           switch ($current) {
             case 0:
               $promise.translate($g.asyncfunctioncallnullable.DoSomethingAsync()).then(function ($result0) {
@@ -57,7 +57,7 @@ $module('asyncfunctioncallnullable', function () {
     var sc;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             sc = $g.asyncfunctioncallnullable.SomeClass.new();

--- a/generator/es5/tests/opexpr/asyncnullcompare.js
+++ b/generator/es5/tests/opexpr/asyncnullcompare.js
@@ -8,7 +8,7 @@ $module('asyncnullcompare', function () {
     var someBool;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             someBool = null;

--- a/generator/es5/tests/resolve/async.js
+++ b/generator/es5/tests/resolve/async.js
@@ -7,7 +7,7 @@ $module('async', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate($g.async.DoSomethingAsync()).then(function ($result0) {
@@ -38,7 +38,7 @@ $module('async', function () {
     var b;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.async.DoSomethingElse()).then(function ($result0) {

--- a/generator/es5/tests/resolve/castignoreinterface.js
+++ b/generator/es5/tests/resolve/castignoreinterface.js
@@ -12,7 +12,7 @@ $module('castignoreinterface', function () {
       var $result;
       var $current = 0;
       var $continue = function ($resolve, $reject) {
-        while (true) {
+        localasyncloop: while (true) {
           switch ($current) {
             case 0:
               $promise.translate($g.castignoreinterface.DoSomethingAsync()).then(function ($result0) {
@@ -67,7 +67,7 @@ $module('castignoreinterface', function () {
     var somevalue;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             somevalue = $t.fastbox('hello', $g.________testlib.basictypes.String);
@@ -78,8 +78,7 @@ $module('castignoreinterface', function () {
               a = null;
             }
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $t.nullableinvoke(a, 'SomeFunction', true, [$t.fastbox(true, $g.________testlib.basictypes.Boolean)]).then(function ($result0) {

--- a/generator/es5/tests/serialization/custom.js
+++ b/generator/es5/tests/serialization/custom.js
@@ -116,7 +116,7 @@ $module('custom', function () {
     var s;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             s = $g.custom.SomeStruct.new($t.fastbox(2, $g.________testlib.basictypes.Integer), $t.fastbox(false, $g.________testlib.basictypes.Boolean), $g.custom.AnotherStruct.new($t.fastbox(true, $g.________testlib.basictypes.Boolean)));

--- a/generator/es5/tests/serialization/json.js
+++ b/generator/es5/tests/serialization/json.js
@@ -86,7 +86,7 @@ $module('json', function () {
     var s;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             s = $g.json.SomeStruct.new($t.fastbox(2, $g.________testlib.basictypes.Integer), $t.fastbox(false, $g.________testlib.basictypes.Boolean), $g.json.AnotherStruct.new($t.fastbox(true, $g.________testlib.basictypes.Boolean)));

--- a/generator/es5/tests/serialization/jsondefault.js
+++ b/generator/es5/tests/serialization/jsondefault.js
@@ -45,7 +45,7 @@ $module('jsondefault', function () {
     var parsed;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             jsonString = $t.fastbox('{}', $g.________testlib.basictypes.String);

--- a/generator/es5/tests/serialization/jsonfail.js
+++ b/generator/es5/tests/serialization/jsonfail.js
@@ -84,7 +84,7 @@ $module('jsonfail', function () {
     var parsed;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             jsonString = $t.fastbox('{"SomeField":"hello world"}', $g.________testlib.basictypes.String);

--- a/generator/es5/tests/serialization/nominaljson.js
+++ b/generator/es5/tests/serialization/nominaljson.js
@@ -100,7 +100,7 @@ $module('nominaljson', function () {
     var s;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             s = $g.nominaljson.SomeStruct.new($t.box($g.nominaljson.AnotherStruct.new($t.fastbox(true, $g.________testlib.basictypes.Boolean)), $g.nominaljson.SomeNominal));

--- a/generator/es5/tests/serialization/slice.js
+++ b/generator/es5/tests/serialization/slice.js
@@ -75,7 +75,7 @@ $module('slice', function () {
     var values;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             values = $g.________testlib.basictypes.Slice($g.slice.AnotherStruct).overArray([$g.slice.AnotherStruct.new($t.fastbox(1, $g.________testlib.basictypes.Integer)), $g.slice.AnotherStruct.new($t.fastbox(2, $g.________testlib.basictypes.Integer)), $g.slice.AnotherStruct.new($t.fastbox(3, $g.________testlib.basictypes.Integer))]);

--- a/generator/es5/tests/serialization/tagged.js
+++ b/generator/es5/tests/serialization/tagged.js
@@ -39,7 +39,7 @@ $module('tagged', function () {
     var s;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             s = $g.tagged.SomeStruct.new($t.fastbox(2, $g.________testlib.basictypes.Integer));

--- a/generator/es5/tests/sml/asyncchildren.js
+++ b/generator/es5/tests/sml/asyncchildren.js
@@ -8,19 +8,17 @@ $module('asyncchildren', function () {
     var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             counter = $t.fastbox(0, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = children;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -39,20 +37,17 @@ $module('asyncchildren', function () {
             value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve($t.fastbox(counter.$wrapped == 5, $g.________testlib.basictypes.Boolean));
@@ -73,7 +68,7 @@ $module('asyncchildren', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate($g.asyncchildren.DoSomethingAsync(i)).then(function ($result0) {
@@ -103,7 +98,7 @@ $module('asyncchildren', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.asyncchildren.SimpleFunction($g.________testlib.basictypes.Mapping($g.________testlib.basictypes.String).Empty(), (function () {

--- a/generator/es5/tests/sml/asyncfunction.js
+++ b/generator/es5/tests/sml/asyncfunction.js
@@ -7,7 +7,7 @@ $module('asyncfunction', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.translate($g.asyncfunction.DoSomethingAsync()).then(function ($result0) {
@@ -37,7 +37,7 @@ $module('asyncfunction', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.asyncfunction.SimpleFunction()).then(function ($result0) {

--- a/generator/es5/tests/sml/children.js
+++ b/generator/es5/tests/sml/children.js
@@ -8,19 +8,17 @@ $module('children', function () {
     var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             counter = $t.fastbox(0, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = children;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -39,20 +37,17 @@ $module('children', function () {
             value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve($t.fastbox(counter.$wrapped == 6, $g.________testlib.basictypes.Boolean));
@@ -70,7 +65,7 @@ $module('children', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.children.SimpleFunction($g.________testlib.basictypes.Mapping($g.________testlib.basictypes.String).Empty(), (function () {

--- a/generator/es5/tests/sml/maybeasyncfunction.js
+++ b/generator/es5/tests/sml/maybeasyncfunction.js
@@ -12,7 +12,7 @@ $module('maybeasyncfunction', function () {
       var $result;
       var $current = 0;
       var $continue = function ($resolve, $reject) {
-        while (true) {
+        localasyncloop: while (true) {
           switch ($current) {
             case 0:
               $promise.translate($g.maybeasyncfunction.DoSomethingAsync()).then(function ($result0) {
@@ -95,7 +95,7 @@ $module('maybeasyncfunction', function () {
     var r2;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             isi = $g.maybeasyncfunction.SomeClass.new();

--- a/generator/es5/tests/sml/nochildren.js
+++ b/generator/es5/tests/sml/nochildren.js
@@ -8,19 +8,17 @@ $module('nochildren', function () {
     var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             found = $t.fastbox(true, $g.________testlib.basictypes.Boolean);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = children;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -39,20 +37,17 @@ $module('nochildren', function () {
             value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             found = $t.fastbox(false, $g.________testlib.basictypes.Boolean);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve(found);
@@ -70,7 +65,7 @@ $module('nochildren', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.nochildren.SimpleFunction($g.________testlib.basictypes.Mapping($g.________testlib.basictypes.String).Empty(), $generator.directempty())).then(function ($result0) {

--- a/generator/es5/tests/sml/streamchild.js
+++ b/generator/es5/tests/sml/streamchild.js
@@ -8,19 +8,17 @@ $module('streamchild', function () {
     var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             counter = $t.fastbox(0, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = children;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -39,20 +37,17 @@ $module('streamchild', function () {
             value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             counter = $t.fastbox(counter.$wrapped + value.$wrapped, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve($t.fastbox(counter.$wrapped == 9, $g.________testlib.basictypes.Boolean));
@@ -98,7 +93,7 @@ $module('streamchild', function () {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $promise.maybe($g.streamchild.SimpleFunction($g.________testlib.basictypes.Mapping($g.________testlib.basictypes.String).Empty(), $g.________testlib.basictypes.MapStream($g.________testlib.basictypes.Integer, $g.________testlib.basictypes.Integer)($g.streamchild.GetValues(), function (value) {

--- a/generator/es5/tests/statements/loopstreamable.js
+++ b/generator/es5/tests/statements/loopstreamable.js
@@ -55,19 +55,17 @@ $module('loopstreamable', function () {
     var something;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $t.fastbox(1234, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = somethingElse.Stream();
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -86,20 +84,17 @@ $module('loopstreamable', function () {
             something = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             $t.fastbox(7654, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $t.fastbox(5678, $g.________testlib.basictypes.Integer);
@@ -123,20 +118,18 @@ $module('loopstreamable', function () {
     var s;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             result = $t.fastbox('noloop', $g.________testlib.basictypes.String);
             s = $g.loopstreamable.SomeStreamable.new();
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = s.Stream();
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -155,20 +148,17 @@ $module('loopstreamable', function () {
             i = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             result = i;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $resolve(result);

--- a/generator/es5/tests/statements/loopvar.js
+++ b/generator/es5/tests/statements/loopvar.js
@@ -33,19 +33,17 @@ $module('loopvar', function () {
     var something;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $t.fastbox(1234, $g.________testlib.basictypes.Integer);
             $current = 1;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 1:
             $temp1 = somethingElse;
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 2:
             $promise.maybe($temp1.Next()).then(function ($result0) {
@@ -64,20 +62,17 @@ $module('loopvar', function () {
             something = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             } else {
               $current = 5;
-              $continue($resolve, $reject);
-              return;
+              continue localasyncloop;
             }
             break;
 
           case 4:
             $t.fastbox(7654, $g.________testlib.basictypes.Integer);
             $current = 2;
-            $continue($resolve, $reject);
-            return;
+            continue localasyncloop;
 
           case 5:
             $t.fastbox(5678, $g.________testlib.basictypes.Integer);

--- a/generator/es5/tests/statements/withasync.js
+++ b/generator/es5/tests/statements/withasync.js
@@ -12,7 +12,7 @@ $module('withasync', function () {
       var $result;
       var $current = 0;
       var $continue = function ($resolve, $reject) {
-        while (true) {
+        localasyncloop: while (true) {
           switch ($current) {
             case 0:
               $promise.translate($g.withasync.DoSomethingAsync()).then(function ($result0) {
@@ -56,7 +56,7 @@ $module('withasync', function () {
     var $continue = function ($resolve, $reject) {
       $resolve = $resources.bind($resolve, true);
       $reject = $resources.bind($reject, true);
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             $t.fastbox(123, $g.________testlib.basictypes.Integer);

--- a/generator/es5/tests/struct/innergeneric.js
+++ b/generator/es5/tests/struct/innergeneric.js
@@ -74,7 +74,7 @@ $module('innergeneric', function () {
     var sscopy;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             ss = $g.innergeneric.SomeStruct($t.struct).new($g.innergeneric.AnotherStruct.new($t.fastbox(true, $g.________testlib.basictypes.Boolean)));

--- a/generator/es5/tests/struct/nominal.js
+++ b/generator/es5/tests/struct/nominal.js
@@ -57,7 +57,7 @@ $module('nominal', function () {
     var s2;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
-      while (true) {
+      localasyncloop: while (true) {
         switch ($current) {
           case 0:
             c = $t.box($t.fastbox(true, $g.________testlib.basictypes.Boolean), $g.nominal.CoolBool);


### PR DESCRIPTION
This makes code faster, and prevents a stack size explosion when operating under very large loops