### PR TITLE
Change lexer and parser to treat negative numbers correctly

### DIFF
--- a/parser/lex.go
+++ b/parser/lex.go
@@ -467,15 +467,11 @@ Loop:
 
 		// Cases:
 		// -
-		// -1234
 		// ->
 		case r == '-':
 			if l.peek() == '>' {
 				l.next()
 				l.emit(tokenTypeArrowAccessOperator)
-			} else if unicode.IsDigit(l.peek()) {
-				l.backup()
-				return lexNumber
 			} else {
 				l.emit(tokenTypeMinus)
 			}
@@ -722,21 +718,12 @@ func lexNumber(l *lexer) stateFn {
 	if !l.scanNumber() {
 		return l.errorf("bad number syntax: %q", l.input[l.start:l.pos])
 	}
-	if sign := l.peek(); sign == '+' || sign == '-' {
-		// Complex: 1+2i. No spaces, must end in 'i'.
-		if !l.scanNumber() || l.input[l.pos-1] != 'i' {
-			return l.errorf("bad number syntax: %q", l.input[l.start:l.pos])
-		}
-		l.emit(tokenTypeNumericLiteral)
-	} else {
-		l.emit(tokenTypeNumericLiteral)
-	}
+
+	l.emit(tokenTypeNumericLiteral)
 	return lexSource
 }
 
 func (l *lexer) scanNumber() bool {
-	// Optional leading sign.
-	l.accept("+-")
 	// Is it hex?
 	digits := "0123456789"
 	if l.accept("0") {

--- a/parser/lex_test.go
+++ b/parser/lex_test.go
@@ -125,16 +125,16 @@ var lexerTests = []lexerTest{
 	{"unicode identifier", "םש", []lexeme{lexeme{tokenTypeIdentifer, 0, "םש"}, tEOF}},
 
 	{"numeric literal", "123", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "123"}, tEOF}},
-	{"numeric literal 2", "-123", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "-123"}, tEOF}},
-	{"numeric literal 3", "123.56", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "123.56"}, tEOF}},
-	{"numeric literal 4", "-123.56", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "-123.56"}, tEOF}},
-	{"numeric literal 5", "123e56", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "123e56"}, tEOF}},
-	{"numeric literal 6", "123e-56", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "123e-56"}, tEOF}},
-	{"numeric literal 7", "0xfe", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "0xfe"}, tEOF}},
-	{"numeric literal 8", "42f", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "42f"}, tEOF}},
-	{"numeric literal 9", "42.7f", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "42.7f"}, tEOF}},
-	{"numeric literal 10", "0b10", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "0b10"}, tEOF}},
-	{"numeric literal 11", "0B11", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "0B11"}, tEOF}},
+	{"numeric literal 1", "123.56", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "123.56"}, tEOF}},
+	{"numeric literal 2", "123e56", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "123e56"}, tEOF}},
+	{"numeric literal 3", "123e-56", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "123e-56"}, tEOF}},
+	{"numeric literal 4", "0xfe", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "0xfe"}, tEOF}},
+	{"numeric literal 5", "42f", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "42f"}, tEOF}},
+	{"numeric literal 6", "42.7f", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "42.7f"}, tEOF}},
+	{"numeric literal 7", "0b10", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "0b10"}, tEOF}},
+	{"numeric literal 8", "0B11", []lexeme{lexeme{tokenTypeNumericLiteral, 0, "0B11"}, tEOF}},
+
+	{"negative number", "-1", []lexeme{lexeme{tokenTypeMinus, 0, "-"}, lexeme{tokenTypeNumericLiteral, 1, "1"}, tEOF}},
 
 	// Complex tests.
 	{"dot expression test", "this.foo", []lexeme{

--- a/parser/parser_rules.go
+++ b/parser/parser_rules.go
@@ -3187,6 +3187,21 @@ func (p *sourceParser) tryConsumeBaseExpression() (AstNode, bool) {
 	case p.isToken(tokenTypeLeftBracket):
 		return p.consumeBracketedLiteralExpression(), true
 
+	// Negative numeric literal.
+	case p.isToken(tokenTypeMinus):
+		// If the next token is numeric, then this is a negative number.
+		if p.isNextToken(tokenTypeNumericLiteral) {
+			literalNode := p.startNode(NodeNumericLiteralExpression)
+			defer p.finishNode()
+
+			// Consume the minus sign.
+			p.consume(tokenTypeMinus)
+
+			token, _ := p.consume(tokenTypeNumericLiteral)
+			literalNode.Decorate(NodeNumericLiteralExpressionValue, "-"+token.value)
+			return literalNode, true
+		}
+
 	// Unary: not
 	case p.isKeyword("not"):
 		p.consumeKeyword("not")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -246,6 +246,7 @@ var parserTests = []parserTest{
 	{"complex conditional expr test", "expression/complexconditional"},
 	{"loop expr test", "expression/loop"},
 	{"slice literal slice expr test", "expression/sliceliteralslice"},
+	{"numeric literal expr test", "expression/numericliteral"},
 
 	// Serulian Markup Language expression tests.
 	{"tag only sml test", "sml/tagonly"},

--- a/parser/tests/expression/all.seru
+++ b/parser/tests/expression/all.seru
@@ -80,4 +80,8 @@ function<void> SomeFunction() {
 			NestedField: 'hello!',
 		},
 	}
+	a+1
+	a-1
+	-1
+	1234
 }

--- a/parser/tests/expression/all.tree
+++ b/parser/tests/expression/all.tree
@@ -1,16 +1,16 @@
 NodeTypeFile
-  end-rune = 810
+  end-rune = 830
   input-source = all expr test
   start-rune = 0
   child-node =>
     NodeTypeFunction
-      end-rune = 810
+      end-rune = 830
       input-source = all expr test
       named = SomeFunction
       start-rune = 0
       definition-body =>
         NodeTypeStatementBlock
-          end-rune = 810
+          end-rune = 830
           input-source = all expr test
           start-rune = 30
           block-child =>
@@ -1510,6 +1510,68 @@ NodeTypeFile
                       identexpr-name = SomeStruct
                       input-source = all expr test
                       start-rune = 699
+            NodeTypeExpressionStatement
+              end-rune = 814
+              input-source = all expr test
+              start-rune = 811
+              expr-statement-expr =>
+                NodeBinaryAddExpression
+                  end-rune = 813
+                  input-source = all expr test
+                  start-rune = 811
+                  binary-expression-left =>
+                    NodeTypeIdentifierExpression
+                      end-rune = 811
+                      identexpr-name = a
+                      input-source = all expr test
+                      start-rune = 811
+                  binary-expression-right =>
+                    NodeNumericLiteralExpression
+                      end-rune = 813
+                      input-source = all expr test
+                      literal-value = 1
+                      start-rune = 813
+            NodeTypeExpressionStatement
+              end-rune = 819
+              input-source = all expr test
+              start-rune = 816
+              expr-statement-expr =>
+                NodeBinarySubtractExpression
+                  end-rune = 818
+                  input-source = all expr test
+                  start-rune = 816
+                  binary-expression-left =>
+                    NodeTypeIdentifierExpression
+                      end-rune = 816
+                      identexpr-name = a
+                      input-source = all expr test
+                      start-rune = 816
+                  binary-expression-right =>
+                    NodeNumericLiteralExpression
+                      end-rune = 818
+                      input-source = all expr test
+                      literal-value = 1
+                      start-rune = 818
+            NodeTypeExpressionStatement
+              end-rune = 823
+              input-source = all expr test
+              start-rune = 821
+              expr-statement-expr =>
+                NodeNumericLiteralExpression
+                  end-rune = 822
+                  input-source = all expr test
+                  literal-value = -1
+                  start-rune = 821
+            NodeTypeExpressionStatement
+              end-rune = 829
+              input-source = all expr test
+              start-rune = 825
+              expr-statement-expr =>
+                NodeNumericLiteralExpression
+                  end-rune = 828
+                  input-source = all expr test
+                  literal-value = 1234
+                  start-rune = 825
       typemember-return-type =>
         NodeTypeVoid
           end-rune = 12

--- a/parser/tests/expression/numericliteral.seru
+++ b/parser/tests/expression/numericliteral.seru
@@ -1,0 +1,4 @@
+function<void> DoSomething() {
+    -1
+    1234
+}

--- a/parser/tests/expression/numericliteral.tree
+++ b/parser/tests/expression/numericliteral.tree
@@ -1,0 +1,41 @@
+NodeTypeFile
+  end-rune = 47
+  input-source = numeric literal expr test
+  start-rune = 0
+  child-node =>
+    NodeTypeFunction
+      end-rune = 47
+      input-source = numeric literal expr test
+      named = DoSomething
+      start-rune = 0
+      definition-body =>
+        NodeTypeStatementBlock
+          end-rune = 47
+          input-source = numeric literal expr test
+          start-rune = 29
+          block-child =>
+            NodeTypeExpressionStatement
+              end-rune = 37
+              input-source = numeric literal expr test
+              start-rune = 35
+              expr-statement-expr =>
+                NodeNumericLiteralExpression
+                  end-rune = 36
+                  input-source = numeric literal expr test
+                  literal-value = -1
+                  start-rune = 35
+            NodeTypeExpressionStatement
+              end-rune = 46
+              input-source = numeric literal expr test
+              start-rune = 42
+              expr-statement-expr =>
+                NodeNumericLiteralExpression
+                  end-rune = 45
+                  input-source = numeric literal expr test
+                  literal-value = 1234
+                  start-rune = 42
+      typemember-return-type =>
+        NodeTypeVoid
+          end-rune = 12
+          input-source = numeric literal expr test
+          start-rune = 9


### PR DESCRIPTION
Before this change, `a-1` was treated as `a` and `-1`, since the lexer was consuming the minus sign. After this change, the parser makes the determination as to whether the negative is an operator or part of the number