### PR TITLE
Assign statement auto-unboxing support

### DIFF
--- a/generator/es5/dombuilder/build_statements.go
+++ b/generator/es5/dombuilder/build_statements.go
@@ -246,7 +246,9 @@ func (db *domBuilder) buildLoopStatement(node compilergraph.GraphNode) (codedom.
 // buildAssignStatement builds the CodeDOM for an assignment statement.
 func (db *domBuilder) buildAssignStatement(node compilergraph.GraphNode) codedom.Statement {
 	targetNode := node.GetNode(parser.NodeAssignStatementName)
-	exprValue := db.getExpression(node, parser.NodeAssignStatementValue)
+	valueNode := node.GetNode(parser.NodeAssignStatementValue)
+
+	exprValue := db.buildExpressionWithOption(valueNode, buildExprCheckNominalShortcutting)
 	return codedom.ExpressionStatement(db.buildAssignmentExpression(targetNode, exprValue, node), node)
 }
 

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -146,6 +146,7 @@ var generationTests = []generationTest{
 	generationTest{"with exit scope statement", "statements", "withexit", integrationTestSuccessExpected, ""},
 	generationTest{"with async statement", "statements", "withasync", integrationTestSuccessExpected, ""},
 	generationTest{"single call statement", "statements", "singlecall", integrationTestSuccessExpected, ""},
+	generationTest{"auto-unboxing assign statement", "statements", "autounboxassign", integrationTestSuccessExpected, ""},
 
 	generationTest{"generic op expression", "opexpr", "generic", integrationTestSuccessExpected, ""},
 

--- a/generator/es5/tests/statements/autounboxassign.js
+++ b/generator/es5/tests/statements/autounboxassign.js
@@ -1,0 +1,52 @@
+$module('autounboxassign', function () {
+  var $static = this;
+  this.$class('3234898a', 'SomeClass', false, '', function () {
+    var $static = this;
+    var $instance = this.prototype;
+    $static.new = function () {
+      var instance = new $static();
+      return instance;
+    };
+    $instance.SomeValue = $t.property(function () {
+      var $this = this;
+      return $t.fastbox(42, $g.________testlib.basictypes.Integer);
+    });
+    this.$typesig = function () {
+      if (this.$cachedtypesig) {
+        return this.$cachedtypesig;
+      }
+      var computed = {
+        "SomeValue|3|bb8d3aad": true,
+      };
+      return this.$cachedtypesig = computed;
+    };
+  });
+
+  this.$type('2cec5b57', 'AnotherType', false, '', function () {
+    var $instance = this.prototype;
+    var $static = this;
+    this.$box = function ($wrapped) {
+      var instance = new this();
+      instance[BOXED_DATA_PROPERTY] = $wrapped;
+      return instance;
+    };
+    this.$roottype = function () {
+      return $g.autounboxassign.SomeClass;
+    };
+    this.$typesig = function () {
+      return {
+      };
+    };
+  });
+
+  $static.TEST = function () {
+    var at;
+    var sc;
+    at = $t.fastbox($g.autounboxassign.SomeClass.new(), $g.autounboxassign.AnotherType);
+    sc = null;
+    sc = $t.unbox(at);
+    return $t.fastbox($t.syncnullcompare($t.dynamicaccess(sc, 'SomeValue', false), function () {
+      return $t.fastbox(0, $g.________testlib.basictypes.Integer);
+    }).$wrapped == 42, $g.________testlib.basictypes.Boolean);
+  };
+});

--- a/generator/es5/tests/statements/autounboxassign.seru
+++ b/generator/es5/tests/statements/autounboxassign.seru
@@ -1,0 +1,14 @@
+class SomeClass {
+    property<int> SomeValue {
+        get { return 42 }
+    }
+}
+
+type AnotherType : SomeClass {}
+
+function<any> TEST() {
+    at := AnotherType(SomeClass.new())
+    var<SomeClass?> sc
+    sc = at
+    return (sc?.SomeValue ?? 0) == 42
+}

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -519,6 +519,9 @@ var scopeGraphTests = []scopegraphTest{
 	scopegraphTest{"assign interface property test", "assign", "interfaceprop", []expectedScopeEntry{},
 		"", ""},
 
+	scopegraphTest{"assign auto unbox test", "assign", "autounbox", []expectedScopeEntry{},
+		"", ""},
+
 	scopegraphTest{"assign indexer test", "assign", "indexer",
 		[]expectedScopeEntry{},
 		"", ""},

--- a/graphs/scopegraph/tests/assign/autounbox.seru
+++ b/graphs/scopegraph/tests/assign/autounbox.seru
@@ -1,0 +1,8 @@
+class SomeClass {}
+
+type AnotherType : SomeClass {}
+
+function<void> DoSomething(at AnotherType) {
+    var<SomeClass?> sc
+    sc = at
+}


### PR DESCRIPTION
Adds support for automatic unboxing of nominal types in assignment statements. This allows statements of the form:

```seru
someNominalVar = someBoxedVersion
```

This is especially useful when assigning {string, number, boolean} literals to native attributes and properties, as we will no longer need to include a nominal root `&` operator to match the types.