### PR TITLE
Add support for nested SML attributes

### DIFF
--- a/formatter/tests/sml.in.seru
+++ b/formatter/tests/sml.in.seru
@@ -34,4 +34,11 @@ function<void> SomeFunction() {
 	var ninth = <Foo Bar={{'someawesomekey': this.foo.bar.baz.meh, 'andanotherawesomekey': morestuffgoeshere}}/>
 
 	var tenth = <Foo @Bar={someType{foo: 'foo', bar: 'bar'}}/>
+
+	var eleventh = <Foo>
+		<.Foo>{1234}</.Foo>
+		<Baz />
+		<.Bar>Hi!</.Bar>
+		<Meh />
+	</Foo>
 }

--- a/formatter/tests/sml.out.seru
+++ b/formatter/tests/sml.out.seru
@@ -41,4 +41,12 @@ function<void> SomeFunction() {
 	}} />
 
 	var tenth = <Foo @Bar={someType{foo: 'foo', bar: 'bar'}} />
+
+	var eleventh = <Foo>
+		<.Bar>Hi!</.Bar>
+		<.Foo>{1234}</.Foo>
+		<Baz />
+
+		<Meh />
+	</Foo>
 }

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -295,6 +295,7 @@ var generationTests = []generationTest{
 	generationTest{"sml async function test", "sml", "asyncfunction", integrationTestSuccessExpected, ""},
 	generationTest{"sml maybe async function test", "sml", "maybeasyncfunction", integrationTestSuccessExpected, ""},
 	generationTest{"sml async children test", "sml", "asyncchildren", integrationTestSuccessExpected, ""},
+	generationTest{"sml nested attributes test", "sml", "nestedattributes", integrationTestSuccessExpected, ""},
 
 	generationTest{"native new integration test", "nativenew", "nativenew", integrationTestSuccessExpected, ""},
 	generationTest{"dynamic access non-promising test", "dynamicaccess", "nonpromising", integrationTestSuccessExpected, ""},

--- a/generator/es5/tests/sml/nestedattributes.js
+++ b/generator/es5/tests/sml/nestedattributes.js
@@ -1,0 +1,13 @@
+$module('nestedattributes', function () {
+  var $static = this;
+  $static.SimpleFunction = function (props) {
+    return $g.________testlib.basictypes.String.$equals($t.syncnullcompare(props.$index($t.fastbox('SomeProp', $g.________testlib.basictypes.String)), function () {
+      return $t.fastbox('', $g.________testlib.basictypes.String);
+    }), $t.fastbox('hello world', $g.________testlib.basictypes.String));
+  };
+  $static.TEST = function () {
+    return $g.nestedattributes.SimpleFunction($g.________testlib.basictypes.Mapping($g.________testlib.basictypes.String).overObject({
+      SomeProp: $t.fastbox("hello world", $g.________testlib.basictypes.String),
+    }));
+  };
+});

--- a/generator/es5/tests/sml/nestedattributes.seru
+++ b/generator/es5/tests/sml/nestedattributes.seru
@@ -1,0 +1,9 @@
+function<bool> SimpleFunction(props []{string}) {
+	return (props['SomeProp'] ?? '') == 'hello world'
+}
+
+function<any> TEST() {
+	return <SimpleFunction>
+        <.SomeProp>hello world</.SomeProp>
+    </SimpleFunction>
+}

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -465,6 +465,10 @@ var scopeGraphTests = []scopegraphTest{
 		[]expectedScopeEntry{},
 		"Child #1 under SML declaration must be subtype of Integer: 'String' cannot be used in place of non-interface 'Integer'", ""},
 
+	scopegraphTest{"sml expression unknown nested attribute test", "sml", "nestedattributeunknown",
+		[]expectedScopeEntry{},
+		"Could not find instance name 'unknown' under struct SomeType", ""},
+
 	/////////// Numeric literals ///////////
 
 	scopegraphTest{"numeric literals test", "literals", "numeric",

--- a/graphs/scopegraph/tests/sml/nestedattributeunknown.seru
+++ b/graphs/scopegraph/tests/sml/nestedattributeunknown.seru
@@ -1,0 +1,11 @@
+struct SomeType {}
+
+function<int> SomeFunction(props SomeType, child any) {
+	return 2
+}
+
+function<void> DoSomething() {
+	<SomeFunction>
+        <.unknown>Foo</.unknown>
+    </SomeFunction>
+}

--- a/graphs/scopegraph/tests/sml/success.seru
+++ b/graphs/scopegraph/tests/sml/success.seru
@@ -86,4 +86,5 @@ function<void> DoSomething(someStream int*) {
 
 	/* propsclass */(<FunctionWithPropsClass something="hello" />)
 	/* propsclass2 */(<FunctionWithPropsClass something="hello" somethingElse={42} />)
+	/* propsclass3 */(<FunctionWithPropsClass somethingElse={42}><.something>hello</.something></FunctionWithPropsClass>)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -260,6 +260,7 @@ var parserTests = []parserTest{
 	{"children sml test", "sml/children"},
 	{"multiple children sml test", "sml/multichild"},
 	{"whitespace text sml test", "sml/whitespacetext"},
+	{"nested property sml test", "sml/nestedprop"},
 
 	{"all expr test", "expression/all"},
 	{"complex expr test", "expression/complex"},

--- a/parser/parser_types.go
+++ b/parser/parser_types.go
@@ -94,7 +94,7 @@ const (
 	NodeTypeLambdaExpression // A lambda expression
 
 	NodeTypeSmlExpression // <sometag />
-	NodeTypeSmlAttribute  // a="somevalue"
+	NodeTypeSmlAttribute  // a="somevalue" or <.a>
 	NodeTypeSmlDecorator  // @a="somevalue"
 	NodeTypeSmlText       // some text
 
@@ -404,12 +404,14 @@ const (
 	NodeSmlExpressionAttribute      = "sml-expression-attribute"
 	NodeSmlExpressionDecorator      = "sml-expression-decorator"
 	NodeSmlExpressionChild          = "sml-expression-child"
+	NodeSmlExpressionNestedProperty = "sml-expression-nested-prop"
 
 	//
 	// NodeTypeSmlAttribute
 	//
-	NodeSmlAttributeName  = "sml-attribute-name"
-	NodeSmlAttributeValue = "sml-attribute-value"
+	NodeSmlAttributeName   = "sml-attribute-name"
+	NodeSmlAttributeValue  = "sml-attribute-value"
+	NodeSmlAttributeNested = "sml-attribute-nested"
 
 	//
 	// NodeTypeSmlDecorator

--- a/parser/tests/sml/nestedprop.seru
+++ b/parser/tests/sml/nestedprop.seru
@@ -1,0 +1,7 @@
+function<void> DoSomething() {
+    <SomeTag>
+        <.SomeProp>
+            hello world!
+        </.SomeProp>
+    </SomeTag>
+}

--- a/parser/tests/sml/nestedprop.tree
+++ b/parser/tests/sml/nestedprop.tree
@@ -1,0 +1,51 @@
+NodeTypeFile
+  end-rune = 126
+  input-source = nested property sml test
+  start-rune = 0
+  child-node =>
+    NodeTypeFunction
+      end-rune = 126
+      input-source = nested property sml test
+      named = DoSomething
+      start-rune = 0
+      definition-body =>
+        NodeTypeStatementBlock
+          end-rune = 126
+          input-source = nested property sml test
+          start-rune = 29
+          block-child =>
+            NodeTypeExpressionStatement
+              end-rune = 125
+              input-source = nested property sml test
+              start-rune = 35
+              expr-statement-expr =>
+                NodeTypeSmlExpression
+                  end-rune = 124
+                  input-source = nested property sml test
+                  start-rune = 35
+                  sml-expression-attribute =>
+                    NodeTypeSmlAttribute
+                      end-rune = 109
+                      input-source = nested property sml test
+                      sml-attribute-name = SomeProp
+                      sml-attribute-nested = true
+                      start-rune = 53
+                      sml-attribute-value =>
+                        NodeTypeSmlText
+                          end-rune = 97
+                          input-source = nested property sml test
+                          sml-text-value = 
+            hello world!
+        
+                          start-rune = 64
+                  sml-expression-typefunc =>
+                    NodeTypeIdentifierExpression
+                      end-rune = 42
+                      identexpr-name = SomeTag
+                      input-source = nested property sml test
+                      start-rune = 36
+      typemember-return-type =>
+        NodeTypeVoid
+          end-rune = 12
+          input-source = nested property sml test
+          start-rune = 9


### PR DESCRIPTION
Following this change, SML expressions can contain attribute values as nested tags, like so:

```seru
<SomeTag>
  <.SomeAttribute>value goes here</.SomeAttribute>
</SomeTag>
```

This will help with defining attributes with complex values