### PR TITLE
Add import alias support

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -23,6 +23,7 @@ var CORE_LIBRARY = packageloader.Library{
 	// TODO: this should be set to a defined tag once the compiler is stable.
 	PathOrURL: "github.com/serulian/corelib:master",
 	IsSCM:     true,
+	Alias:     "core",
 }
 
 type WarningsSlice []compilercommon.SourceWarning

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -311,7 +311,7 @@ func TestGenerator(t *testing.T) {
 
 		fmt.Printf("Running test %v...\n", test.name)
 
-		result, _ := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		result, _ := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, "", "testcore"})
 		if !assert.True(t, result.Status, "Got error for ScopeGraph construction %v: %s", test.name, result.Errors) {
 			continue
 		}
@@ -520,7 +520,7 @@ func TestSourceMapping(t *testing.T) {
 
 		// Parse and scope.
 		fmt.Printf("Running mapping test %v...\n", test.name)
-		scopeResult, _ := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		scopeResult, _ := scopegraph.ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, "", "testcore"})
 		if !assert.True(t, scopeResult.Status, "Got error for ScopeGraph construction %v: %s", test.name, scopeResult.Errors) {
 			continue
 		}

--- a/graphs/scopegraph/promise_labeler_test.go
+++ b/graphs/scopegraph/promise_labeler_test.go
@@ -229,7 +229,7 @@ func TestPromisingLabels(t *testing.T) {
 		fmt.Printf("Running promise label test: %v\n", test.name)
 
 		entrypointFile := "tests/promising/" + test.entrypoint + ".seru"
-		result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, "", "testcore"})
 		if !assert.True(t, result.Status, "Expected success in scoping on test: %v\n%v\n%v", test.name, result.Errors, result.Warnings) {
 			continue
 		}

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1588,7 +1588,7 @@ func TestGraphs(t *testing.T) {
 		fmt.Printf("Running test: %v\n", test.name)
 
 		entrypointFile := "tests/" + test.input + "/" + test.entrypoint + ".seru"
-		result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+		result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, "", "testcore"})
 
 		if test.expectedError != "" {
 			if !assert.False(t, result.Status, "Expected failure in scoping on test : %v", test.name) {
@@ -1662,7 +1662,7 @@ var transientScopeTests = []transientScopeTest{
 
 func TestBuildTransientScope(t *testing.T) {
 	entrypointFile := "tests/transient/transient.seru"
-	result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, ""})
+	result, _ := ParseAndBuildScopeGraph(entrypointFile, []string{}, packageloader.Library{TESTLIB_PATH, false, "", "testcore"})
 	if !assert.True(t, result.Status, "Expected success in transient scope test") {
 		return
 	}

--- a/graphs/srg/testutil.go
+++ b/graphs/srg/testutil.go
@@ -5,6 +5,7 @@
 package srg
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/serulian/compiler/compilercommon"
@@ -20,7 +21,7 @@ func loadSRG(t *testing.T, path string, libPaths ...string) (*SRG, packageloader
 
 	libraries := make([]packageloader.Library, len(libPaths))
 	for index, libPath := range libPaths {
-		libraries[index] = packageloader.Library{libPath, false, ""}
+		libraries[index] = packageloader.Library{libPath, false, "", fmt.Sprintf("testlib%v", index)}
 	}
 
 	testSRG := NewSRG(graph)

--- a/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.json
+++ b/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.json
@@ -1,0 +1,82 @@
+{
+    "914e0641ec2003c5d39a7e949105a8d7": {
+        "Key": "914e0641ec2003c5d39a7e949105a8d7",
+        "Kind": 7,
+        "Children": {
+            "5de0a8ada15f60a57308bab2325338e6": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "5de0a8ada15f60a57308bab2325338e6",
+                    "Kind": 9,
+                    "Children": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        }
+                    },
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "SomeFunction",
+                        "tdg-member-promising": "1",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cInteger\u003e",
+                        "tdg-member-signature": "\n\u000csomefunction\u0010\u0002 \u0001*\u0011function\u003cInteger\u003e",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/aliasedimport/aliasedimport.seru",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
+            "84326f6adbf9646f7cb37e855b4ce3e6": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "84326f6adbf9646f7cb37e855b4ce3e6",
+                    "Kind": 9,
+                    "Children": {
+                        "4b1f9170e3b15f2226d98b1b1f721325": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "4b1f9170e3b15f2226d98b1b1f721325",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "Integer",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        }
+                    },
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "SomeOtherFunction",
+                        "tdg-member-promising": "1",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cInteger\u003e",
+                        "tdg-member-signature": "\n\u0011someotherfunction\u0010\u0002 \u0001*\u0011function\u003cInteger\u003e",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/aliasedimport/aliasedimport.seru",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-module-name": "aliasedimport.seru",
+            "tdg-node-kind": "7|NodeType|tdg",
+            "tdg-source-module": "tests/aliasedimport/aliasedimport.seru",
+            "tdg-source-node": "(NodeRef)"
+        }
+    }
+}

--- a/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.seru
+++ b/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.seru
@@ -1,0 +1,9 @@
+from @testcore import Integer
+
+function<Integer> SomeFunction() {
+    return 42
+}
+
+function<int> SomeOtherFunction() {
+    return 43
+}

--- a/graphs/srg/typeconstructor/typeconstructor_test.go
+++ b/graphs/srg/typeconstructor/typeconstructor_test.go
@@ -80,6 +80,7 @@ var typeGraphTests = []typegraphTest{
 	typegraphTest{"simple generic agent test", "agent", "simplegeneric", ""},
 	typegraphTest{"agent meets principal requirements test", "agent", "agentmeetsprincipal", ""},
 	typegraphTest{"documentation test", "doccomment", "doccomment", ""},
+	typegraphTest{"aliased import test", "aliasedimport", "aliasedimport", ""},
 
 	// Failure tests.
 	typegraphTest{"struct invalid ref test", "struct", "invalidref", "SomeStruct<SomeClass> has non-structural generic type SomeClass: SomeClass is not structural nor serializable"},

--- a/graphs/srg/typeconstructor/typeconstructor_test.go
+++ b/graphs/srg/typeconstructor/typeconstructor_test.go
@@ -125,7 +125,7 @@ func TestGraphs(t *testing.T) {
 		loader := packageloader.NewPackageLoader(
 			packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.SourceHandler(), testIDL.SourceHandler()))
 
-		srgResult := loader.Load(packageloader.Library{TESTLIB_PATH, false, ""})
+		srgResult := loader.Load(packageloader.Library{TESTLIB_PATH, false, "", "testcore"})
 
 		// Make sure we had no errors during construction.
 		if !assert.True(t, srgResult.Status, "Got error for SRG construction %v: %s", test.name, srgResult.Errors) {
@@ -174,7 +174,7 @@ func TestLookupReturnType(t *testing.T) {
 
 	loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testSRG.SourceHandler(), testIDL.SourceHandler()))
 
-	srgResult := loader.Load(packageloader.Library{TESTLIB_PATH, false, ""})
+	srgResult := loader.Load(packageloader.Library{TESTLIB_PATH, false, "", "testcore"})
 	if !assert.True(t, srgResult.Status, "Got error for SRG construction: %v", srgResult.Errors) {
 		return
 	}

--- a/grok/completion_test.go
+++ b/grok/completion_test.go
@@ -200,7 +200,7 @@ var grokCompletionTests = []grokCompletionTest{
 func TestGrokCompletion(t *testing.T) {
 	for _, grokCompletionTest := range grokCompletionTests {
 		testSourcePath := "tests/" + grokCompletionTest.name + "/" + grokCompletionTest.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, "", "testcore"}})
 		handle, err := groker.GetHandle()
 
 		// Ensure we have a valid groker.

--- a/grok/range_test.go
+++ b/grok/range_test.go
@@ -132,7 +132,7 @@ var grokRangeTests = []grokRangeTest{
 func TestGrokRange(t *testing.T) {
 	for _, grokRangeTest := range grokRangeTests {
 		testSourcePath := "tests/" + grokRangeTest.name + "/" + grokRangeTest.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, "", "testcore"}})
 		handle, err := groker.GetHandle()
 
 		// Ensure we have a valid groker.

--- a/grok/search_test.go
+++ b/grok/search_test.go
@@ -63,7 +63,7 @@ var searchTests = []searchTest{
 func TestSymbolSearch(t *testing.T) {
 	for _, test := range searchTests {
 		testSourcePath := "tests/" + test.name + "/" + test.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, "", "testcore"}})
 		handle, err := groker.GetHandle()
 
 		// Ensure we have a valid groker.

--- a/grok/signatures_test.go
+++ b/grok/signatures_test.go
@@ -127,7 +127,7 @@ var grokSignaturesTests = []grokSignaturesTest{
 func TestGrokSignatures(t *testing.T) {
 	for _, grokSignaturesTest := range grokSignaturesTests {
 		testSourcePath := "tests/" + grokSignaturesTest.name + "/" + grokSignaturesTest.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, ""}})
+		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, "", "testcore"}})
 		handle, err := groker.GetHandle()
 
 		// Ensure we have a valid groker.

--- a/packageloader/packageloader_test.go
+++ b/packageloader/packageloader_test.go
@@ -238,7 +238,7 @@ func TestLibraryPath(t *testing.T) {
 	}
 
 	loader := NewPackageLoader(NewBasicConfig("tests/basic/somefile.json", tt.createHandler()))
-	result := loader.Load(Library{"tests/libtest", false, ""})
+	result := loader.Load(Library{"tests/libtest", false, "", "testlib"})
 	if !result.Status || len(result.Errors) > 0 {
 		t.Errorf("Expected success, found: %v", result.Errors)
 		return

--- a/packageloader/sourcehandler.go
+++ b/packageloader/sourcehandler.go
@@ -40,6 +40,9 @@ const (
 	// ImportTypeLocal indicates the import is a local module or package.
 	ImportTypeLocal PackageImportType = iota
 
+	// ImportTypeAlias indicates that the import is a library alias.
+	ImportTypeAlias
+
 	// ImportTypeVCS indicates the import is a VCS package.
 	ImportTypeVCS
 )

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -121,6 +121,8 @@ func (p *sourceParser) reportImport(value string, kind string) (string, error) {
 	var packageImportType = packageloader.ImportTypeLocal
 	if importType == ParsedImportTypeVCS {
 		packageImportType = packageloader.ImportTypeVCS
+	} else if importType == ParsedImportTypeAlias {
+		packageImportType = packageloader.ImportTypeAlias
 	}
 
 	return p.importReporter(kind, importPath, packageImportType, p.source, int(p.currentToken.position)), nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -102,6 +102,7 @@ var parserTests = []parserTest{
 	{"relative import test 2", "import/relative2"},
 	{"absolute import test", "import/absolute"},
 	{"empty import test", "import/empty"},
+	{"alias import test", "import/aliases"},
 
 	// Import failure tests.
 	{"missing source import test", "import/missing_source"},

--- a/parser/tests/import/aliases.seru
+++ b/parser/tests/import/aliases.seru
@@ -1,0 +1,3 @@
+from @somealias import something
+from "@somealias" import something
+from somekind`@somealias` import something

--- a/parser/tests/import/aliases.tree
+++ b/parser/tests/import/aliases.tree
@@ -1,0 +1,45 @@
+NodeTypeFile
+  end-rune = 110
+  input-source = alias import test
+  start-rune = 0
+  child-node =>
+    NodeTypeImport
+      end-rune = 32
+      import-location-ref = location:somealias
+      import-source = @somealias
+      input-source = alias import test
+      start-rune = 0
+      import-package =>
+        NodeTypeImportPackage
+          end-rune = 31
+          import-subsource = something
+          input-source = alias import test
+          named = something
+          start-rune = 23
+    NodeTypeImport
+      end-rune = 67
+      import-location-ref = location:somealias
+      import-source = "@somealias"
+      input-source = alias import test
+      start-rune = 33
+      import-package =>
+        NodeTypeImportPackage
+          end-rune = 66
+          import-subsource = something
+          input-source = alias import test
+          named = something
+          start-rune = 58
+    NodeTypeImport
+      end-rune = 110
+      import-kind = somekind
+      import-location-ref = location:somealias
+      import-source = `@somealias`
+      input-source = alias import test
+      start-rune = 68
+      import-package =>
+        NodeTypeImportPackage
+          end-rune = 109
+          import-subsource = something
+          input-source = alias import test
+          named = something
+          start-rune = 101

--- a/webidl/typeconstructor/typeconstructor_test.go
+++ b/webidl/typeconstructor/typeconstructor_test.go
@@ -94,7 +94,7 @@ func TestGraphs(t *testing.T) {
 
 		secondaryLibs := make([]packageloader.Library, 0)
 		if _, err := os.Stat("tests/" + test.entrypoint + "/"); err == nil {
-			secondaryLibs = append(secondaryLibs, packageloader.Library{"tests/" + test.entrypoint + "/", false, "webidl"})
+			secondaryLibs = append(secondaryLibs, packageloader.Library{"tests/" + test.entrypoint + "/", false, "webidl", "secondary"})
 		}
 
 		irgResult := loader.Load(secondaryLibs...)


### PR DESCRIPTION
Import aliases are use to reference libraries that are imported outside of code. For now, this will only be the core library. This support is necessary as the core library's version will change in sync with the compiler version, but it would be a major pain to have to update all *core* imports accordingly (this is necessary as, unlike all other libraries, the compiler does *not* support importation of two core library versions without failure).

Instead, the following is now possible:

```seru
from @core import List
```

And `List` will be imported from the core library version used by the toolkit.