### PR TITLE
Libraries that are imported as aliases need to be imported with their kinds intact

### DIFF
--- a/graphs/srg/packages.go
+++ b/graphs/srg/packages.go
@@ -35,9 +35,8 @@ func (g *SRG) getPackageForImport(importPackageNode compilergraph.GraphNode) (im
 	if !ok {
 		source := importNode.Get(parser.NodeImportPredicateSource)
 		subsource, _ := importPackageNode.TryGet(parser.NodeImportPredicateSubsource)
-		err := fmt.Errorf("Missing package info for import %s %s (reference %v) (node %v)\nPackage Map: %v",
-			source, subsource, packageLocation, importNode, g.packageMap)
-
+		err := fmt.Errorf("Missing package info for import %s %s (reference %v::%v) (node %v)\nPackage Map: %v",
+			source, subsource, packageKind, packageLocation, importNode, g.packageMap)
 		return importedPackage{}, err
 	}
 

--- a/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.json
+++ b/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.json
@@ -3,6 +3,40 @@
         "Key": "914e0641ec2003c5d39a7e949105a8d7",
         "Kind": 7,
         "Children": {
+            "03b30c54edc551a9ccc89ffbbf4f6a38": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "03b30c54edc551a9ccc89ffbbf4f6a38",
+                    "Kind": 9,
+                    "Children": {
+                        "c8370e376e82bd6ac4578b2d41bb4998": {
+                            "Predicate": "tdg-member-returnable",
+                            "Child": {
+                                "Key": "c8370e376e82bd6ac4578b2d41bb4998",
+                                "Kind": 13,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "13|NodeType|tdg",
+                                    "tdg-return-type": "Boolean",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        }
+                    },
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "SomeNativeBool",
+                        "tdg-member-promising": "1",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cBoolean\u003e",
+                        "tdg-member-signature": "\n\u000esomenativebool\u0010\u0002 \u0001*\u0011function\u003cBoolean\u003e",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/aliasedimport/aliasedimport.seru",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
             "5de0a8ada15f60a57308bab2325338e6": {
                 "Predicate": "tdg-node-member",
                 "Child": {

--- a/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.seru
+++ b/graphs/srg/typeconstructor/tests/aliasedimport/aliasedimport.seru
@@ -1,4 +1,5 @@
 from @testcore import Integer
+from webidl`@testcore` import Boolean
 
 function<Integer> SomeFunction() {
     return 42
@@ -7,3 +8,5 @@ function<Integer> SomeFunction() {
 function<int> SomeOtherFunction() {
     return 43
 }
+
+function<Boolean> SomeNativeBool() {}

--- a/packageloader/packageloader.go
+++ b/packageloader/packageloader.go
@@ -217,7 +217,7 @@ func (p *PackageLoader) Load(libraries ...Library) LoadResult {
 	// Add the libraries to be parsed.
 	for _, library := range libraries {
 		sourceRange := compilercommon.InputSource(library.PathOrURL).RangeForRunePosition(0, p.sourceTracker)
-		p.pushLibrary(library, sourceRange)
+		p.pushLibrary(library, library.Kind, sourceRange)
 	}
 
 	// Wait for all packages and source files to be completed.
@@ -370,12 +370,12 @@ func (p *PackageLoader) getVCSDirectoryForPath(vcsPath string) (string, error) {
 }
 
 // pushLibrary adds a library to be processed by the package loader.
-func (p *PackageLoader) pushLibrary(library Library, sourceRange compilercommon.SourceRange) string {
+func (p *PackageLoader) pushLibrary(library Library, kind string, sourceRange compilercommon.SourceRange) string {
 	if library.IsSCM {
-		return p.pushPath(pathVCSPackage, library.Kind, library.PathOrURL, sourceRange)
-	} else {
-		return p.pushPath(pathLocalPackage, library.Kind, library.PathOrURL, sourceRange)
+		return p.pushPath(pathVCSPackage, kind, library.PathOrURL, sourceRange)
 	}
+
+	return p.pushPath(pathLocalPackage, kind, library.PathOrURL, sourceRange)
 }
 
 // pushPath adds a path to be processed by the package loader.
@@ -612,7 +612,7 @@ func (p *PackageLoader) handleImport(sourceKind string, importPath string, impor
 			return ""
 		}
 
-		return p.pushLibrary(library, importInformation.SourceRange)
+		return p.pushLibrary(library, importInformation.Kind, importInformation.SourceRange)
 
 	case ImportTypeVCS:
 		// VCS paths get added directly.


### PR DESCRIPTION
Libraries are usually specified with a default kind in the packageloader, but they may be used as *other* kinds (webidl, etc) via aliased imports. This fixes a bug where importing `@core` via `webidl` results in the package not being found.