### PR TITLE
Integer division optimization bug

### DIFF
--- a/generator/es5/dombuilder/build_op_expr.go
+++ b/generator/es5/dombuilder/build_op_expr.go
@@ -251,6 +251,12 @@ func (db *domBuilder) buildOptimizedBinaryOperatorExpression(node compilergraph.
 
 	switch {
 	case parentType.IsDirectReferenceTo(db.scopegraph.TypeGraph().IntType()):
+		// Since division of integers requires flooring, turn this off for int div.
+		// TODO: Have the optimizer add the proper Math.floor call.
+		if opString == "/" {
+			return nil, false
+		}
+
 		isNumeric = true
 
 	case parentType.IsDirectReferenceTo(db.scopegraph.TypeGraph().BoolType()):

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -150,6 +150,7 @@ var generationTests = []generationTest{
 
 	generationTest{"generic op expression", "opexpr", "generic", integrationTestSuccessExpected, ""},
 	generationTest{"exclusive range expression", "opexpr", "exrange", integrationTestSuccessExpected, ""},
+	generationTest{"numeric op expression", "opexpr", "numeric", integrationTestSuccessExpected, ""},
 
 	generationTest{"match statement", "statements", "match", integrationTestSuccessExpected, ""},
 

--- a/generator/es5/tests/accessexpr/asyncnullaccess.js
+++ b/generator/es5/tests/accessexpr/asyncnullaccess.js
@@ -43,7 +43,7 @@ $module('asyncnullaccess', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|54ff3ddf": true,
+        "SomeProperty|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/cast.js
+++ b/generator/es5/tests/accessexpr/cast.js
@@ -16,7 +16,7 @@ $module('cast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Result|3|54ff3ddf": true,
+        "Result|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/dynamicprop.js
+++ b/generator/es5/tests/accessexpr/dynamicprop.js
@@ -22,7 +22,7 @@ $module('dynamicprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProp|3|bb8d3aad": true,
+        "SomeProp|3|7243cf1b": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/funcref.js
+++ b/generator/es5/tests/accessexpr/funcref.js
@@ -17,7 +17,7 @@ $module('funcref', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeFunction|2|fd8bc7c9<54ff3ddf>": true,
+        "SomeFunction|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/memberaccess.js
+++ b/generator/es5/tests/accessexpr/memberaccess.js
@@ -25,9 +25,9 @@ $module('memberaccess', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Build|1|fd8bc7c9<a95b5789>": true,
-        "InstanceFunc|2|fd8bc7c9<void>": true,
-        "SomeProp|3|bb8d3aad": true,
+        "Build|1|2549c819<a95b5789>": true,
+        "InstanceFunc|2|2549c819<void>": true,
+        "SomeProp|3|7243cf1b": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/nullaccess.js
+++ b/generator/es5/tests/accessexpr/nullaccess.js
@@ -16,7 +16,7 @@ $module('nullaccess', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeBool|3|54ff3ddf": true,
+        "SomeBool|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/agent/basic.js
+++ b/generator/es5/tests/agent/basic.js
@@ -26,9 +26,9 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Declare|1|fd8bc7c9<78afdb83>": true,
-        "GetValue|2|fd8bc7c9<bb8d3aad>": true,
-        "GetMainValue|2|fd8bc7c9<bb8d3aad>": true,
+        "Declare|1|2549c819<78afdb83>": true,
+        "GetValue|2|2549c819<7243cf1b>": true,
+        "GetMainValue|2|2549c819<7243cf1b>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -41,7 +41,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|fd8bc7c9<bb8d3aad>": true,
+        "GetValue|2|2549c819<7243cf1b>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -63,7 +63,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetMainValue|2|fd8bc7c9<bb8d3aad>": true,
+        "GetMainValue|2|2549c819<7243cf1b>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/agent/field.js
+++ b/generator/es5/tests/agent/field.js
@@ -25,7 +25,7 @@ $module('field', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Declare|1|fd8bc7c9<ad638208>": true,
+        "Declare|1|2549c819<ad638208>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/arrowexpr/arrow.js
+++ b/generator/es5/tests/arrowexpr/arrow.js
@@ -21,8 +21,8 @@ $module('arrow', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Then|2|fd8bc7c9<69a8a979<54ff3ddf>>": true,
-        "Catch|2|fd8bc7c9<69a8a979<54ff3ddf>>": true,
+        "Then|2|2549c819<837d6211<f361570c>>": true,
+        "Catch|2|2549c819<837d6211<f361570c>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/arrowexpr/await.js
+++ b/generator/es5/tests/arrowexpr/await.js
@@ -21,8 +21,8 @@ $module('await', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Then|2|fd8bc7c9<69a8a979<54ff3ddf>>": true,
-        "Catch|2|fd8bc7c9<69a8a979<54ff3ddf>>": true,
+        "Then|2|2549c819<837d6211<f361570c>>": true,
+        "Catch|2|2549c819<837d6211<f361570c>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/arrowexpr/multiawait.js
+++ b/generator/es5/tests/arrowexpr/multiawait.js
@@ -15,7 +15,7 @@ $module('multiawait', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "plus|4|fd8bc7c9<5965b3f7>": true,
+        "plus|4|2549c819<5965b3f7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/async/asyncstruct.js
+++ b/generator/es5/tests/async/asyncstruct.js
@@ -28,12 +28,12 @@ $module('asyncstruct', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<4e1a7940>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<4e1a7940>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<4e1a7940>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<4e1a7940>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/genericinterfacecast.js
+++ b/generator/es5/tests/cast/genericinterfacecast.js
@@ -16,7 +16,7 @@ $module('genericinterfacecast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|54ff3ddf": true,
+        "SomeValue|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/interfacecast.js
+++ b/generator/es5/tests/cast/interfacecast.js
@@ -16,7 +16,7 @@ $module('interfacecast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|54ff3ddf": true,
+        "SomeValue|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -29,7 +29,7 @@ $module('interfacecast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|54ff3ddf": true,
+        "SomeValue|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/interfacecastfail.js
+++ b/generator/es5/tests/cast/interfacecastfail.js
@@ -16,7 +16,7 @@ $module('interfacecastfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|bb8d3aad": true,
+        "SomeValue|3|7243cf1b": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -29,7 +29,7 @@ $module('interfacecastfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|54ff3ddf": true,
+        "SomeValue|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/nominalautobox.js
+++ b/generator/es5/tests/cast/nominalautobox.js
@@ -33,7 +33,7 @@ $module('nominalautobox', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|54ff3ddf": true,
+        "SomeValue|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/class/basic.js
+++ b/generator/es5/tests/class/basic.js
@@ -18,7 +18,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherFunction|2|fd8bc7c9<void>": true,
+        "AnotherFunction|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/class/generic.js
+++ b/generator/es5/tests/class/generic.js
@@ -17,7 +17,7 @@ $module('generic', function () {
       }
       var computed = {
       };
-      computed[("Something|2|fd8bc7c9<" + $t.typeid(T)) + ">"] = true;
+      computed[("Something|2|2549c819<" + $t.typeid(T)) + ">"] = true;
       return this.$cachedtypesig = computed;
     };
   });
@@ -55,7 +55,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Something|2|fd8bc7c9<e0aeb390>": true,
+        "Something|2|2549c819<e0aeb390>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -68,7 +68,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Something|2|fd8bc7c9<2989c0d0>": true,
+        "Something|2|2549c819<2989c0d0>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/class/property.js
+++ b/generator/es5/tests/class/property.js
@@ -22,7 +22,7 @@ $module('property', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProp|3|54ff3ddf": true,
+        "SomeProp|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/condexpr/calls.js
+++ b/generator/es5/tests/condexpr/calls.js
@@ -16,7 +16,7 @@ $module('calls', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|44e219a9": true,
+        "Message|3|ec87fc3f": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/dynamicaccess/nonpromising.js
+++ b/generator/es5/tests/dynamicaccess/nonpromising.js
@@ -22,12 +22,12 @@ $module('nonpromising', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<5d13a931>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<5d13a931>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<5d13a931>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<5d13a931>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/generator/resource.js
+++ b/generator/es5/tests/generator/resource.js
@@ -18,7 +18,7 @@ $module('resource', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|fd8bc7c9<void>": true,
+        "Release|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/interface/constructable.js
+++ b/generator/es5/tests/interface/constructable.js
@@ -19,8 +19,8 @@ $module('constructable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Get|1|fd8bc7c9<ceb86b8e>": true,
-        "SomeBool|3|54ff3ddf": true,
+        "Get|1|2549c819<ceb86b8e>": true,
+        "SomeBool|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -36,8 +36,8 @@ $module('constructable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Get|1|fd8bc7c9<ba50ace2>": true,
-        "SomeBool|3|54ff3ddf": true,
+        "Get|1|2549c819<ba50ace2>": true,
+        "SomeBool|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/interface/interfaceprop.js
+++ b/generator/es5/tests/interface/interfaceprop.js
@@ -22,7 +22,7 @@ $module('interfaceprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|54ff3ddf": true,
+        "SomeProperty|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -75,7 +75,7 @@ $module('interfaceprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|54ff3ddf": true,
+        "SomeProperty|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -88,7 +88,7 @@ $module('interfaceprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|54ff3ddf": true,
+        "SomeProperty|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/literals/structnew.js
+++ b/generator/es5/tests/literals/structnew.js
@@ -23,7 +23,7 @@ $module('structnew', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherField|3|54ff3ddf": true,
+        "AnotherField|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/literals/this.js
+++ b/generator/es5/tests/literals/this.js
@@ -16,7 +16,7 @@ $module('this', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "DoSomething|2|fd8bc7c9<void>": true,
+        "DoSomething|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/basic.js
+++ b/generator/es5/tests/nominal/basic.js
@@ -16,7 +16,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "DoSomething|2|fd8bc7c9<54ff3ddf>": true,
+        "DoSomething|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -46,8 +46,8 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherThing|2|fd8bc7c9<54ff3ddf>": true,
-        "SomeProp|3|54ff3ddf": true,
+        "AnotherThing|2|2549c819<f361570c>": true,
+        "SomeProp|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/generic.js
+++ b/generator/es5/tests/nominal/generic.js
@@ -16,7 +16,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "DoSomething|2|fd8bc7c9<54ff3ddf>": true,
+        "DoSomething|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -46,8 +46,8 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherThing|2|fd8bc7c9<54ff3ddf>": true,
-        "SomeProp|3|54ff3ddf": true,
+        "AnotherThing|2|2549c819<f361570c>": true,
+        "SomeProp|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/interface.js
+++ b/generator/es5/tests/nominal/interface.js
@@ -16,7 +16,7 @@ $module('interface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|bb8d3aad": true,
+        "SomeValue|3|7243cf1b": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -29,7 +29,7 @@ $module('interface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|bb8d3aad": true,
+        "SomeValue|3|7243cf1b": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,7 +55,7 @@ $module('interface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|fd8bc7c9<bb8d3aad>": true,
+        "GetValue|2|2549c819<7243cf1b>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/nominalbase.js
+++ b/generator/es5/tests/nominal/nominalbase.js
@@ -34,7 +34,7 @@ $module('nominalbase', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProp|3|54ff3ddf": true,
+        "SomeProp|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -60,7 +60,7 @@ $module('nominalbase', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|fd8bc7c9<54ff3ddf>": true,
+        "GetValue|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/shortcut.js
+++ b/generator/es5/tests/nominal/shortcut.js
@@ -16,7 +16,7 @@ $module('shortcut', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Value|3|54ff3ddf": true,
+        "Value|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/asyncfunctioncallnullable.js
+++ b/generator/es5/tests/opexpr/asyncfunctioncallnullable.js
@@ -43,7 +43,7 @@ $module('asyncfunctioncallnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeMethod|2|fd8bc7c9<54ff3ddf>": true,
+        "SomeMethod|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/functioncallnullable.js
+++ b/generator/es5/tests/opexpr/functioncallnullable.js
@@ -16,7 +16,7 @@ $module('functioncallnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeMethod|2|fd8bc7c9<54ff3ddf>": true,
+        "SomeMethod|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -38,7 +38,7 @@ $module('functioncallnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherMethod|2|fd8bc7c9<54ff3ddf>": true,
+        "AnotherMethod|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/generic.js
+++ b/generator/es5/tests/opexpr/generic.js
@@ -19,7 +19,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "BoolValue|3|54ff3ddf": true,
+        "BoolValue|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/nullcomparecall.js
+++ b/generator/es5/tests/opexpr/nullcomparecall.js
@@ -16,7 +16,7 @@ $module('nullcomparecall', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|44e219a9": true,
+        "Message|3|ec87fc3f": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/numeric.js
+++ b/generator/es5/tests/opexpr/numeric.js
@@ -1,0 +1,12 @@
+$module('numeric', function () {
+  var $static = this;
+  $static.TEST = function () {
+    var result;
+    result = $t.fastbox(true, $g.________testlib.basictypes.Boolean);
+    result = $t.fastbox(result.$wrapped && ((1 + 2) == 3), $g.________testlib.basictypes.Boolean);
+    result = $t.fastbox(result.$wrapped && ((2 - 1) == 1), $g.________testlib.basictypes.Boolean);
+    result = $t.fastbox(result.$wrapped && ((2 * 1) == 2), $g.________testlib.basictypes.Boolean);
+    result = $t.fastbox(result.$wrapped && ($g.________testlib.basictypes.Integer.$div($t.fastbox(5, $g.________testlib.basictypes.Integer), $t.fastbox(2, $g.________testlib.basictypes.Integer)).$wrapped == 2), $g.________testlib.basictypes.Boolean);
+    return result;
+  };
+});

--- a/generator/es5/tests/opexpr/numeric.seru
+++ b/generator/es5/tests/opexpr/numeric.seru
@@ -1,0 +1,8 @@
+function<bool> TEST() {
+    var<bool> result = true
+    result = result && (1 + 2 == 3)
+    result = result && (2 - 1 == 1)
+    result = result && (2 * 1 == 2)
+    result = result && (5 / 2 == 2)
+    return result
+}

--- a/generator/es5/tests/opexpr/shortcircuit.js
+++ b/generator/es5/tests/opexpr/shortcircuit.js
@@ -16,7 +16,7 @@ $module('shortcircuit', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|44e219a9": true,
+        "Message|3|ec87fc3f": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/unwrap.js
+++ b/generator/es5/tests/opexpr/unwrap.js
@@ -16,7 +16,7 @@ $module('unwrap', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|54ff3ddf": true,
+        "SomeProperty|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/unwrapnullable.js
+++ b/generator/es5/tests/opexpr/unwrapnullable.js
@@ -16,7 +16,7 @@ $module('unwrapnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|54ff3ddf": true,
+        "SomeProperty|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/resolve/castignoreinterface.js
+++ b/generator/es5/tests/resolve/castignoreinterface.js
@@ -43,7 +43,7 @@ $module('castignoreinterface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeFunction|2|fd8bc7c9<void>": true,
+        "SomeFunction|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -56,7 +56,7 @@ $module('castignoreinterface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeFunction|2|fd8bc7c9<void>": true,
+        "SomeFunction|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/resolve/expectrejection.js
+++ b/generator/es5/tests/resolve/expectrejection.js
@@ -16,7 +16,7 @@ $module('expectrejection', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|44e219a9": true,
+        "Message|3|ec87fc3f": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/custom.js
+++ b/generator/es5/tests/serialization/custom.js
@@ -23,9 +23,9 @@ $module('custom', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Get|1|fd8bc7c9<38a26367>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Parse|2|fd8bc7c9<ad6de9ce<any>>": true,
+        "Get|1|2549c819<38a26367>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Parse|2|2549c819<95776681<any>>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -53,12 +53,12 @@ $module('custom', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<9a932bd6>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<9a932bd6>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<9a932bd6>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<9a932bd6>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -98,12 +98,12 @@ $module('custom', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<f97a88eb>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<f97a88eb>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<f97a88eb>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<f97a88eb>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/json.js
+++ b/generator/es5/tests/serialization/json.js
@@ -22,12 +22,12 @@ $module('json', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<143c410b>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<143c410b>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<143c410b>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<143c410b>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -67,12 +67,12 @@ $module('json', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<8c772f6d>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<8c772f6d>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<8c772f6d>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<8c772f6d>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/jsondefault.js
+++ b/generator/es5/tests/serialization/jsondefault.js
@@ -28,12 +28,12 @@ $module('jsondefault', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<d610e0b2>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<d610e0b2>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<d610e0b2>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<d610e0b2>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/jsonfail.js
+++ b/generator/es5/tests/serialization/jsonfail.js
@@ -22,12 +22,12 @@ $module('jsonfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<8c9ddb23>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<8c9ddb23>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<8c9ddb23>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<8c9ddb23>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -67,12 +67,12 @@ $module('jsonfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<9251ae6e>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<9251ae6e>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<9251ae6e>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<9251ae6e>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/nominaljson.js
+++ b/generator/es5/tests/serialization/nominaljson.js
@@ -20,7 +20,7 @@ $module('nominaljson', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|fd8bc7c9<54ff3ddf>": true,
+        "GetValue|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -48,12 +48,12 @@ $module('nominaljson', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<c267cdf9>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<c267cdf9>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<c267cdf9>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<c267cdf9>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -81,12 +81,12 @@ $module('nominaljson', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<2904f0f0>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<2904f0f0>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<2904f0f0>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<2904f0f0>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/slice.js
+++ b/generator/es5/tests/serialization/slice.js
@@ -22,12 +22,12 @@ $module('slice', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<9b59dab3>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<9b59dab3>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<9b59dab3>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<9b59dab3>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,12 +55,12 @@ $module('slice', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<a7573ae2>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<a7573ae2>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<a7573ae2>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<a7573ae2>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/tagged.js
+++ b/generator/es5/tests/serialization/tagged.js
@@ -22,12 +22,12 @@ $module('tagged', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<bad44f92>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<bad44f92>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<bad44f92>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<bad44f92>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sml/maybeasyncfunction.js
+++ b/generator/es5/tests/sml/maybeasyncfunction.js
@@ -43,7 +43,7 @@ $module('maybeasyncfunction', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SimpleFunction|2|fd8bc7c9<54ff3ddf>": true,
+        "SimpleFunction|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -65,7 +65,7 @@ $module('maybeasyncfunction', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SimpleFunction|2|fd8bc7c9<54ff3ddf>": true,
+        "SimpleFunction|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -78,7 +78,7 @@ $module('maybeasyncfunction', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SimpleFunction|2|fd8bc7c9<54ff3ddf>": true,
+        "SimpleFunction|2|2549c819<f361570c>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sml/simpleclass.js
+++ b/generator/es5/tests/sml/simpleclass.js
@@ -19,8 +19,8 @@ $module('simpleclass', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Declare|1|fd8bc7c9<f6e326a6>": true,
-        "Value|3|54ff3ddf": true,
+        "Declare|1|2549c819<f6e326a6>": true,
+        "Value|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sml/structprops.js
+++ b/generator/es5/tests/sml/structprops.js
@@ -33,12 +33,12 @@ $module('structprops', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<3f6b14fb>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<3f6b14fb>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<3f6b14fb>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<3f6b14fb>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sourcemapping/basic.js
+++ b/generator/es5/tests/sourcemapping/basic.js
@@ -791,7 +791,7 @@ this.Serulian = (function ($global) {
   };
   $module('________testlib.basictypes', function () {
     var $static = this;
-    this.$class('58998129', 'Tuple', true, 'tuple', function (T, Q) {
+    this.$class('4b63a755', 'Tuple', true, 'tuple', function (T, Q) {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -813,12 +813,12 @@ this.Serulian = (function ($global) {
         }
         var computed = {
         };
-        computed[((("Build|1|fd8bc7c9<58998129<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
+        computed[((("Build|1|2549c819<4b63a755<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('fd8bc7c9', 'Function', true, 'function', function (T) {
+    this.$class('2549c819', 'Function', true, 'function', function (T) {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -831,7 +831,7 @@ this.Serulian = (function ($global) {
       };
     });
 
-    this.$class('08e38881', 'IntStream', false, '$intstream', function () {
+    this.$class('f884cf2a', 'IntStream', false, '$intstream', function () {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -883,27 +883,14 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "OverRange|1|fd8bc7c9<08e38881>": true,
-          "Next|2|fd8bc7c9<58998129<bb8d3aad,54ff3ddf>>": true,
+          "OverRange|1|2549c819<f884cf2a>": true,
+          "Next|2|2549c819<4b63a755<7243cf1b,f361570c>>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('2c6e7a16', 'Float64', false, 'float64', function () {
-      var $static = this;
-      var $instance = this.prototype;
-      $static.new = function () {
-        var instance = new $static();
-        return instance;
-      };
-      this.$typesig = function () {
-        return {
-        };
-      };
-    });
-
-    this.$class('49c113d9', 'List', true, 'list', function (T) {
+    this.$class('969963a7', 'List', true, 'list', function (T) {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -994,15 +981,15 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Count|3|bb8d3aad": true,
+          "Count|3|7243cf1b": true,
         };
-        computed[("index|4|fd8bc7c9<" + $t.typeid(T)) + ">"] = true;
-        computed[("slice|4|fd8bc7c9<9b1698d6<" + $t.typeid(T)) + ">>"] = true;
+        computed[("index|4|2549c819<" + $t.typeid(T)) + ">"] = true;
+        computed[("slice|4|2549c819<fe002889<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('f2f897e8', 'Map', true, 'map', function (T, Q) {
+    this.$class('5b1201ed', 'Map', true, 'map', function (T, Q) {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -1106,16 +1093,16 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "setindex|4|fd8bc7c9<void>": true,
+          "setindex|4|2549c819<void>": true,
         };
-        computed[((("Empty|1|fd8bc7c9<f2f897e8<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
-        computed[("Mapping|2|fd8bc7c9<ad6de9ce<" + $t.typeid(Q)) + ">>"] = true;
-        computed[("index|4|fd8bc7c9<" + $t.typeid(Q)) + ">"] = true;
+        computed[((("Empty|1|2549c819<5b1201ed<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
+        computed[("Mapping|2|2549c819<95776681<" + $t.typeid(Q)) + ">>"] = true;
+        computed[("index|4|2549c819<" + $t.typeid(Q)) + ">"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('17172d1e', 'JSON', false, 'json', function () {
+    this.$class('5f5f1f6f', 'JSON', false, 'json', function () {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -1138,41 +1125,28 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Get|1|fd8bc7c9<17172d1e>": true,
-          "Stringify|2|fd8bc7c9<44e219a9>": true,
-          "Parse|2|fd8bc7c9<ad6de9ce<any>>": true,
+          "Get|1|2549c819<5f5f1f6f>": true,
+          "Stringify|2|2549c819<ec87fc3f>": true,
+          "Parse|2|2549c819<95776681<any>>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('8ca0891a', 'Stringable', false, 'stringable', function () {
+    this.$interface('10d66da0', 'Stringable', false, 'stringable', function () {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "String|2|fd8bc7c9<44e219a9>": true,
+          "String|2|2549c819<ec87fc3f>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('1d733667', 'Stream', true, 'stream', function (T) {
-      var $static = this;
-      this.$typesig = function () {
-        if (this.$cachedtypesig) {
-          return this.$cachedtypesig;
-        }
-        var computed = {
-        };
-        computed[("Next|2|fd8bc7c9<58998129<" + $t.typeid(T)) + ",54ff3ddf>>"] = true;
-        return this.$cachedtypesig = computed;
-      };
-    });
-
-    this.$interface('0d4528b3', 'Streamable', true, 'streamable', function (T) {
+    this.$interface('47956471', 'Stream', true, 'stream', function (T) {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
@@ -1180,25 +1154,12 @@ this.Serulian = (function ($global) {
         }
         var computed = {
         };
-        computed[("Stream|2|fd8bc7c9<1d733667<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Next|2|2549c819<4b63a755<" + $t.typeid(T)) + ",f361570c>>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('b6ef544c', 'Error', false, 'error', function () {
-      var $static = this;
-      this.$typesig = function () {
-        if (this.$cachedtypesig) {
-          return this.$cachedtypesig;
-        }
-        var computed = {
-          "Message|3|44e219a9": true,
-        };
-        return this.$cachedtypesig = computed;
-      };
-    });
-
-    this.$interface('69a8a979', 'Awaitable', true, 'awaitable', function (T) {
+    this.$interface('7d230f2f', 'Streamable', true, 'streamable', function (T) {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
@@ -1206,56 +1167,65 @@ this.Serulian = (function ($global) {
         }
         var computed = {
         };
-        computed[("Then|2|fd8bc7c9<69a8a979<" + $t.typeid(T)) + ">>"] = true;
-        computed[("Catch|2|fd8bc7c9<69a8a979<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Stream|2|2549c819<47956471<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('8875fbad', 'Releasable', false, 'releasable', function () {
+    this.$interface('04a4d70b', 'Error', false, 'error', function () {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Release|2|fd8bc7c9<void>": true,
+          "Message|3|ec87fc3f": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('ef89c4c8', 'Mappable', false, 'mappable', function () {
+    this.$interface('837d6211', 'Awaitable', true, 'awaitable', function (T) {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "MapKey|3|8ca0891a": true,
         };
+        computed[("Then|2|2549c819<837d6211<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Catch|2|2549c819<837d6211<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('195abf50', 'Stringifier', false, '$stringifier', function () {
+    this.$interface('6234a420', 'Releasable', false, 'releasable', function () {
       var $static = this;
-      $static.Get = function () {
-        return $g.________testlib.basictypes.JSON.new();
-      };
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Get|1|fd8bc7c9<195abf50>": true,
-          "Stringify|2|fd8bc7c9<44e219a9>": true,
+          "Release|2|2549c819<void>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('7e8913a0', 'Parser', false, '$parser', function () {
+    this.$interface('8e9e617a', 'Mappable', false, 'mappable', function () {
+      var $static = this;
+      this.$typesig = function () {
+        if (this.$cachedtypesig) {
+          return this.$cachedtypesig;
+        }
+        var computed = {
+          "MapKey|3|10d66da0": true,
+        };
+        return this.$cachedtypesig = computed;
+      };
+    });
+
+    this.$interface('d93f43e3', 'Stringifier', false, '$stringifier', function () {
       var $static = this;
       $static.Get = function () {
         return $g.________testlib.basictypes.JSON.new();
@@ -1265,14 +1235,31 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Get|1|fd8bc7c9<7e8913a0>": true,
-          "Parse|2|fd8bc7c9<ad6de9ce<any>>": true,
+          "Get|1|2549c819<d93f43e3>": true,
+          "Stringify|2|2549c819<ec87fc3f>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('ad6de9ce', 'Mapping', true, 'mapping', function (T) {
+    this.$interface('445b8e8e', 'Parser', false, '$parser', function () {
+      var $static = this;
+      $static.Get = function () {
+        return $g.________testlib.basictypes.JSON.new();
+      };
+      this.$typesig = function () {
+        if (this.$cachedtypesig) {
+          return this.$cachedtypesig;
+        }
+        var computed = {
+          "Get|1|2549c819<445b8e8e>": true,
+          "Parse|2|2549c819<95776681<any>>": true,
+        };
+        return this.$cachedtypesig = computed;
+      };
+    });
+
+    this.$type('95776681', 'Mapping', true, 'mapping', function (T) {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1326,15 +1313,15 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Keys|3|9b1698d6<44e219a9>": true,
+          "Keys|3|fe002889<ec87fc3f>": true,
         };
-        computed[("Empty|1|fd8bc7c9<ad6de9ce<" + $t.typeid(T)) + ">>"] = true;
-        computed[("index|4|fd8bc7c9<" + $t.typeid(T)) + ">"] = true;
+        computed[("Empty|1|2549c819<95776681<" + $t.typeid(T)) + ">>"] = true;
+        computed[("index|4|2549c819<" + $t.typeid(T)) + ">"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('9b1698d6', 'Slice', true, 'slice', function (T) {
+    this.$type('fe002889', 'Slice', true, 'slice', function (T) {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1428,16 +1415,16 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Length|3|bb8d3aad": true,
+          "Length|3|7243cf1b": true,
         };
-        computed[("Empty|1|fd8bc7c9<9b1698d6<" + $t.typeid(T)) + ">>"] = true;
-        computed[("index|4|fd8bc7c9<" + $t.typeid(T)) + ">"] = true;
-        computed[("slice|4|fd8bc7c9<9b1698d6<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Empty|1|2549c819<fe002889<" + $t.typeid(T)) + ">>"] = true;
+        computed[("index|4|2549c819<" + $t.typeid(T)) + ">"] = true;
+        computed[("slice|4|2549c819<fe002889<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('bb8d3aad', 'Integer', false, 'int', function () {
+    this.$type('7243cf1b', 'Integer', false, 'int', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1463,6 +1450,12 @@ this.Serulian = (function ($global) {
       $static.$plus = function (left, right) {
         return $t.fastbox(left.$wrapped + right.$wrapped, $g.________testlib.basictypes.Integer);
       };
+      $static.$times = function (left, right) {
+        return $t.fastbox(left.$wrapped - right.$wrapped, $g.________testlib.basictypes.Integer);
+      };
+      $static.$div = function (left, right) {
+        return $t.fastbox(left.$wrapped / right.$wrapped, $g.________testlib.basictypes.Float64).Floor();
+      };
       $static.$minus = function (left, right) {
         return $t.fastbox(left.$wrapped - right.$wrapped, $g.________testlib.basictypes.Integer);
       };
@@ -1483,21 +1476,23 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "range|4|fd8bc7c9<1d733667<bb8d3aad>>": true,
-          "exclusiverange|4|fd8bc7c9<1d733667<bb8d3aad>>": true,
-          "compare|4|fd8bc7c9<bb8d3aad>": true,
-          "equals|4|fd8bc7c9<54ff3ddf>": true,
-          "plus|4|fd8bc7c9<bb8d3aad>": true,
-          "minus|4|fd8bc7c9<bb8d3aad>": true,
-          "Release|2|fd8bc7c9<void>": true,
-          "MapKey|3|8ca0891a": true,
-          "String|2|fd8bc7c9<44e219a9>": true,
+          "range|4|2549c819<47956471<7243cf1b>>": true,
+          "exclusiverange|4|2549c819<47956471<7243cf1b>>": true,
+          "compare|4|2549c819<7243cf1b>": true,
+          "equals|4|2549c819<f361570c>": true,
+          "plus|4|2549c819<7243cf1b>": true,
+          "times|4|2549c819<7243cf1b>": true,
+          "div|4|2549c819<7243cf1b>": true,
+          "minus|4|2549c819<7243cf1b>": true,
+          "Release|2|2549c819<void>": true,
+          "MapKey|3|10d66da0": true,
+          "String|2|2549c819<ec87fc3f>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('54ff3ddf', 'Boolean', false, 'bool', function () {
+    this.$type('f361570c', 'Boolean', false, 'bool', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1549,16 +1544,42 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "compare|4|fd8bc7c9<bb8d3aad>": true,
-          "equals|4|fd8bc7c9<54ff3ddf>": true,
-          "String|2|fd8bc7c9<44e219a9>": true,
-          "MapKey|3|8ca0891a": true,
+          "compare|4|2549c819<7243cf1b>": true,
+          "equals|4|2549c819<f361570c>": true,
+          "String|2|2549c819<ec87fc3f>": true,
+          "MapKey|3|10d66da0": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('44e219a9', 'String', false, 'string', function () {
+    this.$type('b54a5518', 'Float64', false, 'float64', function () {
+      var $instance = this.prototype;
+      var $static = this;
+      this.$box = function ($wrapped) {
+        var instance = new this();
+        instance[BOXED_DATA_PROPERTY] = $wrapped;
+        return instance;
+      };
+      this.$roottype = function () {
+        return $global.Number;
+      };
+      $instance.Floor = function () {
+        var $this = this;
+        return $t.fastbox($global.Math.floor($this.$wrapped), $g.________testlib.basictypes.Integer);
+      };
+      this.$typesig = function () {
+        if (this.$cachedtypesig) {
+          return this.$cachedtypesig;
+        }
+        var computed = {
+          "Floor|2|2549c819<7243cf1b>": true,
+        };
+        return this.$cachedtypesig = computed;
+      };
+    });
+
+    this.$type('ec87fc3f', 'String', false, 'string', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1592,17 +1613,17 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "String|2|fd8bc7c9<44e219a9>": true,
-          "equals|4|fd8bc7c9<54ff3ddf>": true,
-          "plus|4|fd8bc7c9<44e219a9>": true,
-          "MapKey|3|8ca0891a": true,
-          "Length|3|bb8d3aad": true,
+          "String|2|2549c819<ec87fc3f>": true,
+          "equals|4|2549c819<f361570c>": true,
+          "plus|4|2549c819<ec87fc3f>": true,
+          "MapKey|3|10d66da0": true,
+          "Length|3|7243cf1b": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('f16409fd', 'WrappedError', false, 'wrappederror', function () {
+    this.$type('49139d13', 'WrappedError', false, 'wrappederror', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1625,8 +1646,8 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "For|1|fd8bc7c9<f16409fd>": true,
-          "Message|3|44e219a9": true,
+          "For|1|2549c819<49139d13>": true,
+          "Message|3|ec87fc3f": true,
         };
         return this.$cachedtypesig = computed;
       };

--- a/generator/es5/tests/statements/autounboxassign.js
+++ b/generator/es5/tests/statements/autounboxassign.js
@@ -16,7 +16,7 @@ $module('autounboxassign', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|bb8d3aad": true,
+        "SomeValue|3|7243cf1b": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/loopstreamable.js
+++ b/generator/es5/tests/statements/loopstreamable.js
@@ -16,7 +16,7 @@ $module('loopstreamable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Stream|2|fd8bc7c9<1d733667<54ff3ddf>>": true,
+        "Stream|2|2549c819<47956471<f361570c>>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -42,7 +42,7 @@ $module('loopstreamable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Next|2|fd8bc7c9<58998129<54ff3ddf,54ff3ddf>>": true,
+        "Next|2|2549c819<4b63a755<f361570c,f361570c>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/loopvar.js
+++ b/generator/es5/tests/statements/loopvar.js
@@ -20,7 +20,7 @@ $module('loopvar', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Next|2|fd8bc7c9<58998129<54ff3ddf,54ff3ddf>>": true,
+        "Next|2|2549c819<4b63a755<f361570c,f361570c>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/match.js
+++ b/generator/es5/tests/statements/match.js
@@ -16,7 +16,7 @@ $module('match', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Value|3|54ff3ddf": true,
+        "Value|3|f361570c": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/with.js
+++ b/generator/es5/tests/statements/with.js
@@ -17,7 +17,7 @@ $module('with', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|fd8bc7c9<void>": true,
+        "Release|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/withasync.js
+++ b/generator/es5/tests/statements/withasync.js
@@ -43,7 +43,7 @@ $module('withasync', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|fd8bc7c9<void>": true,
+        "Release|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/withexit.js
+++ b/generator/es5/tests/statements/withexit.js
@@ -17,7 +17,7 @@ $module('withexit', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|fd8bc7c9<void>": true,
+        "Release|2|2549c819<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/basic.js
+++ b/generator/es5/tests/struct/basic.js
@@ -22,12 +22,12 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<a76166f4>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<a76166f4>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<a76166f4>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<a76166f4>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -67,12 +67,12 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<1a1b7840>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<1a1b7840>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<1a1b7840>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<1a1b7840>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/clone.js
+++ b/generator/es5/tests/struct/clone.js
@@ -28,12 +28,12 @@ $module('clone', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<be48fdbe>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<be48fdbe>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<be48fdbe>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<be48fdbe>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/defaults.js
+++ b/generator/es5/tests/struct/defaults.js
@@ -22,12 +22,12 @@ $module('defaults', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<6cbd0ebf>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<6cbd0ebf>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<6cbd0ebf>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<6cbd0ebf>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -77,12 +77,12 @@ $module('defaults', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<41f59c9b>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<41f59c9b>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<41f59c9b>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<41f59c9b>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/equals.js
+++ b/generator/es5/tests/struct/equals.js
@@ -28,12 +28,12 @@ $module('equals', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<9285bf36>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<9285bf36>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<9285bf36>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<9285bf36>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -61,12 +61,12 @@ $module('equals', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<4fb96a52>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<4fb96a52>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<4fb96a52>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<4fb96a52>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/generic.js
+++ b/generator/es5/tests/struct/generic.js
@@ -22,12 +22,12 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<6b885b52>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<6b885b52>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<6b885b52>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<6b885b52>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,13 +55,13 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
-      computed[("Parse|1|fd8bc7c9<d34106e1<" + $t.typeid(T)) + ">>"] = true;
-      computed[("Clone|2|fd8bc7c9<d34106e1<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Parse|1|2549c819<d34106e1<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Clone|2|2549c819<d34106e1<" + $t.typeid(T)) + ">>"] = true;
       return this.$cachedtypesig = computed;
     };
   });

--- a/generator/es5/tests/struct/innergeneric.js
+++ b/generator/es5/tests/struct/innergeneric.js
@@ -22,12 +22,12 @@ $module('innergeneric', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<078feecd>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<078feecd>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<078feecd>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<078feecd>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,13 +55,13 @@ $module('innergeneric', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
-      computed[("Parse|1|fd8bc7c9<8369fb45<" + $t.typeid(T)) + ">>"] = true;
-      computed[("Clone|2|fd8bc7c9<8369fb45<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Parse|1|2549c819<8369fb45<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Clone|2|2549c819<8369fb45<" + $t.typeid(T)) + ">>"] = true;
       return this.$cachedtypesig = computed;
     };
   });

--- a/generator/es5/tests/struct/nominal.js
+++ b/generator/es5/tests/struct/nominal.js
@@ -39,12 +39,12 @@ $module('nominal', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<0d40ca4a>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<0d40ca4a>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<0d40ca4a>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<0d40ca4a>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/nullbox.js
+++ b/generator/es5/tests/struct/nullbox.js
@@ -21,12 +21,12 @@ $module('nullbox', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|fd8bc7c9<45b3c939>": true,
-        "equals|4|fd8bc7c9<54ff3ddf>": true,
-        "Stringify|2|fd8bc7c9<44e219a9>": true,
-        "Mapping|2|fd8bc7c9<ad6de9ce<any>>": true,
-        "Clone|2|fd8bc7c9<45b3c939>": true,
-        "String|2|fd8bc7c9<44e219a9>": true,
+        "Parse|1|2549c819<45b3c939>": true,
+        "equals|4|2549c819<f361570c>": true,
+        "Stringify|2|2549c819<ec87fc3f>": true,
+        "Mapping|2|2549c819<95776681<any>>": true,
+        "Clone|2|2549c819<45b3c939>": true,
+        "String|2|2549c819<ec87fc3f>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/testlib/basic.webidl
+++ b/testlib/basic.webidl
@@ -22,7 +22,7 @@ interface Boolean {
 };
 
 [Constructor(optional any value),
- NativeOperator=Plus, NativeOperator=Minus, NativeOperator=Equals]
+ NativeOperator=Plus, NativeOperator=Minus, NativeOperator=Times, NativeOperator=Div, NativeOperator=Equals]
 interface Number {
 	String toString();
 	serializer;
@@ -60,4 +60,8 @@ interface Error {
 	readonly attribute Number lineNumber;
 	readonly attribute Number columnNumber;
 	readonly attribute String stack;
+};
+
+interface Math {
+  static Number floor(Number value);
 };

--- a/testlib/basictypes.seru
+++ b/testlib/basictypes.seru
@@ -2,6 +2,7 @@ from webidl`basic` import Number
 from webidl`basic` import String as NativeString
 from webidl`basic` import Boolean as NativeBoolean
 from webidl`basic` import Array
+from webidl`basic` import Math
 from webidl`basic` import Object
 from webidl`basic` import Error as NativeError
 from webidl`basic` import debugprint
@@ -185,6 +186,14 @@ type Integer : Number {
 		return Integer(Number(left) + Number(right))
 	}
 
+	operator Times(left int, right int) {
+		return Integer(Number(left) - Number(right))
+	}
+
+	operator Div(left int, right int) {
+		return Float64(Number(left) / Number(right)).Floor()
+	}
+
 	operator Minus(left int, right int) {
 		return Integer(Number(left) - Number(right))
 	}
@@ -224,7 +233,11 @@ type Boolean : NativeBoolean {
 }
 
 @•typealias('float64')
-class Float64 {}
+type Float64 : Number {
+	function<int> Floor() {
+		return Integer(Math.floor(Number(this)))
+	}
+}
 
 @•typealias('string')
 type String : NativeString {


### PR DESCRIPTION
We accidentally allowed the optimizer to replace integer division with native division, which doesn't follow the same rules around Flooring the result