### PR TITLE
Add support for inline loops in SML

### DIFF
--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -298,6 +298,7 @@ var generationTests = []generationTest{
 	generationTest{"sml maybe async function test", "sml", "maybeasyncfunction", integrationTestSuccessExpected, ""},
 	generationTest{"sml async children test", "sml", "asyncchildren", integrationTestSuccessExpected, ""},
 	generationTest{"sml nested attributes test", "sml", "nestedattributes", integrationTestSuccessExpected, ""},
+	generationTest{"sml inline loop test", "sml", "inlineloop", integrationTestSuccessExpected, ""},
 
 	generationTest{"native new integration test", "nativenew", "nativenew", integrationTestSuccessExpected, ""},
 	generationTest{"dynamic access non-promising test", "dynamicaccess", "nonpromising", integrationTestSuccessExpected, ""},

--- a/generator/es5/tests/sml/inlineloop.js
+++ b/generator/es5/tests/sml/inlineloop.js
@@ -1,0 +1,101 @@
+$module('inlineloop', function () {
+  var $static = this;
+  $static.somenumber = function (props, value) {
+    return value;
+  };
+  $static.somesum = $t.markpromising(function (props, numbers) {
+    var $result;
+    var $temp0;
+    var $temp1;
+    var number;
+    var sum;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            sum = $t.fastbox(0, $g.________testlib.basictypes.Integer);
+            $current = 1;
+            continue localasyncloop;
+
+          case 1:
+            $temp1 = numbers;
+            $current = 2;
+            continue localasyncloop;
+
+          case 2:
+            $promise.maybe($temp1.Next()).then(function ($result0) {
+              $temp0 = $result0;
+              $result = $temp0;
+              $current = 3;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 3:
+            number = $temp0.First;
+            if ($temp0.Second.$wrapped) {
+              $current = 4;
+              continue localasyncloop;
+            } else {
+              $current = 5;
+              continue localasyncloop;
+            }
+            break;
+
+          case 4:
+            sum = $t.fastbox(sum.$wrapped + number.$wrapped, $g.________testlib.basictypes.Integer);
+            $current = 2;
+            continue localasyncloop;
+
+          case 5:
+            $resolve(sum);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+  $static.TEST = $t.markpromising(function () {
+    var $result;
+    var result;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            $promise.maybe($g.inlineloop.somesum($g.________testlib.basictypes.Mapping($t.any).Empty(), $g.________testlib.basictypes.MapStream($g.________testlib.basictypes.Integer, $g.________testlib.basictypes.Integer)($g.________testlib.basictypes.Integer.$range($t.fastbox(0, $g.________testlib.basictypes.Integer), $t.fastbox(2, $g.________testlib.basictypes.Integer)), function (index) {
+              return $g.inlineloop.somenumber($g.________testlib.basictypes.Mapping($t.any).Empty(), index);
+            }))).then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            result = $result;
+            $resolve($t.fastbox(result.$wrapped == 3, $g.________testlib.basictypes.Boolean));
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+});

--- a/generator/es5/tests/sml/inlineloop.seru
+++ b/generator/es5/tests/sml/inlineloop.seru
@@ -1,0 +1,19 @@
+function<int> somenumber(props []{any}, value int) {
+    return value
+}
+
+function<int> somesum(props []{any}, numbers *int) {
+    var<int> sum = 0
+    for number in numbers {
+        sum = sum + number
+    }
+    return sum
+}
+
+function<any> TEST() {
+    result := <somesum>
+        <somenumber [for index in 0..2]>{index}</somenumber>
+    </somesum>
+
+    return result == 3
+}

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -365,6 +365,18 @@ var scopeGraphTests = []scopegraphTest{
 		},
 		"", ""},
 
+	scopegraphTest{"sml loop success test", "sml", "loop",
+		[]expectedScopeEntry{
+			expectedScopeEntry{"something", expectedScope{true, proto.ScopeKind_VALUE, "Integer", "void"}},
+		},
+		"", ""},
+
+	scopegraphTest{"sml inline loop success test", "sml", "inlineloop",
+		[]expectedScopeEntry{
+			expectedScopeEntry{"something", expectedScope{true, proto.ScopeKind_VALUE, "Integer", "void"}},
+		},
+		"", ""},
+
 	scopegraphTest{"sml expression unknown ref test", "sml", "unknownref",
 		[]expectedScopeEntry{},
 		"The name 'something' could not be found in this context", ""},

--- a/graphs/scopegraph/tests/sml/inlineloop.seru
+++ b/graphs/scopegraph/tests/sml/inlineloop.seru
@@ -1,0 +1,13 @@
+function<bool> li(props []{any}, child any) {
+	return true
+}
+
+function<bool> ul(props []{any}, child any*) {
+	return true
+}
+
+function<void> DoSomething(somestream int*) {
+	<ul>
+		<li [for something in somestream]>{/* something */something}</li>
+	</ul>
+}

--- a/graphs/scopegraph/tests/sml/loop.seru
+++ b/graphs/scopegraph/tests/sml/loop.seru
@@ -1,0 +1,13 @@
+function<bool> li(props []{any}, child any) {
+	return true
+}
+
+function<bool> ul(props []{any}, child any*) {
+	return true
+}
+
+function<void> DoSomething(somestream int*) {
+	<ul>{
+		<li>{/* something */something}</li> for something in somestream
+	}</ul>
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -265,6 +265,7 @@ var parserTests = []parserTest{
 	{"nested property sml test", "sml/nestedprop"},
 	{"loop sml test", "sml/loop"},
 	{"multiline loop sml test", "sml/multilineloop"},
+	{"inline loop sml test", "sml/inlineloop"},
 
 	{"all expr test", "expression/all"},
 	{"complex expr test", "expression/complex"},

--- a/parser/tests/sml/inlineloop.seru
+++ b/parser/tests/sml/inlineloop.seru
@@ -1,0 +1,3 @@
+function<void> DoSomething() {
+	<ul><li [for something in somestream]>{something}</li></ul>
+}

--- a/parser/tests/sml/inlineloop.tree
+++ b/parser/tests/sml/inlineloop.tree
@@ -1,0 +1,70 @@
+NodeTypeFile
+  end-rune = 92
+  input-source = inline loop sml test
+  start-rune = 0
+  child-node =>
+    NodeTypeFunction
+      end-rune = 92
+      input-source = inline loop sml test
+      named = DoSomething
+      start-rune = 0
+      definition-body =>
+        NodeTypeStatementBlock
+          end-rune = 92
+          input-source = inline loop sml test
+          start-rune = 29
+          block-child =>
+            NodeTypeExpressionStatement
+              end-rune = 91
+              input-source = inline loop sml test
+              start-rune = 32
+              expr-statement-expr =>
+                NodeTypeSmlExpression
+                  end-rune = 90
+                  input-source = inline loop sml test
+                  start-rune = 32
+                  sml-expression-child =>
+                    NodeTypeLoopExpression
+                      end-rune = 86
+                      input-source = inline loop sml test
+                      start-rune = 36
+                      loop-expr-map-expr =>
+                        NodeTypeSmlExpression
+                          end-rune = 85
+                          input-source = inline loop sml test
+                          start-rune = 36
+                          sml-expression-child =>
+                            NodeTypeIdentifierExpression
+                              end-rune = 79
+                              identexpr-name = something
+                              input-source = inline loop sml test
+                              start-rune = 71
+                          sml-expression-typefunc =>
+                            NodeTypeIdentifierExpression
+                              end-rune = 38
+                              identexpr-name = li
+                              input-source = inline loop sml test
+                              start-rune = 37
+                      loop-expr-stream-expr =>
+                        NodeTypeIdentifierExpression
+                          end-rune = 67
+                          identexpr-name = somestream
+                          input-source = inline loop sml test
+                          start-rune = 58
+                      named-value =>
+                        NodeTypeNamedValue
+                          end-rune = 53
+                          input-source = inline loop sml test
+                          named = something
+                          start-rune = 45
+                  sml-expression-typefunc =>
+                    NodeTypeIdentifierExpression
+                      end-rune = 34
+                      identexpr-name = ul
+                      input-source = inline loop sml test
+                      start-rune = 33
+      typemember-return-type =>
+        NodeTypeVoid
+          end-rune = 12
+          input-source = inline loop sml test
+          start-rune = 9


### PR DESCRIPTION
Introduces a new syntax into SML to make looping easier:

```seru
<SomeTag [for something in somestream]>...</SomeTag>
```

The above will repeat the `SomeTag` as if written as:

```seru
<SomeTag>...</SomeTag> for something in somestream
```