### PR TITLE
Fix bug in generic type caching

### DIFF
--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -303,6 +303,8 @@ var generationTests = []generationTest{
 
 	generationTest{"native new integration test", "nativenew", "nativenew", integrationTestSuccessExpected, ""},
 	generationTest{"dynamic access non-promising test", "dynamicaccess", "nonpromising", integrationTestSuccessExpected, ""},
+
+	generationTest{"cached generic types test", "runtime", "cachedgenerictypes", integrationTestSuccessExpected, ""},
 }
 
 func TestGenerator(t *testing.T) {

--- a/generator/es5/runtime.go
+++ b/generator/es5/runtime.go
@@ -1070,14 +1070,14 @@ this.Serulian = (function($global) {
             }
 
             // Check for a cached version of the generic type.
-            var cached = module[fullName];
+            var cached = module[fullId];
             if (cached) {
               return cached;
             }
 
             var tpe = buildType(fullId + '>', fullName, generics);
             tpe.$generic = genericType;
-            return module[fullName] = tpe;
+            return module[fullId] = tpe;
           };
         } else {
           module[name] = buildType(typeId, name);

--- a/generator/es5/tests/runtime/cachedgenerictypes.js
+++ b/generator/es5/tests/runtime/cachedgenerictypes.js
@@ -1,0 +1,30 @@
+$module('cachedgenerictypes', function () {
+  var $static = this;
+  this.$class('d23601e8', 'Boolean', false, '', function () {
+    var $static = this;
+    var $instance = this.prototype;
+    $static.new = function () {
+      var instance = new $static();
+      return instance;
+    };
+    this.$typesig = function () {
+      return {
+      };
+    };
+  });
+
+  $static.TEST = function () {
+    var firstMapping;
+    var secondMapping;
+    firstMapping = $g.________testlib.basictypes.Mapping($g.cachedgenerictypes.Boolean).Empty();
+    secondMapping = $g.________testlib.basictypes.Mapping($g.________testlib.basictypes.Boolean).overObject((function () {
+      var obj = {
+      };
+      obj["somekey"] = $t.fastbox(true, $g.________testlib.basictypes.Boolean);
+      return obj;
+    })());
+    return $t.syncnullcompare(secondMapping.$index($t.fastbox('somekey', $g.________testlib.basictypes.String)), function () {
+      return $t.fastbox(false, $g.________testlib.basictypes.Boolean);
+    });
+  };
+});

--- a/generator/es5/tests/runtime/cachedgenerictypes.seru
+++ b/generator/es5/tests/runtime/cachedgenerictypes.seru
@@ -1,0 +1,15 @@
+class Boolean {}
+
+function<any> TEST() {
+    // Create a Mapping<Boolean> where Boolean is defined here. This will prime the cache with that type.
+    firstMapping := []{Boolean}{}
+
+    // Create another Mapping<Boolean>, but with the core type. If caching is working correctly, this will
+    // be given a *different* class, rather than the same as above (which was the behavior the bug was causing).
+    secondMapping := []{bool}{
+        "somekey": true,
+    }
+
+    // Access a key, which forces a cast, and will ensure things work so long as type caching is not broken.
+    return secondMapping['somekey'] ?? false
+}

--- a/generator/es5/tests/sourcemapping/basic.js
+++ b/generator/es5/tests/sourcemapping/basic.js
@@ -759,13 +759,13 @@ this.Serulian = (function ($global) {
               fullId = fullId + arguments[i].$typeId;
               generics[i] = arguments[i];
             }
-            var cached = module[fullName];
+            var cached = module[fullId];
             if (cached) {
               return cached;
             }
             var tpe = buildType(fullId + '>', fullName, generics);
             tpe.$generic = genericType;
-            return module[fullName] = tpe;
+            return module[fullId] = tpe;
           };
         } else {
           module[name] = buildType(typeId, name);


### PR DESCRIPTION
We were previously using the type's *name* as the caching key, instead of its ID. Unfortunately, if any type shared its name with another type (like, for example, `Boolean` the native type and `Boolean` the core type), the cache would return an incorrect type class, breaking code.

Also adds a test to ensure this doesn't occur again.