### PR TITLE
Fix module naming and pathing for paths containing dots

### DIFF
--- a/generator/es5/shared/es5pather.go
+++ b/generator/es5/shared/es5pather.go
@@ -168,6 +168,7 @@ func (p Pather) GetRelativeModulePath(module typegraph.TGModule) string {
 }
 
 var allowedModulePathCharacters, _ = regexp.Compile("[^a-zA-Z_0-9\\$\\.]")
+var allowedPathPartCharacters, _ = regexp.Compile("[^a-zA-Z_0-9\\$]")
 
 func normalizeModulePath(rel string) string {
 	if rel == "" {
@@ -204,6 +205,8 @@ func normalizeModulePath(rel string) string {
 			newPart = "m$" + part
 		}
 
+		// Ensure any non-identifier pieces are replaced with a dash.
+		newPart = allowedPathPartCharacters.ReplaceAllLiteralString(newPart, "_")
 		updatedParts = append(updatedParts, newPart)
 	}
 

--- a/generator/es5/shared/es5pather_test.go
+++ b/generator/es5/shared/es5pather_test.go
@@ -27,6 +27,9 @@ var normalizeTests = []normalizeTest{
 	normalizeTest{"123/456/789", "m$123.m$456.m$789"},
 	normalizeTest{"foo/../bar", "foo.__bar"},
 	normalizeTest{"../../bar", "____bar"},
+	normalizeTest{"v0.0.1/bar", "v0_0_1.bar"},
+	normalizeTest{"/v0.0.1/bar", "v0_0_1.bar"},
+	normalizeTest{"/*.0.1/bar", "m$__0_1.bar"},
 }
 
 func TestNormalizeModulePath(t *testing.T) {


### PR DESCRIPTION
This was breaking on a module named `v0.0.1`