### PR TITLE
Add validation of basic types during typegraph construction

### DIFF
--- a/graphs/scopegraph/scopegraph.go
+++ b/graphs/scopegraph/scopegraph.go
@@ -192,7 +192,15 @@ func ParseAndBuildScopeGraphWithConfig(config Config) (Result, error) {
 	// Construct the type graph.
 	resolver := typerefresolver.NewResolver(sourcegraph)
 	srgConstructor := srgtc.GetConstructorWithResolver(sourcegraph, resolver)
-	typeResult := typegraph.BuildTypeGraph(sourcegraph.Graph, webidl.TypeConstructor(), srgConstructor)
+	typeResult, err := typegraph.BuildTypeGraph(sourcegraph.Graph, webidl.TypeConstructor(), srgConstructor)
+	if err != nil {
+		return Result{
+			Status:   false,
+			Errors:   combineErrors(loaderResult.Errors, typeResult.Errors),
+			Warnings: combineWarnings(loaderResult.Warnings, typeResult.Warnings),
+		}, nil
+	}
+
 	if !typeResult.Status && !config.Target.continueWithErrors {
 		return Result{
 			Status:   false,

--- a/graphs/srg/typeconstructor/typeconstructor_test.go
+++ b/graphs/srg/typeconstructor/typeconstructor_test.go
@@ -134,7 +134,7 @@ func TestGraphs(t *testing.T) {
 		}
 
 		// Construct the type graph.
-		result := typegraph.BuildTypeGraph(testSRG.Graph, testIDL.TypeConstructor(), GetConstructor(testSRG))
+		result, _ := typegraph.BuildTypeGraph(testSRG.Graph, testIDL.TypeConstructor(), GetConstructor(testSRG))
 
 		if test.expectedError == "" {
 			// Make sure we had no errors during construction.
@@ -181,7 +181,7 @@ func TestLookupReturnType(t *testing.T) {
 	}
 
 	// Construct the type graph.
-	result := typegraph.BuildTypeGraph(testSRG.Graph, testIDL.TypeConstructor(), GetConstructor(testSRG))
+	result, _ := typegraph.BuildTypeGraph(testSRG.Graph, testIDL.TypeConstructor(), GetConstructor(testSRG))
 	if !assert.True(t, result.Status, "Got error for TypeGraph construction: %v", result.Errors) {
 		return
 	}

--- a/graphs/typegraph/basictypes.go
+++ b/graphs/typegraph/basictypes.go
@@ -80,16 +80,6 @@ func (t *TypeGraph) StreamTypeReference(generic TypeReference) TypeReference {
 	return t.NewTypeReference(t.StreamType(), generic)
 }
 
-// ListTypeReference returns a new reference to the list type, with the given generic.
-func (t *TypeGraph) ListTypeReference(generic TypeReference) TypeReference {
-	return t.NewTypeReference(t.ListType(), generic)
-}
-
-// MapTypeReference returns a new reference to the map type, with the given generics.
-func (t *TypeGraph) MapTypeReference(key TypeReference, value TypeReference) TypeReference {
-	return t.NewTypeReference(t.MapType(), key, value)
-}
-
 // MappingTypeReference returns a new reference to the mapoing type, with the given generic.
 func (t *TypeGraph) MappingTypeReference(value TypeReference) TypeReference {
 	return t.NewTypeReference(t.MappingType(), value)
@@ -108,11 +98,6 @@ func (t *TypeGraph) ErrorTypeReference() TypeReference {
 // StringableTypeReference returns a reference to the stringable type.
 func (t *TypeGraph) StringableTypeReference() TypeReference {
 	return t.NewTypeReference(t.StringableType())
-}
-
-// MappableTypeReference returns a reference to the mappable type.
-func (t *TypeGraph) MappableTypeReference() TypeReference {
-	return t.NewTypeReference(t.MappableType())
 }
 
 // StreamableType returns the streamable type.
@@ -145,11 +130,6 @@ func (t *TypeGraph) FunctionType() TGTypeDecl {
 	return t.getGlobalAliasedType("function")
 }
 
-// MappableType returns the mappable type.
-func (t *TypeGraph) MappableType() TGTypeDecl {
-	return t.getGlobalAliasedType("mappable")
-}
-
 // StringableType returns the string type.
 func (t *TypeGraph) StringableType() TGTypeDecl {
 	return t.getGlobalAliasedType("stringable")
@@ -173,16 +153,6 @@ func (t *TypeGraph) FloatType() TGTypeDecl {
 // BoolType returns the boolean type.
 func (t *TypeGraph) BoolType() TGTypeDecl {
 	return t.getGlobalAliasedType("bool")
-}
-
-// ListType returns the list type.
-func (t *TypeGraph) ListType() TGTypeDecl {
-	return t.getGlobalAliasedType("list")
-}
-
-// MapType returns the map type.
-func (t *TypeGraph) MapType() TGTypeDecl {
-	return t.getGlobalAliasedType("map")
 }
 
 // ReleasableType returns the releasable type.
@@ -210,7 +180,7 @@ func (t *TypeGraph) SerializationParserType() TGTypeDecl {
 	return t.getGlobalAliasedType("$parser")
 }
 
-// SerializationStringifierType returns the $stringifier type.
+// SerializationStringifier returns the $stringifier type.
 func (t *TypeGraph) SerializationStringifier() TGTypeDecl {
 	return t.getGlobalAliasedType("$stringifier")
 }
@@ -223,4 +193,20 @@ func (t *TypeGraph) getGlobalAliasedType(alias string) TGTypeDecl {
 	}
 
 	return typeDecl
+}
+
+// validateBasicTypes checks if the expected basic types are found. If not, the error is returned.
+func (t *TypeGraph) validateBasicTypes() error {
+	return t.ensureBasicTypesExist("streamable", "slice", "mapping", "int", "string", "bool", "float64", "releasable", "error", "json", "$intstream", "$parser", "$stringifier")
+}
+
+func (t *TypeGraph) ensureBasicTypesExist(typeAliases ...string) error {
+	for _, typeAlias := range typeAliases {
+		_, found := t.LookupGlobalAliasedType(typeAlias)
+		if !found {
+			return fmt.Errorf("Missing expected basic type %v", typeAlias)
+		}
+	}
+
+	return nil
 }

--- a/graphs/typegraph/typegraph_testutil_construct.go
+++ b/graphs/typegraph/typegraph_testutil_construct.go
@@ -22,7 +22,8 @@ func newTestTypeGraph(graph *compilergraph.SerulianGraph, constructors ...TypeGr
 	fsg := graph.NewGraphLayer("test", fakeNodeTypeTagged)
 
 	constructors = append(constructors, &testBasicTypesConstructor{emptyTypeConstructor{}, fsg, nil})
-	return BuildTypeGraph(graph, constructors...).Graph
+	built, _ := BuildTypeGraphWithOption(graph, SkipBasicTypeValidation, constructors...)
+	return built.Graph
 }
 
 // parseTypeReferenceForTesting parses the given human-form of a type reference string into

--- a/webidl/typeconstructor/typeconstructor_test.go
+++ b/webidl/typeconstructor/typeconstructor_test.go
@@ -89,7 +89,6 @@ func TestGraphs(t *testing.T) {
 		}
 
 		testIRG := webidl.NewIRG(graph)
-
 		loader := packageloader.NewPackageLoader(packageloader.NewBasicConfig(graph.RootSourceFilePath, testIRG.SourceHandler()))
 
 		secondaryLibs := make([]packageloader.Library, 0)
@@ -103,7 +102,7 @@ func TestGraphs(t *testing.T) {
 		assert.True(t, irgResult.Status, "Got error for IRG construction %v: %s", test.name, irgResult.Errors)
 
 		// Construct the type graph.
-		result := typegraph.BuildTypeGraph(graph, GetConstructor(testIRG), typegraph.NewBasicTypesConstructor(graph))
+		result, _ := typegraph.BuildTypeGraphWithOption(graph, typegraph.SkipBasicTypeValidation, GetConstructor(testIRG), typegraph.NewBasicTypesConstructor(graph))
 
 		if test.expectedError == "" {
 			// Make sure we had no errors during construction.


### PR DESCRIPTION
This will ensure that if basic types are not present, the compiler doesn't panic. This is especially useful when Grok is loading a Handle, but basic types are either not yet fully present or not present