### PR TITLE
Fix panics when using Grok due to concurrent reads and writes

### DIFF
--- a/graphs/scopegraph/builder_appliers.go
+++ b/graphs/scopegraph/builder_appliers.go
@@ -1,0 +1,51 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package scopegraph
+
+import (
+	"strconv"
+
+	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/graphs/scopegraph/proto"
+)
+
+// noopScopeApplier is a scope applier that does nothing.
+type noopScopeApplier struct{}
+
+func (nsa noopScopeApplier) NodeScoped(node compilergraph.GraphNode, result proto.ScopeInfo) {}
+func (nsa noopScopeApplier) DecorateWithSecondaryLabel(node compilergraph.GraphNode, label proto.ScopeLabel) {
+}
+func (nsa noopScopeApplier) AddErrorForSourceNode(node compilergraph.GraphNode, message string)   {}
+func (nsa noopScopeApplier) AddWarningForSourceNode(node compilergraph.GraphNode, message string) {}
+
+// concreteScopeApplier is a scope applier that writes changes back to the scope graph using
+// the given modifier.
+type concreteScopeApplier struct {
+	modifier compilergraph.GraphLayerModifier
+}
+
+func (csa concreteScopeApplier) NodeScoped(node compilergraph.GraphNode, result proto.ScopeInfo) {
+	scopeNode := csa.modifier.CreateNode(NodeTypeResolvedScope)
+	scopeNode.DecorateWithTagged(NodePredicateScopeInfo, &result)
+	scopeNode.Connect(NodePredicateSource, node)
+}
+
+func (csa concreteScopeApplier) DecorateWithSecondaryLabel(node compilergraph.GraphNode, label proto.ScopeLabel) {
+	labelNode := csa.modifier.CreateNode(NodeTypeSecondaryLabel)
+	labelNode.Decorate(NodePredicateSecondaryLabelValue, strconv.Itoa(int(label)))
+	labelNode.Connect(NodePredicateLabelSource, node)
+}
+
+func (csa concreteScopeApplier) AddErrorForSourceNode(node compilergraph.GraphNode, message string) {
+	errorNode := csa.modifier.CreateNode(NodeTypeError)
+	errorNode.Decorate(NodePredicateNoticeMessage, message)
+	errorNode.Connect(NodePredicateNoticeSource, node)
+}
+
+func (csa concreteScopeApplier) AddWarningForSourceNode(node compilergraph.GraphNode, message string) {
+	warningNode := csa.modifier.CreateNode(NodeTypeWarning)
+	warningNode.Decorate(NodePredicateNoticeMessage, message)
+	warningNode.Connect(NodePredicateNoticeSource, node)
+}

--- a/graphs/scopegraph/scope_lambda_expr.go
+++ b/graphs/scopegraph/scope_lambda_expr.go
@@ -19,9 +19,9 @@ var _ = fmt.Printf
 func (sb *scopeBuilder) scopeLambdaExpression(node compilergraph.GraphNode, context scopeContext) proto.ScopeInfo {
 	if _, ok := node.TryGetNode(parser.NodeLambdaExpressionBlock); ok {
 		return sb.scopeFullLambaExpression(node, context)
-	} else {
-		return sb.scopeInlineLambaExpression(node, context)
 	}
+
+	return sb.scopeInlineLambaExpression(node, context)
 }
 
 // scopeFullLambaExpression scopes a fully defined lambda expression node in the SRG.
@@ -187,12 +187,10 @@ func (sb *scopeBuilder) inferLambdaParameterTypes(node compilergraph.GraphNode, 
 			}
 
 			sb.inferredParameterTypes.Set(string(inferenceParameter.NodeId), inferredType)
-			sb.modifier.Modify(inferenceParameter).DecorateWithTagged(NodePredicateInferredType, inferredType)
 		}
 	} else {
 		for _, inferenceParameter := range inferenceParameters {
 			sb.inferredParameterTypes.Set(string(inferenceParameter.NodeId), sb.sg.tdg.AnyTypeReference())
-			sb.modifier.Modify(inferenceParameter).DecorateWithTagged(NodePredicateInferredType, sb.sg.tdg.AnyTypeReference())
 		}
 	}
 }

--- a/graphs/scopegraph/scopecontext.go
+++ b/graphs/scopegraph/scopecontext.go
@@ -10,6 +10,15 @@ import (
 	"github.com/serulian/compiler/graphs/typegraph"
 )
 
+// scopeAccessOption defines the kind of access under which the scope
+// exists.
+type scopeAccessOption int
+
+const (
+	scopeGetAccess scopeAccessOption = iota
+	scopeSetAccess
+)
+
 // scopeContext represents the currently operating context for scoping, allowing for
 // scope-specific overrides of such items as types of expressions.
 type scopeContext struct {

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1624,8 +1624,9 @@ func TestGraphs(t *testing.T) {
 				continue
 			}
 
-			assert.Equal(t, 1, len(result.Errors), "Expected 1 error on test %v, found: %v", test.name, result.Errors)
-			assert.Equal(t, test.expectedError, result.Errors[0].Error(), "Error mismatch on test %v", test.name)
+			if assert.Equal(t, 1, len(result.Errors), "Expected 1 error on test %v, found: %v", test.name, result.Errors) {
+				assert.Equal(t, test.expectedError, result.Errors[0].Error(), "Error mismatch on test %v", test.name)
+			}
 			continue
 		} else {
 			if !assert.True(t, result.Status, "Expected success in scoping on test: %v\n%v\n%v", test.name, result.Errors, result.Warnings) {

--- a/graphs/scopegraph/scopegraph_types.go
+++ b/graphs/scopegraph/scopegraph_types.go
@@ -42,9 +42,6 @@ const (
 
 	// The error or warning message on a scope notice node.
 	NodePredicateNoticeMessage = "notice-message"
-
-	// Decorates a *SRG* node with its inferred type.
-	NodePredicateInferredType = "scope-inferred-type"
 )
 
 func (t NodeType) Name() string {

--- a/graphs/srg/parsing.go
+++ b/graphs/srg/parsing.go
@@ -1,0 +1,40 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package srg
+
+import (
+	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/parser"
+)
+
+// ParseExpression parses the given expression string and returns its node. Note that the
+// expression will be added to *its own layer*, which means it will not be accessible from
+// the normal SRG layer.
+func ParseExpression(expressionString string, source compilercommon.InputSource, startRune int) (compilergraph.GraphNode, bool) {
+	graph, err := compilergraph.NewGraph(string(source))
+	if err != nil {
+		return compilergraph.GraphNode{}, false
+	}
+
+	layer := graph.NewGraphLayer("exprlayer", parser.NodeTypeTagged)
+	defer layer.Freeze()
+
+	modifier := layer.NewModifier()
+	defer modifier.Apply()
+
+	astNode, ok := parser.ParseExpression(func(source compilercommon.InputSource, kind parser.NodeType) parser.AstNode {
+		graphNode := modifier.CreateNode(kind)
+		return &srgASTNode{
+			graphNode: graphNode,
+		}
+	}, source, startRune, expressionString)
+
+	if !ok {
+		return compilergraph.GraphNode{}, false
+	}
+
+	return astNode.(*srgASTNode).graphNode.AsNode(), true
+}

--- a/graphs/typegraph/typegraph.go
+++ b/graphs/typegraph/typegraph.go
@@ -66,6 +66,7 @@ func BuildTypeGraphWithOption(graph *compilergraph.SerulianGraph, validateBasicT
 		globalAliasedTypes: map[string]TGTypeDecl{},
 		constructors:       constructors,
 	}
+	defer typeGraph.layer.Freeze()
 
 	// Create a struct to hold the results of the construction.
 	result := &Result{

--- a/graphs/typegraph/typegraph_testutil_construct.go
+++ b/graphs/typegraph/typegraph_testutil_construct.go
@@ -23,6 +23,7 @@ func newTestTypeGraph(graph *compilergraph.SerulianGraph, constructors ...TypeGr
 
 	constructors = append(constructors, &testBasicTypesConstructor{emptyTypeConstructor{}, fsg, nil})
 	built, _ := BuildTypeGraphWithOption(graph, SkipBasicTypeValidation, constructors...)
+	built.Graph.layer.Unfreeze()
 	return built.Graph
 }
 

--- a/grok/handle_completion.go
+++ b/grok/handle_completion.go
@@ -108,8 +108,7 @@ func (gh Handle) addAccessCompletions(node compilergraph.GraphNode, activationSt
 	// Parse the activation string into an expression.
 	source := compilercommon.InputSource(node.Get(parser.NodePredicateSource))
 	startRune := node.GetValue(parser.NodePredicateStartRune).Int()
-
-	parsed, ok := gh.scopeResult.Graph.SourceGraph().ParseExpression(expressionString, source, startRune)
+	parsed, ok := srg.ParseExpression(expressionString, source, startRune)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
Fixes panics inside the Cayley memstore (which does not support concurrent reads and writes), caused by Grok (accidentally) modifying already constructed graphs. To accomplish this safely, we now have a concept of freezing on graph layers, which is called after each layer has finished construction. Once frozen, any attempt to instantiate or use a modifier on the layer will *immediately* panic, ensuring that concurrent reads and writes do not occur.