### PR TITLE
Fix error handling of invalid typegraph construction

### DIFF
--- a/graphs/scopegraph/scopegraph.go
+++ b/graphs/scopegraph/scopegraph.go
@@ -199,11 +199,7 @@ func ParseAndBuildScopeGraphWithConfig(config Config) (Result, error) {
 	srgConstructor := srgtc.GetConstructorWithResolver(sourcegraph, resolver)
 	typeResult, err := typegraph.BuildTypeGraph(sourcegraph.Graph, webidl.TypeConstructor(), srgConstructor)
 	if err != nil {
-		return Result{
-			Status:   false,
-			Errors:   combineErrors(loaderResult.Errors, typeResult.Errors),
-			Warnings: combineWarnings(loaderResult.Warnings, typeResult.Warnings),
-		}, nil
+		return Result{}, err
 	}
 
 	if !typeResult.Status && !config.Target.continueWithErrors {

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1759,3 +1759,10 @@ func TestBuildTransientScope(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildWithInvalidTypeGraph(t *testing.T) {
+	// Load the file without a corelib, which should fail.
+	entrypointFile := "tests/transient/transient.seru"
+	_, err := ParseAndBuildScopeGraph(entrypointFile, []string{})
+	assert.NotNil(t, err, "Expected error when constructing the scope graph")
+}

--- a/grok/handle_test.go
+++ b/grok/handle_test.go
@@ -1,0 +1,21 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grok
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/serulian/compiler/packageloader"
+)
+
+func TestInvalidGrokHandle(t *testing.T) {
+	// Load a Grok handle without a valid core library and ensure we get back an error.
+	testSourcePath := "tests/basic/basic.seru"
+	groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{})
+	_, err := groker.GetHandle()
+	assert.NotNil(t, err, "Expected error for Grok handle")
+}


### PR DESCRIPTION
An error in typegraph construction should not return a valid scopegraph or Grok Handle, which, if returned, can lead to a panic.