### PR TITLE
Add a new toolkit command: package diff

### DIFF
--- a/compilercommon/source.go
+++ b/compilercommon/source.go
@@ -92,6 +92,9 @@ type SourceRange interface {
 
 	// AtStartPosition returns a SourceRange located only at the starting position of this range.
 	AtStartPosition() SourceRange
+
+	// String returns a (somewhat) human-readable form of the range.
+	String() string
 }
 
 // SourcePosition represents a single position in a source file.
@@ -107,6 +110,9 @@ type SourcePosition interface {
 
 	// LineText returns the text of the line for this position.
 	LineText() (string, error)
+
+	// String returns a (somewhat) human-readable form of the position.
+	String() string
 }
 
 // sourceRange implements the SourceRange interface.
@@ -153,6 +159,10 @@ func (sr sourceRange) ContainsPosition(position SourcePosition) (bool, error) {
 	}
 
 	return positionRune >= startRune && positionRune <= endRune, nil
+}
+
+func (sr sourceRange) String() string {
+	return fmt.Sprintf("%v -> %v", sr.start, sr.end)
 }
 
 // runeIndexedPosition implements the SourcePosition interface over a rune position.

--- a/compilerutil/console.go
+++ b/compilerutil/console.go
@@ -11,7 +11,7 @@ import (
 
 	"strings"
 
-	"github.com/fatih/color"
+	color "github.com/fatih/color"
 	"github.com/kr/text"
 	terminal "github.com/wayneashleyberry/terminal-dimensions"
 )
@@ -27,44 +27,58 @@ const (
 	ErrorLogLevel
 )
 
+var (
+	InfoColor       = color.New(color.FgBlue, color.Bold)
+	SuccessColor    = color.New(color.FgGreen, color.Bold)
+	WarningColor    = color.New(color.FgYellow, color.Bold)
+	ErrorColor      = color.New(color.FgRed, color.Bold)
+	BoldWhiteColor  = color.New(color.FgWhite, color.Bold)
+	FaintWhiteColor = color.New(color.FgWhite, color.Faint)
+	MessageColor    = color.New(color.FgHiWhite)
+)
+
 // LogToConsole logs a message to the console, with the given level and range.
 func LogToConsole(level ConsoleLogLevel, sourceRange compilercommon.SourceRange, message string, args ...interface{}) {
-	width, _ := terminal.Width()
-	if width <= 0 {
-		width = 80
-	}
-
-	locationColor := color.New(color.FgWhite)
-	messageColor := color.New(color.FgHiWhite)
-	codeColor := color.New(color.FgWhite)
 	prefixColor := color.New(color.FgWhite)
-
 	prefixText := ""
 
 	switch level {
 	case InfoLogLevel:
-		prefixColor = color.New(color.FgBlue, color.Bold)
+		prefixColor = InfoColor
 		prefixText = "INFO: "
 
 	case SuccessLogLevel:
-		prefixColor = color.New(color.FgGreen, color.Bold)
+		prefixColor = SuccessColor
 		prefixText = "SUCCESS: "
 
 	case WarningLogLevel:
-		prefixColor = color.New(color.FgYellow, color.Bold)
+		prefixColor = WarningColor
 		prefixText = "WARNING: "
 
 	case ErrorLogLevel:
-		prefixColor = color.New(color.FgRed, color.Bold)
+		prefixColor = ErrorColor
 		prefixText = "ERROR: "
 	}
 
+	LogMessageToConsole(prefixColor, prefixText, sourceRange, message, args...)
+}
+
+// LogMessageToConsole logs a message to the console, with the given level and range.
+func LogMessageToConsole(prefixColor *color.Color, prefixText string, sourceRange compilercommon.SourceRange, message string, args ...interface{}) {
 	formattedMessage := fmt.Sprintf(message, args...)
 
 	if sourceRange == nil {
 		prefixColor.Print(prefixText)
-		messageColor.Printf("%s\n", formattedMessage)
+		MessageColor.Printf("%s\n", formattedMessage)
 		return
+	}
+
+	locationColor := color.New(color.FgWhite)
+	codeColor := color.New(color.FgWhite)
+
+	width, _ := terminal.Width()
+	if width <= 0 {
+		width = 80
 	}
 
 	startLine, startCol, err := sourceRange.Start().LineAndColumn()
@@ -86,11 +100,11 @@ func LogToConsole(level ConsoleLogLevel, sourceRange compilercommon.SourceRange,
 	if len(prefixText+locationText+formattedMessage) > int(width) {
 		prefixColor.Print(prefixText)
 		locationColor.Print(locationText)
-		messageColor.Printf("\n%s\n\n", text.Indent(text.Wrap(formattedMessage, int(width)-len(INDENTATION)), INDENTATION))
+		MessageColor.Printf("\n%s\n\n", text.Indent(text.Wrap(formattedMessage, int(width)-len(INDENTATION)), INDENTATION))
 	} else {
 		prefixColor.Print(prefixText)
 		locationColor.Print(locationText)
-		messageColor.Printf(" %s\n", formattedMessage)
+		MessageColor.Printf(" %s\n", formattedMessage)
 	}
 
 	// Print the actual code line, and annotate the range.

--- a/generator/es5/generate_member.go
+++ b/generator/es5/generate_member.go
@@ -20,7 +20,7 @@ import (
 // generateImplementedMembers generates all the members under the given type or module into ES5.
 func (gen *es5generator) generateImplementedMembers(typeOrModule typegraph.TGTypeOrModule) *ordered_map.OrderedMap {
 	memberMap := ordered_map.NewOrderedMap()
-	members := typeOrModule.Members()
+	members := typeOrModule.MembersAndOperators()
 	for _, member := range members {
 		// Check for a base member. If one exists, generate the member has an aliased member.
 		_, hasBaseMember := member.BaseMember()

--- a/graphs/typegraph/diff/diff.go
+++ b/graphs/typegraph/diff/diff.go
@@ -10,8 +10,14 @@ import (
 	"github.com/serulian/compiler/graphs/typegraph"
 )
 
+// TypeGraphInformation specifies the graph information for a type graph to be diff-ed.
 type TypeGraphInformation struct {
-	Graph           *typegraph.TypeGraph
+	// Graph is the type graph to diff.
+	Graph *typegraph.TypeGraph
+
+	// PackageRootPath is the root path from which the type graph was constructed. Used
+	// to normalize all package paths relative to the root, for easy comparison across
+	// type graphs.
 	PackageRootPath string
 }
 

--- a/graphs/typegraph/diff/diff_test.go
+++ b/graphs/typegraph/diff/diff_test.go
@@ -280,6 +280,13 @@ var sourceDiffTests = []string{
 	"memberchanged",
 	"unexportedmemberchanged",
 	"nullableparameteradded",
+	"generics",
+	"withwebidl",
+	"withwebidlchanges",
+	"withcorelibref",
+	"withwebidlsubpackage",
+	"operatorchanged",
+	"operatorsame",
 }
 
 func TestSourcedDiff(t *testing.T) {

--- a/graphs/typegraph/diff/diff_test.go
+++ b/graphs/typegraph/diff/diff_test.go
@@ -287,6 +287,9 @@ var sourceDiffTests = []string{
 	"withwebidlsubpackage",
 	"operatorchanged",
 	"operatorsame",
+	"fieldadded",
+	"interfacefunctionadded",
+	"nonrequiredfieldadded",
 }
 
 func TestSourcedDiff(t *testing.T) {

--- a/graphs/typegraph/diff/test/fieldadded/diff.json
+++ b/graphs/typegraph/diff/test/fieldadded/diff.json
@@ -1,0 +1,29 @@
+{
+    "Packages": {
+        "fieldadded": {
+            "Kind": "changed",
+            "Path": "fieldadded",
+            "ChangeReason": 8,
+            "Types": [
+                {
+                    "Kind": "changed",
+                    "Name": "SomeClass",
+                    "ChangeReason": 1152,
+                    "Members": [
+                        {
+                            "Kind": "added",
+                            "Name": "SomeField",
+                            "ChangeReason": 0
+                        },
+                        {
+                            "Kind": "same",
+                            "Name": "new",
+                            "ChangeReason": 0
+                        }
+                    ]
+                }
+            ],
+            "Members": []
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/fieldadded/original.seru
+++ b/graphs/typegraph/diff/test/fieldadded/original.seru
@@ -1,0 +1,1 @@
+class SomeClass {}

--- a/graphs/typegraph/diff/test/fieldadded/updated.seru
+++ b/graphs/typegraph/diff/test/fieldadded/updated.seru
@@ -1,0 +1,3 @@
+class SomeClass {
+	var<int> SomeField
+}

--- a/graphs/typegraph/diff/test/generics/diff.json
+++ b/graphs/typegraph/diff/test/generics/diff.json
@@ -1,0 +1,35 @@
+{
+    "Packages": {
+        "generics": {
+            "Kind": "same",
+            "Path": "generics",
+            "ChangeReason": 0,
+            "Types": [
+                {
+                    "Kind": "same",
+                    "Name": "SomeClass",
+                    "ChangeReason": 0,
+                    "Members": [
+                        {
+                            "Kind": "same",
+                            "Name": "DoSomething",
+                            "ChangeReason": 0
+                        },
+                        {
+                            "Kind": "same",
+                            "Name": "new",
+                            "ChangeReason": 0
+                        }
+                    ]
+                }
+            ],
+            "Members": [
+                {
+                    "Kind": "same",
+                    "Name": "DoSomething",
+                    "ChangeReason": 0
+                }
+            ]
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/generics/original.seru
+++ b/graphs/typegraph/diff/test/generics/original.seru
@@ -1,0 +1,7 @@
+class SomeClass<T1, Q1> {
+    function<void> DoSomething<R1, S1>(param1 T1, param2 Q1, param3 R1, param4 S1) {
+    }
+}
+
+function<void> DoSomething<R2, S2>(param3 R2, param4 S2) {
+}

--- a/graphs/typegraph/diff/test/generics/updated.seru
+++ b/graphs/typegraph/diff/test/generics/updated.seru
@@ -1,0 +1,7 @@
+class SomeClass<T1, Q1> {
+    function<void> DoSomething<R1, S1>(param1 T1, param2 Q1, param3 R1, param4 S1) {
+    }
+}
+
+function<void> DoSomething<R2, S2>(param3 R2, param4 S2) {
+}

--- a/graphs/typegraph/diff/test/interfacefunctionadded/diff.json
+++ b/graphs/typegraph/diff/test/interfacefunctionadded/diff.json
@@ -1,0 +1,24 @@
+{
+    "Packages": {
+        "interfacefunctionadded": {
+            "Kind": "changed",
+            "Path": "interfacefunctionadded",
+            "ChangeReason": 8,
+            "Types": [
+                {
+                    "Kind": "changed",
+                    "Name": "SomeInterface",
+                    "ChangeReason": 1152,
+                    "Members": [
+                        {
+                            "Kind": "added",
+                            "Name": "SomeFunction",
+                            "ChangeReason": 0
+                        }
+                    ]
+                }
+            ],
+            "Members": []
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/interfacefunctionadded/original.seru
+++ b/graphs/typegraph/diff/test/interfacefunctionadded/original.seru
@@ -1,0 +1,1 @@
+interface SomeInterface {}

--- a/graphs/typegraph/diff/test/interfacefunctionadded/updated.seru
+++ b/graphs/typegraph/diff/test/interfacefunctionadded/updated.seru
@@ -1,0 +1,3 @@
+interface SomeInterface {
+	function<void> SomeFunction()
+}

--- a/graphs/typegraph/diff/test/nonrequiredfieldadded/diff.json
+++ b/graphs/typegraph/diff/test/nonrequiredfieldadded/diff.json
@@ -1,0 +1,29 @@
+{
+    "Packages": {
+        "nonrequiredfieldadded": {
+            "Kind": "changed",
+            "Path": "nonrequiredfieldadded",
+            "ChangeReason": 8,
+            "Types": [
+                {
+                    "Kind": "changed",
+                    "Name": "SomeClass",
+                    "ChangeReason": 128,
+                    "Members": [
+                        {
+                            "Kind": "added",
+                            "Name": "SomeField",
+                            "ChangeReason": 0
+                        },
+                        {
+                            "Kind": "same",
+                            "Name": "new",
+                            "ChangeReason": 0
+                        }
+                    ]
+                }
+            ],
+            "Members": []
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/nonrequiredfieldadded/original.seru
+++ b/graphs/typegraph/diff/test/nonrequiredfieldadded/original.seru
@@ -1,0 +1,1 @@
+class SomeClass {}

--- a/graphs/typegraph/diff/test/nonrequiredfieldadded/updated.seru
+++ b/graphs/typegraph/diff/test/nonrequiredfieldadded/updated.seru
@@ -1,0 +1,3 @@
+class SomeClass {
+	var<int> SomeField = 42
+}

--- a/graphs/typegraph/diff/test/operatorchanged/diff.json
+++ b/graphs/typegraph/diff/test/operatorchanged/diff.json
@@ -1,0 +1,29 @@
+{
+    "Packages": {
+        "operatorchanged": {
+            "Kind": "changed",
+            "Path": "operatorchanged",
+            "ChangeReason": 8,
+            "Types": [
+                {
+                    "Kind": "changed",
+                    "Name": "SomeClass",
+                    "ChangeReason": 512,
+                    "Members": [
+                        {
+                            "Kind": "same",
+                            "Name": "new",
+                            "ChangeReason": 0
+                        },
+                        {
+                            "Kind": "changed",
+                            "Name": "•equals",
+                            "ChangeReason": 2
+                        }
+                    ]
+                }
+            ],
+            "Members": []
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/operatorchanged/original.seru
+++ b/graphs/typegraph/diff/test/operatorchanged/original.seru
@@ -1,0 +1,5 @@
+class SomeClass {
+	operator Equals(left SomeClass, right SomeClass) {
+		return true
+	}
+}

--- a/graphs/typegraph/diff/test/operatorchanged/updated.seru
+++ b/graphs/typegraph/diff/test/operatorchanged/updated.seru
@@ -1,0 +1,5 @@
+class SomeClass {
+	operator equals(left SomeClass, right SomeClass) {
+		return true
+	}
+}

--- a/graphs/typegraph/diff/test/operatorsame/diff.json
+++ b/graphs/typegraph/diff/test/operatorsame/diff.json
@@ -1,0 +1,29 @@
+{
+    "Packages": {
+        "operatorsame": {
+            "Kind": "same",
+            "Path": "operatorsame",
+            "ChangeReason": 0,
+            "Types": [
+                {
+                    "Kind": "same",
+                    "Name": "SomeClass",
+                    "ChangeReason": 0,
+                    "Members": [
+                        {
+                            "Kind": "same",
+                            "Name": "new",
+                            "ChangeReason": 0
+                        },
+                        {
+                            "Kind": "same",
+                            "Name": "•equals",
+                            "ChangeReason": 0
+                        }
+                    ]
+                }
+            ],
+            "Members": []
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/operatorsame/original.seru
+++ b/graphs/typegraph/diff/test/operatorsame/original.seru
@@ -1,0 +1,5 @@
+class SomeClass {
+	operator Equals(left SomeClass, right SomeClass) {
+		return true
+	}
+}

--- a/graphs/typegraph/diff/test/operatorsame/updated.seru
+++ b/graphs/typegraph/diff/test/operatorsame/updated.seru
@@ -1,0 +1,5 @@
+class SomeClass {
+	operator Equals(left SomeClass, right SomeClass) {
+		return true
+	}
+}

--- a/graphs/typegraph/diff/test/withcorelibref/diff.json
+++ b/graphs/typegraph/diff/test/withcorelibref/diff.json
@@ -1,0 +1,22 @@
+{
+    "Packages": {
+        "withcorelibref": {
+            "Kind": "same",
+            "Path": "withcorelibref",
+            "ChangeReason": 0,
+            "Types": [],
+            "Members": [
+                {
+                    "Kind": "same",
+                    "Name": "DoSomething",
+                    "ChangeReason": 0
+                },
+                {
+                    "Kind": "changed",
+                    "Name": "anotherFunction",
+                    "ChangeReason": 16
+                }
+            ]
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/withcorelibref/original.seru
+++ b/graphs/typegraph/diff/test/withcorelibref/original.seru
@@ -1,0 +1,2 @@
+function<void> DoSomething(foo int, bar string) {}
+function<void> anotherFunction(foo bool, bar []string) {}

--- a/graphs/typegraph/diff/test/withcorelibref/updated.seru
+++ b/graphs/typegraph/diff/test/withcorelibref/updated.seru
@@ -1,0 +1,2 @@
+function<void> DoSomething(foo int, bar string) {}
+function<void> anotherFunction(foo []bool, bar string) {}

--- a/graphs/typegraph/diff/test/withwebidl/diff.json
+++ b/graphs/typegraph/diff/test/withwebidl/diff.json
@@ -1,0 +1,24 @@
+{
+    "Packages": {
+        "withwebidl": {
+            "Kind": "same",
+            "Path": "withwebidl",
+            "ChangeReason": 0,
+            "Types": [
+                {
+                    "Kind": "same",
+                    "Name": "SomeType",
+                    "ChangeReason": 0,
+                    "Members": []
+                }
+            ],
+            "Members": [
+                {
+                    "Kind": "same",
+                    "Name": "DoSomething",
+                    "ChangeReason": 0
+                }
+            ]
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/withwebidl/original.seru
+++ b/graphs/typegraph/diff/test/withwebidl/original.seru
@@ -1,0 +1,3 @@
+from webidl`original` import SomeType
+
+function<void> DoSomething(st SomeType) {}

--- a/graphs/typegraph/diff/test/withwebidl/original.webidl
+++ b/graphs/typegraph/diff/test/withwebidl/original.webidl
@@ -1,0 +1,2 @@
+interface SomeType {
+};

--- a/graphs/typegraph/diff/test/withwebidl/updated.seru
+++ b/graphs/typegraph/diff/test/withwebidl/updated.seru
@@ -1,0 +1,3 @@
+from webidl`updated` import SomeType
+
+function<void> DoSomething(st SomeType) {}

--- a/graphs/typegraph/diff/test/withwebidl/updated.webidl
+++ b/graphs/typegraph/diff/test/withwebidl/updated.webidl
@@ -1,0 +1,2 @@
+interface SomeType {
+};

--- a/graphs/typegraph/diff/test/withwebidlchanges/diff.json
+++ b/graphs/typegraph/diff/test/withwebidlchanges/diff.json
@@ -1,0 +1,30 @@
+{
+    "Packages": {
+        "withwebidlchanges": {
+            "Kind": "changed",
+            "Path": "withwebidlchanges",
+            "ChangeReason": 70,
+            "Types": [
+                {
+                    "Kind": "added",
+                    "Name": "SomeOtherType",
+                    "ChangeReason": 0,
+                    "Members": null
+                },
+                {
+                    "Kind": "removed",
+                    "Name": "SomeType",
+                    "ChangeReason": 0,
+                    "Members": null
+                }
+            ],
+            "Members": [
+                {
+                    "Kind": "changed",
+                    "Name": "DoSomething",
+                    "ChangeReason": 16
+                }
+            ]
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/withwebidlchanges/original.seru
+++ b/graphs/typegraph/diff/test/withwebidlchanges/original.seru
@@ -1,0 +1,3 @@
+from webidl`original` import SomeType
+
+function<void> DoSomething(st SomeType) {}

--- a/graphs/typegraph/diff/test/withwebidlchanges/original.webidl
+++ b/graphs/typegraph/diff/test/withwebidlchanges/original.webidl
@@ -1,0 +1,2 @@
+interface SomeType {
+};

--- a/graphs/typegraph/diff/test/withwebidlchanges/updated.seru
+++ b/graphs/typegraph/diff/test/withwebidlchanges/updated.seru
@@ -1,0 +1,3 @@
+from webidl`updated` import SomeOtherType
+
+function<void> DoSomething(st SomeOtherType) {}

--- a/graphs/typegraph/diff/test/withwebidlchanges/updated.webidl
+++ b/graphs/typegraph/diff/test/withwebidlchanges/updated.webidl
@@ -1,0 +1,2 @@
+interface SomeOtherType {
+};

--- a/graphs/typegraph/diff/test/withwebidlsubpackage/diff.json
+++ b/graphs/typegraph/diff/test/withwebidlsubpackage/diff.json
@@ -1,0 +1,31 @@
+{
+    "Packages": {
+        "withwebidlsubpackage": {
+            "Kind": "same",
+            "Path": "withwebidlsubpackage",
+            "ChangeReason": 0,
+            "Types": [],
+            "Members": [
+                {
+                    "Kind": "same",
+                    "Name": "DoSomething",
+                    "ChangeReason": 0
+                }
+            ]
+        },
+        "withwebidlsubpackage/sub": {
+            "Kind": "same",
+            "Path": "withwebidlsubpackage/sub",
+            "ChangeReason": 0,
+            "Types": [
+                {
+                    "Kind": "same",
+                    "Name": "SomeInterface",
+                    "ChangeReason": 0,
+                    "Members": []
+                }
+            ],
+            "Members": []
+        }
+    }
+}

--- a/graphs/typegraph/diff/test/withwebidlsubpackage/original.seru
+++ b/graphs/typegraph/diff/test/withwebidlsubpackage/original.seru
@@ -1,0 +1,3 @@
+from webidl`sub` import SomeInterface
+
+function<void> DoSomething(param SomeInterface) {}

--- a/graphs/typegraph/diff/test/withwebidlsubpackage/sub/some.webidl
+++ b/graphs/typegraph/diff/test/withwebidlsubpackage/sub/some.webidl
@@ -1,0 +1,1 @@
+interface SomeInterface {};

--- a/graphs/typegraph/diff/test/withwebidlsubpackage/updated.seru
+++ b/graphs/typegraph/diff/test/withwebidlsubpackage/updated.seru
@@ -1,0 +1,3 @@
+from webidl`sub` import SomeInterface
+
+function<void> DoSomething(param SomeInterface) {}

--- a/graphs/typegraph/diff/type_diff.go
+++ b/graphs/typegraph/diff/type_diff.go
@@ -129,6 +129,10 @@ func diffType(original typegraph.TGTypeDecl, updated typegraph.TGTypeDecl, conte
 				changeReason = changeReason | TypeDiffReasonExportedMembersAdded
 			}
 
+			if memberDiff.Updated.IsRequired() {
+				changeReason = changeReason | TypeDiffReasonRequiredMemberAdded
+			}
+
 		case Removed:
 			if memberDiff.Original.IsExported() {
 				changeReason = changeReason | TypeDiffReasonExportedMembersRemoved

--- a/graphs/typegraph/diff/util.go
+++ b/graphs/typegraph/diff/util.go
@@ -25,7 +25,7 @@ func getTypesAndMembers(modules []typegraph.TGModule) (map[string]typegraph.TGTy
 
 			types[typedecl.Name()] = typedecl
 		}
-		for _, member := range module.Members() {
+		for _, member := range module.MembersAndOperators() {
 			members[member.Name()] = member
 		}
 	}
@@ -49,12 +49,12 @@ func (thw typeHolderWrap) Types() []typegraph.TGTypeDecl {
 
 type memberHolderWrap map[string]typegraph.TGMember
 
-func (mhw memberHolderWrap) GetMember(name string) (typegraph.TGMember, bool) {
+func (mhw memberHolderWrap) GetMemberOrOperator(name string) (typegraph.TGMember, bool) {
 	member, ok := mhw[name]
 	return member, ok
 }
 
-func (mhw memberHolderWrap) Members() []typegraph.TGMember {
+func (mhw memberHolderWrap) MembersAndOperators() []typegraph.TGMember {
 	members := make([]typegraph.TGMember, 0, len(mhw))
 	for _, member := range mhw {
 		members = append(members, member)

--- a/graphs/typegraph/entity.go
+++ b/graphs/typegraph/entity.go
@@ -1,0 +1,46 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package typegraph
+
+import "github.com/serulian/compiler/compilergraph"
+
+// EntityKind defines the various kinds of entities in which types or members can
+// be found
+type EntityKind string
+
+const (
+	// EntityKindModule indicates the entity is a module.
+	EntityKindModule EntityKind = "module"
+
+	// EntityKindType indicates the entity is a type.
+	EntityKindType EntityKind = "type"
+
+	// EntityKindMember indicates the entity is a member.
+	EntityKindMember EntityKind = "member"
+)
+
+// Entity represents an entity: module, type, or member.
+type Entity struct {
+	// Kind is it the kind of the entity.
+	Kind EntityKind
+
+	// NameOrPath represents the name or path of the entity. If a module,
+	// this is the module's path. If a type, this is the type's name.
+	// If a member, this is the member's *child name*.
+	NameOrPath string
+
+	// SourceGraphId is the ID of the source graph for the type node. If none,
+	// this will be `typegraph`.
+	SourceGraphId string
+}
+
+// TGEntity represents any form of entity: module, member or type.
+type TGEntity interface {
+	Name() string
+	Node() compilergraph.GraphNode
+	IsType() bool
+	AsType() (TGTypeDecl, bool)
+	EntityPath() []Entity
+}

--- a/graphs/typegraph/internal_construction.go
+++ b/graphs/typegraph/internal_construction.go
@@ -440,7 +440,7 @@ func (g *TypeGraph) checkForDuplicateNames() bool {
 
 			// Check the members of the type.
 			typeMembers := map[string]bool{}
-			for _, typeMember := range typeDecl.Members() {
+			for _, typeMember := range typeDecl.MembersAndOperators() {
 				// Ensure the member name is unique.
 				ensureUniqueName(typeMember, typeDecl, typeMembers)
 

--- a/graphs/typegraph/packagenamemap.go
+++ b/graphs/typegraph/packagenamemap.go
@@ -24,7 +24,7 @@ func newPackageNameMap() packagenamemap {
 // instance seen. If it is not, then false and the existing type or member, under the
 // package, with the same name is returned.
 func (pnm packagenamemap) CheckAndTrack(module TGModule, typeOrMember TGTypeOrMember) (TGTypeOrMember, bool) {
-	key := fmt.Sprintf("%v::%v", module.PackagePath(), typeOrMember.Name())
+	key := fmt.Sprintf("%v::%v::%v", module.SourceGraphId(), module.PackagePath(), typeOrMember.Name())
 	if !pnm.internalmap.SetIfAbsent(key, typeOrMember) {
 		existing, _ := pnm.internalmap.Get(key)
 		return existing.(TGTypeOrMember), false

--- a/graphs/typegraph/typegraph_member.go
+++ b/graphs/typegraph/typegraph_member.go
@@ -324,6 +324,21 @@ func (tn TGMember) Generics() []TGGeneric {
 	return generics
 }
 
+// LookupGeneric looks up the generic under this member with the given name and returns it, if any.
+func (tn TGMember) LookupGeneric(name string) (TGGeneric, bool) {
+	node, found := tn.GraphNode.
+		StartQuery().
+		Out(NodePredicateMemberGeneric).
+		Has(NodePredicateGenericName, name).
+		TryGetNode()
+
+	if !found {
+		return TGGeneric{}, false
+	}
+
+	return TGGeneric{node, tn.tdg}, true
+}
+
 // Parameters returns the parameters on this member.
 func (tn TGMember) Parameters() []TGParameter {
 	it := tn.GraphNode.StartQuery().
@@ -484,6 +499,16 @@ func (tn TGMember) SourceGraphId() string {
 // TypeGraph returns the type graph that contains this member.
 func (tn TGMember) TypeGraph() *TypeGraph {
 	return tn.tdg
+}
+
+// EntityPath returns the path of entities that chain to this member.
+func (tn TGMember) EntityPath() []Entity {
+	parentEntities := tn.Parent().EntityPath()
+	return append(parentEntities, Entity{
+		Kind:          EntityKindMember,
+		NameOrPath:    tn.ChildName(),
+		SourceGraphId: tn.SourceGraphId(),
+	})
 }
 
 // Code returns a code-like summarization of the member, for human consumption.

--- a/graphs/typegraph/typegraph_member.go
+++ b/graphs/typegraph/typegraph_member.go
@@ -248,6 +248,22 @@ func (tn TGMember) InvokesAsync() bool {
 	return invokesAsync
 }
 
+// IsRequired returns whether this member is "required" under the parent type,
+// either by being a required field or by being the member of an interface that
+// is implemented.
+func (tn TGMember) IsRequired() bool {
+	if tn.IsRequiredField() {
+		return true
+	}
+
+	parentType, hasParentType := tn.ParentType()
+	if !hasParentType {
+		return false
+	}
+
+	return parentType.TypeKind() == ImplicitInterfaceType
+}
+
 // IsRequiredField returns whether this member is a field requiring initialization on
 // construction of an instance of the parent type.
 func (tn TGMember) IsRequiredField() bool {

--- a/graphs/typegraph/typegraph_moduledecl.go
+++ b/graphs/typegraph/typegraph_moduledecl.go
@@ -57,6 +57,11 @@ func (tn TGModule) Members() []TGMember {
 	return members
 }
 
+// MembersAndOperators returns the members defined in this module.
+func (tn TGModule) MembersAndOperators() []TGMember {
+	return tn.Members()
+}
+
 // GetMember finds the member under this module with the given name, if any.
 func (tn TGModule) GetMember(name string) (TGMember, bool) {
 	node, found := tn.GraphNode.StartQuery().
@@ -69,6 +74,11 @@ func (tn TGModule) GetMember(name string) (TGMember, bool) {
 	}
 
 	return TGMember{node, tn.tdg}, true
+}
+
+// GetMemberOrOperator finds the member under this module with the given *child* name, if any.
+func (tn TGModule) GetMemberOrOperator(name string) (TGMember, bool) {
+	return tn.GetMember(name)
 }
 
 // IsType returns whether this module is a type (always false).
@@ -98,6 +108,17 @@ func (tn TGModule) Types() []TGTypeDecl {
 	}
 
 	return types
+}
+
+// EntityPath returns the path of entities that chain to this module.
+func (tn TGModule) EntityPath() []Entity {
+	return []Entity{
+		Entity{
+			Kind:          EntityKindModule,
+			NameOrPath:    string(tn.Path()),
+			SourceGraphId: tn.SourceGraphId(),
+		},
+	}
 }
 
 // SourceGraphId returns the ID of the source graph from which this module originated.

--- a/graphs/typegraph/typegraph_typeormember.go
+++ b/graphs/typegraph/typegraph_typeormember.go
@@ -26,6 +26,7 @@ type TGTypeOrMember interface {
 	Node() compilergraph.GraphNode
 	Generics() []TGGeneric
 	HasGenerics() bool
+	LookupGeneric(name string) (TGGeneric, bool)
 	IsReadOnly() bool
 	IsType() bool
 	IsStatic() bool
@@ -41,4 +42,5 @@ type TGTypeOrMember interface {
 	IsAccessibleTo(modulePath compilercommon.InputSource) bool
 	AsType() (TGTypeDecl, bool)
 	Code() (compilercommon.CodeSummary, bool)
+	EntityPath() []Entity
 }

--- a/graphs/typegraph/typegraph_typeormodule.go
+++ b/graphs/typegraph/typegraph_typeormodule.go
@@ -13,10 +13,13 @@ type TGTypeOrModule interface {
 	Name() string
 	Node() compilergraph.GraphNode
 	Members() []TGMember
+	MembersAndOperators() []TGMember
 	Title() string
 	IsType() bool
 	ParentModule() TGModule
 	GetMember(name string) (TGMember, bool)
+	GetMemberOrOperator(name string) (TGMember, bool)
 	AsType() (TGTypeDecl, bool)
 	SourceGraphId() string
+	EntityPath() []Entity
 }

--- a/packagetools/packagetools.go
+++ b/packagetools/packagetools.go
@@ -1,0 +1,303 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package packagetools implements tools for working on Serulian packages.
+package packagetools
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/serulian/compiler/builder"
+	"github.com/serulian/compiler/compilerutil"
+	"github.com/serulian/compiler/graphs/scopegraph"
+	"github.com/serulian/compiler/graphs/typegraph"
+	"github.com/serulian/compiler/graphs/typegraph/diff"
+	"github.com/serulian/compiler/packageloader"
+	"github.com/serulian/compiler/vcs"
+)
+
+// OutputDiff outputs the diff between the Serulian package found at the given
+// path and the version found in the same repository with (optional) comparison
+// version. If the comparison version is not specified, then the latest semver
+// of the package is used (if any).
+func OutputDiff(packagePath string, comparisonVersion string, verbose bool, debug bool, vcsDevelopmentDirectories ...string) {
+	// Disable logging unless the debug flag is on.
+	if !debug {
+		log.SetOutput(ioutil.Discard)
+	}
+
+	// Ensure the package is VCS-backed.
+	handler, hasHandler := vcs.DetectHandler(packagePath)
+	if !hasHandler {
+		compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil,
+			"Path `%s` is not a valid Serulian package. Please make sure to point to the root of the Serulian package.", packagePath)
+		return
+	}
+
+	// List the tags and find the latest release or specified comparison version.
+	compilerutil.LogToConsole(compilerutil.InfoLogLevel, nil, "Listing versions for package...")
+
+	tags, err := handler.ListTags(packagePath)
+	if err != nil {
+		compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil,
+			"Could not list tags for package `%s`: %v", packagePath, err)
+		return
+	}
+
+	if comparisonVersion == "" {
+		foundVersion, found := compilerutil.LatestSemanticVersion(tags)
+		if !found {
+			compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil,
+				"Could not find a full semantic version for package `%s`. Package versions: %v", packagePath, tags)
+			return
+		}
+
+		comparisonVersion = foundVersion
+	} else {
+		var found = false
+		for _, version := range tags {
+			if version == comparisonVersion {
+				found = true
+				break
+			}
+		}
+		if !found {
+			compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil,
+				"Version `%s` not found for package `%s`. Package versions: %v", comparisonVersion, packagePath, tags)
+			return
+		}
+	}
+
+	// Retrieve the path information for the package.
+	pathInfo, err := handler.GetPackagePath(packagePath)
+	if err != nil {
+		compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil,
+			"Could not get path information for package `%s`: %v", packagePath, err)
+		return
+	}
+
+	// Checkout the comparison version into a temporary directory.
+	dir, err := ioutil.TempDir("", "package-diff")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer os.RemoveAll(dir)
+
+	compilerutil.LogToConsole(compilerutil.InfoLogLevel, nil, "Cloning version `%s`...", comparisonVersion)
+	cerr := handler.Checkout(pathInfo.WithTag(comparisonVersion), pathInfo.URL(), dir)
+	if cerr != nil {
+		compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil,
+			"Could not clone version `%s` for package `%s`: %v", comparisonVersion, packagePath, cerr)
+		return
+	}
+
+	// Scope and build both versions.
+	compilerutil.LogToConsole(compilerutil.InfoLogLevel, nil, "Analyzing version `%s`...", comparisonVersion)
+	originalGraph, ok := getTypeGraph(dir, vcsDevelopmentDirectories)
+	if !ok {
+		return
+	}
+
+	compilerutil.LogToConsole(compilerutil.InfoLogLevel, nil, "Analyzing HEAD...")
+	updatedGraph, ok := getTypeGraph(packagePath, vcsDevelopmentDirectories)
+	if !ok {
+		return
+	}
+
+	original := diff.TypeGraphInformation{Graph: originalGraph, PackageRootPath: dir}
+	updated := diff.TypeGraphInformation{Graph: updatedGraph, PackageRootPath: packagePath}
+	filter := func(module typegraph.TGModule) bool {
+		// Filter out any VCS loaded packages.
+		return !strings.Contains(module.PackagePath(), packageloader.SerulianPackageDirectory)
+	}
+
+	compilerutil.LogToConsole(compilerutil.InfoLogLevel, nil, "Computing Diff...")
+	computed := diff.ComputeDiff(original, updated, filter)
+
+	fmt.Println()
+
+	for _, packageDiff := range computed.Packages {
+		compilerutil.MessageColor.Print(comparisonVersion)
+		compilerutil.MessageColor.Print(" → ")
+		compilerutil.MessageColor.Print("HEAD")
+
+		if packageDiff.Kind == diff.Same {
+			compilerutil.MessageColor.Print(": No changes found\n")
+			break
+		}
+
+		if packageDiff.HasBreakingChange() {
+			compilerutil.MessageColor.Print(": ")
+			compilerutil.WarningColor.Print("Breaking changes found\n")
+		} else {
+			compilerutil.MessageColor.Print(": ")
+			compilerutil.SuccessColor.Print("Compatible changes found\n")
+		}
+
+		if verbose {
+			outputDetailedDiff(packageDiff)
+		}
+
+		// We only care about a single package.
+		break
+	}
+}
+
+func outputDetailedDiff(packageDiff diff.PackageDiff) {
+	compilerutil.BoldWhiteColor.Print("  Change summary:\n")
+	for _, change := range packageDiff.ChangeReason.Expand() {
+		compatibility, description := change.Describe()
+
+		if compatibility == diff.BackwardIncompatible {
+			compilerutil.ErrorColor.Print("    [Breaking]   ")
+		} else {
+			compilerutil.SuccessColor.Print("    [Compatible] ")
+		}
+
+		fmt.Println(description)
+	}
+
+	fmt.Println()
+	compilerutil.BoldWhiteColor.Print("  Detailed changes:\n")
+
+	indentation := "    "
+	numModified := 0
+	for _, typeDiff := range packageDiff.Types {
+		switch typeDiff.Kind {
+		case diff.Same:
+			continue
+
+		case diff.Added:
+			fmt.Print(indentation)
+			compilerutil.SuccessColor.Print("[+] ")
+			fmt.Printf("Type %s\n", typeDiff.Name)
+
+		case diff.Removed:
+			fmt.Print(indentation)
+			compilerutil.ErrorColor.Print("[X] ")
+			fmt.Printf("Type %s\n", typeDiff.Name)
+
+		case diff.Changed:
+			fmt.Print(indentation)
+			compilerutil.WarningColor.Print("[!] ")
+			fmt.Printf("Type %s\n", typeDiff.Name)
+			outputDetailedTypeDiff(typeDiff, 6)
+		}
+
+		numModified++
+	}
+
+	for _, memberDiff := range packageDiff.Members {
+		switch memberDiff.Kind {
+		case diff.Same:
+			continue
+
+		case diff.Added:
+			fmt.Print(indentation)
+			compilerutil.SuccessColor.Print("[+] ")
+			printMemberPathAndName(memberDiff.Updated)
+
+		case diff.Removed:
+			fmt.Print(indentation)
+			compilerutil.ErrorColor.Print("[X] ")
+			printMemberPathAndName(memberDiff.Original)
+
+		case diff.Changed:
+			fmt.Print(indentation)
+			compilerutil.WarningColor.Print("[!] ")
+			printMemberPathAndName(memberDiff.Original)
+			outputDetailedMemberDiff(memberDiff, 8)
+		}
+		numModified++
+	}
+
+	if numModified == 0 {
+		fmt.Printf("    No modified members or types found under this package")
+	}
+}
+
+func printMemberPathAndName(member *typegraph.TGMember) {
+	compilerutil.FaintWhiteColor.Print(member.Title())
+	fmt.Print(" ")
+	fmt.Print(member.Name())
+	fmt.Println()
+}
+
+func outputDetailedTypeDiff(typeDiff diff.TypeDiff, indentCount int) {
+	indentation := strings.Repeat(" ", indentCount)
+
+	for _, change := range typeDiff.ChangeReason.Expand() {
+		compatibility, description := change.Describe()
+
+		if compatibility == diff.BackwardIncompatible {
+			compilerutil.LogMessageToConsole(compilerutil.ErrorColor, indentation+"[Breaking]   ", nil, "%s", description)
+		} else {
+			compilerutil.LogMessageToConsole(compilerutil.SuccessColor, indentation+"[Compatible] ", nil, "%s", description)
+		}
+	}
+
+	fmt.Println("  ----- Modified Members ------")
+	numModified := 0
+	for _, memberDiff := range typeDiff.Members {
+		switch typeDiff.Kind {
+		case diff.Same:
+			continue
+
+		case diff.Added:
+			fmt.Print(indentation)
+			compilerutil.SuccessColor.Print("[+] ")
+			printMemberPathAndName(memberDiff.Updated)
+
+		case diff.Removed:
+			fmt.Print(indentation)
+			compilerutil.ErrorColor.Print("[X] ")
+			printMemberPathAndName(memberDiff.Original)
+
+		case diff.Changed:
+			fmt.Print(indentation)
+			compilerutil.WarningColor.Print("[!] ")
+			printMemberPathAndName(memberDiff.Original)
+			outputDetailedMemberDiff(memberDiff, indentCount+8)
+		}
+		numModified++
+	}
+
+	if numModified == 0 {
+		fmt.Printf(indentation + "  No modified members found under this type")
+	}
+}
+
+func outputDetailedMemberDiff(memberDiff diff.MemberDiff, indentCount int) {
+	indentation := strings.Repeat(" ", indentCount)
+
+	for _, change := range memberDiff.ChangeReason.Expand() {
+		compatibility, description := change.Describe()
+
+		if compatibility == diff.BackwardIncompatible {
+			compilerutil.LogMessageToConsole(compilerutil.ErrorColor, indentation+"[Breaking]   ", nil, "%s", description)
+		} else {
+			compilerutil.LogMessageToConsole(compilerutil.SuccessColor, indentation+"[Compatible] ", nil, "%s", description)
+		}
+	}
+}
+
+func getTypeGraph(packagePath string, vcsDevelopmentDirectories []string) (*typegraph.TypeGraph, bool) {
+	scopeResult, err := scopegraph.ParseAndBuildScopeGraph(packagePath, vcsDevelopmentDirectories, builder.CORE_LIBRARY)
+	if err != nil {
+		compilerutil.LogToConsole(compilerutil.ErrorLogLevel, nil, "%s", err.Error())
+		return nil, false
+	}
+
+	if !scopeResult.Status {
+		builder.OutputErrors(scopeResult.Errors)
+		return nil, false
+	}
+
+	return scopeResult.Graph.TypeGraph(), true
+}

--- a/vcs/handler_fakegit.go
+++ b/vcs/handler_fakegit.go
@@ -44,3 +44,7 @@ func (fgv fakeGitVcs) ListTags(checkoutDir string) ([]string, error) {
 func (fgv fakeGitVcs) IsDetached(checkoutDir string) (bool, error) {
 	panic("Fake git!")
 }
+
+func (fgv fakeGitVcs) GetPackagePath(checkoutDir string) (vcsPackagePath, error) {
+	panic("Fake git!")
+}

--- a/vcs/handler_fakegit.go
+++ b/vcs/handler_fakegit.go
@@ -1,0 +1,46 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"os"
+	"path"
+)
+
+type fakeGitVcs struct{}
+
+func (fgv fakeGitVcs) Kind() string {
+	return "__fake_git__"
+}
+
+func (fgv fakeGitVcs) Detect(checkoutDir string) bool {
+	gitDirectory := path.Join(checkoutDir, "_dot_git")
+	_, err := os.Stat(gitDirectory)
+	return !os.IsNotExist(err)
+}
+
+func (fgv fakeGitVcs) Checkout(path vcsPackagePath, downloadPath string, checkoutDir string) error {
+	panic("Fake git!")
+}
+
+func (fgv fakeGitVcs) HasLocalChanges(checkoutDir string) bool {
+	panic("Fake git!")
+}
+
+func (fgv fakeGitVcs) Update(checkoutDir string) error {
+	panic("Fake git!")
+}
+
+func (fgv fakeGitVcs) Inspect(checkoutDir string) (string, error) {
+	panic("Fake git!")
+}
+
+func (fgv fakeGitVcs) ListTags(checkoutDir string) ([]string, error) {
+	panic("Fake git!")
+}
+
+func (fgv fakeGitVcs) IsDetached(checkoutDir string) (bool, error) {
+	panic("Fake git!")
+}

--- a/vcs/handler_git.go
+++ b/vcs/handler_git.go
@@ -1,0 +1,152 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+type gitVcs struct{}
+
+func (gv gitVcs) Kind() string {
+	return "git"
+}
+
+func (gv gitVcs) Checkout(vcsPath vcsPackagePath, downloadPath string, checkoutDir string) error {
+	lock := modificationLockMap.GetLock(checkoutDir)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Make the new directory.
+	log.Printf("Making GIT package path: %s", checkoutDir)
+	err := os.MkdirAll(checkoutDir, 0744)
+	if err != nil {
+		return err
+	}
+
+	// Run the clone to checkout the package.
+	log.Printf("Clone git repository: %s", downloadPath)
+	if _, errStr, err := runCommand(checkoutDir, "git", "clone", downloadPath, "."); err != nil {
+		return fmt.Errorf("Error cloning git package %s: %s", downloadPath, errStr)
+	}
+
+	// Checkout any submodules.
+	log.Printf("Clone git repository submodules: %s", downloadPath)
+
+	// Note: No error check here, as submodule returns 1 on none (WHY?!)
+	runCommand(checkoutDir, "git", "submodule", "update", "--init", "--recursive")
+
+	// Switch to the tag or branch if necessary.
+	switch {
+	case vcsPath.branchOrCommit != "":
+		log.Printf("Switch to branch on git repository: %s => %s", downloadPath, vcsPath.branchOrCommit)
+		if _, errStr, err := runCommand(checkoutDir, "git", "checkout", vcsPath.branchOrCommit); err != nil {
+			return fmt.Errorf("Error changing branch of git package %s: %s", downloadPath, errStr)
+		}
+
+	case vcsPath.tag != "":
+		log.Printf("Switch to tag on git repository: %s => %s", downloadPath, vcsPath.tag)
+		if _, errStr, err := runCommand(checkoutDir, "git", "checkout", "tags/"+vcsPath.tag); err != nil {
+			return fmt.Errorf("Error changing tag of git package %s: %s", downloadPath, errStr)
+		}
+	}
+
+	return nil
+}
+
+func (gv gitVcs) Inspect(checkoutDir string) (string, error) {
+	var out bytes.Buffer
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = checkoutDir
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	if strings.HasPrefix(out.String(), "fatal:") {
+		return "", fmt.Errorf("Invalid repository")
+	}
+
+	trimmed := strings.TrimSpace(out.String())
+	return trimmed[0:7], nil
+}
+
+func (gv gitVcs) Detect(checkoutDir string) bool {
+	gitDirectory := path.Join(checkoutDir, ".git")
+	_, err := os.Stat(gitDirectory)
+	return !os.IsNotExist(err)
+}
+
+func (gv gitVcs) Update(checkoutDir string) error {
+	lock := modificationLockMap.GetLock(checkoutDir)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if _, errStr, err := runCommand(checkoutDir, "git", "pull"); err != nil {
+		return fmt.Errorf("Error updating git package %s: %s", checkoutDir, errStr)
+	}
+
+	return nil
+}
+
+func (gv gitVcs) HasLocalChanges(checkoutDir string) bool {
+	var out bytes.Buffer
+
+	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd.Dir = checkoutDir
+	statusCmd.Stdout = &out
+	statusErr := statusCmd.Run()
+	if statusErr != nil {
+		return true
+	}
+
+	return len(out.String()) > 0
+}
+
+func (gv gitVcs) ListTags(checkoutDir string) ([]string, error) {
+	output, errStr, err := runCommand(checkoutDir, "git", "ls-remote", "--tags", "--refs", "--q")
+	if err != nil {
+		return []string{}, fmt.Errorf("Could not list tags: %v", errStr)
+	}
+
+	lines := strings.Split(output, "\n")
+	tags := make([]string, 0, len(lines))
+	for _, line := range lines {
+		pieces := strings.Split(line, "\t")
+		if len(pieces) != 2 {
+			continue
+		}
+
+		ref := pieces[1]
+		if !strings.HasPrefix(ref, "refs/tags/") {
+			continue
+		}
+
+		tags = append(tags, ref[len("refs/tags/"):])
+	}
+
+	return tags, nil
+}
+
+func (gv gitVcs) IsDetached(checkoutDir string) (bool, error) {
+	_, errStr, err := runCommand(checkoutDir, "git", "symbolic-ref", "HEAD")
+	if err != nil {
+		if strings.Contains(errStr, "not a symbolic ref") {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("Could check repo status: %v", errStr)
+	}
+
+	return false, nil
+}

--- a/vcs/handlers.go
+++ b/vcs/handlers.go
@@ -29,6 +29,9 @@ type VCSHandler interface {
 
 	// IsDetached returns whether the checked out directory is in a detached state.
 	IsDetached(checkoutDir string) (bool, error)
+
+	// GetPackagePath returns the VCS Package Path information for the checked out directory.
+	GetPackagePath(checkoutDir string) (vcsPackagePath, error)
 }
 
 var vcsByKind = map[string]VCSHandler{

--- a/vcs/metadiscovery.go
+++ b/vcs/metadiscovery.go
@@ -12,9 +12,9 @@ import (
 
 // VCSUrlInformation holds information about a VCS source URL.
 type VCSUrlInformation struct {
-	UrlPrefix    string  // The prefix matching the source URL.
-	Kind         VCSKind // The kind of VCS for the source URL.
-	DownloadPath string  // The VCS-specific download path.
+	UrlPrefix    string // The prefix matching the source URL.
+	Kind         string // The kind of VCS for the source URL.
+	DownloadPath string // The VCS-specific download path.
 }
 
 // discoveryUrlParamter holds the name of the parameter added to the URL to request it
@@ -98,13 +98,13 @@ func DiscoverVCSInformation(vcsUrl string) (VCSUrlInformation, error) {
 	}
 
 	// Find the associated VCS.
-	handler, ok := vcsByID[pieces[1]]
+	handler, ok := vcsByKind[pieces[1]]
 	if !ok {
 		err := fmt.Errorf("VCS url '%s' requires engine '%s', which is not currently supported", vcsUrl, pieces[1])
 		return VCSUrlInformation{}, err
 	}
 
-	return VCSUrlInformation{pieces[0], handler.kind, pieces[2]}, nil
+	return VCSUrlInformation{pieces[0], handler.Kind(), pieces[2]}, nil
 }
 
 // findVCSDiscoveryTag searches the parsed HTML DOM from the given start node, downward,

--- a/vcs/util.go
+++ b/vcs/util.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"bytes"
+	"log"
+	"os/exec"
+
+	"github.com/serulian/compiler/compilerutil"
+)
+
+// modificationLockMap is a map for locking checkouts or updates of specific paths, to prevent multiple concurrent calls
+// from being made.
+var modificationLockMap = compilerutil.CreateLockMap()
+
+// runCommand uses exec to run an external command.
+func runCommand(runDirectory string, command string, args ...string) (string, string, error) {
+	log.Printf("Running command %s %v", command, args)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := exec.Command(command, args...)
+	cmd.Dir = runDirectory
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	log.Printf("Result: %v | %s | %s", err, stdout.String(), stderr.String())
+	return stdout.String(), stderr.String(), err
+}

--- a/webidl/typeconstructor/tests/basic.json
+++ b/webidl/typeconstructor/tests/basic.json
@@ -1,4 +1,17 @@
 {
+    "10a60a69d034c73bb5aa6714184ba2fd": {
+        "Key": "10a60a69d034c73bb5aa6714184ba2fd",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "Object",
+            "tdg-type-name": "Object"
+        }
+    },
     "273a62dd235e16a6b38c36d0d17c3328": {
         "Key": "273a62dd235e16a6b38c36d0d17c3328",
         "Kind": 8,
@@ -10,6 +23,19 @@
             "tdg-type-exported": "true",
             "tdg-type-globalid": "ba696263",
             "tdg-type-name": "SomeInterface"
+        }
+    },
+    "47f812450eef3e196288e2b540a8d69f": {
+        "Key": "47f812450eef3e196288e2b540a8d69f",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "AnotherType",
+            "tdg-type-name": "AnotherType"
         }
     },
     "597032fb96164adf54671a0ec0c01d36": {
@@ -25,14 +51,14 @@
             "tdg-type-name": "AnotherType"
         }
     },
-    "5c9700b7b82c7033c03ee5303bd91eb2": {
-        "Key": "5c9700b7b82c7033c03ee5303bd91eb2",
+    "9ed9815726334eab6b37167300d688d7": {
+        "Key": "9ed9815726334eab6b37167300d688d7",
         "Kind": 3,
         "Children": {
-            "58fa5fe68268c4631a1fa5cc26e60a42": {
+            "a277eed9f8c5fab80af478264c1a1209": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "58fa5fe68268c4631a1fa5cc26e60a42",
+                    "Key": "a277eed9f8c5fab80af478264c1a1209",
                     "Kind": 9,
                     "Children": {},
                     "Predicates": {
@@ -41,33 +67,15 @@
                         "tdg-member-resolved-type": "any",
                         "tdg-member-signature": "\n\u0008anything\u0010\t\u0018\u0001 \u0001*\u0003any",
                         "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
             },
-            "750d12e671e597134b2563d396845d16": {
+            "e05fa194ff37cafd6104a1b22bb01539": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "750d12e671e597134b2563d396845d16",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "CoolThing",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "Object",
-                        "tdg-member-signature": "\n\tcoolthing\u0010\t \u0001*\u0006Object",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
-            "b4bbd10b06021518d6bedab2d8c2141d": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "b4bbd10b06021518d6bedab2d8c2141d",
+                    "Key": "e05fa194ff37cafd6104a1b22bb01539",
                     "Kind": 9,
                     "Children": {
                         "e4596b7d34177eb547e319b339d698e9": {
@@ -93,7 +101,25 @@
                         "tdg-member-signature": "\n\ranothermember\u0010\u0007 \u0001*\u001efunction\u003cAnotherType?\u003e(Object)",
                         "tdg-member-static": "true",
                         "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
+            "fffb25ca514c6575006b74dee152ca8d": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "fffb25ca514c6575006b74dee152ca8d",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "CoolThing",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "Object",
+                        "tdg-member-signature": "\n\tcoolthing\u0010\t \u0001*\u0006Object",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -101,7 +127,7 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "SomeInterface",
@@ -118,32 +144,6 @@
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "f5dd57b7",
-            "tdg-type-name": "Object"
-        }
-    },
-    "abbe46a39bbe8990c443e3a8fa823430": {
-        "Key": "abbe46a39bbe8990c443e3a8fa823430",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "AnotherType",
-            "tdg-type-name": "AnotherType"
-        }
-    },
-    "d9d96cd6aa72433fdc6af7ad61f4d56e": {
-        "Key": "d9d96cd6aa72433fdc6af7ad61f4d56e",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "Object",
             "tdg-type-name": "Object"
         }
     }

--- a/webidl/typeconstructor/tests/basicmultifile.json
+++ b/webidl/typeconstructor/tests/basicmultifile.json
@@ -1,44 +1,12 @@
 {
-    "5c9700b7b82c7033c03ee5303bd91eb2": {
-        "Key": "5c9700b7b82c7033c03ee5303bd91eb2",
+    "03d66d2e09d58fa7e634d8511281e6c3": {
+        "Key": "03d66d2e09d58fa7e634d8511281e6c3",
         "Kind": 3,
         "Children": {
-            "8fb3880b832e5f05e1c81f7f8ef5f2e1": {
+            "7789979a35e7f199809c0d636a613a9a": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "8fb3880b832e5f05e1c81f7f8ef5f2e1",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "CoolThing",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "AnotherInterface",
-                        "tdg-member-signature": "\n\tcoolthing\u0010\t \u0001*\u0010AnotherInterface",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            }
-        },
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "SomeInterface",
-            "tdg-type-name": "SomeInterface"
-        }
-    },
-    "60959f9be08309fd49e91d64a4dd6634": {
-        "Key": "60959f9be08309fd49e91d64a4dd6634",
-        "Kind": 3,
-        "Children": {
-            "237320870965977bd7b85d3ee2a1db71": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "237320870965977bd7b85d3ee2a1db71",
+                    "Key": "7789979a35e7f199809c0d636a613a9a",
                     "Kind": 9,
                     "Children": {},
                     "Predicates": {
@@ -48,7 +16,7 @@
                         "tdg-member-resolved-type": "function\u003cvoid\u003e",
                         "tdg-member-signature": "\n\u000bdosomething\u0010\u0007 \u0001*\u000efunction\u003cvoid\u003e",
                         "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -56,7 +24,7 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "AnotherInterface",
@@ -73,6 +41,38 @@
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "e4f645a7",
+            "tdg-type-name": "SomeInterface"
+        }
+    },
+    "9ed9815726334eab6b37167300d688d7": {
+        "Key": "9ed9815726334eab6b37167300d688d7",
+        "Kind": 3,
+        "Children": {
+            "556fd3c098311b76f9201357fc8ffc68": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "556fd3c098311b76f9201357fc8ffc68",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "CoolThing",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "AnotherInterface",
+                        "tdg-member-signature": "\n\tcoolthing\u0010\t \u0001*\u0010AnotherInterface",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "SomeInterface",
             "tdg-type-name": "SomeInterface"
         }
     }

--- a/webidl/typeconstructor/tests/collapsed.json
+++ b/webidl/typeconstructor/tests/collapsed.json
@@ -12,32 +12,14 @@
             "tdg-type-name": "ISomeCollapsedType"
         }
     },
-    "87965a1a2e46c89eeda43e2ea07249e0": {
-        "Key": "87965a1a2e46c89eeda43e2ea07249e0",
+    "a4172017693956734259d1e238fc6204": {
+        "Key": "a4172017693956734259d1e238fc6204",
         "Kind": 3,
         "Children": {
-            "386f3d463c204cc0af01b7ee26485ffa": {
+            "3e14408f442353c597e2631a8e48a98d": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "386f3d463c204cc0af01b7ee26485ffa",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "First",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "any",
-                        "tdg-member-signature": "\n\u0005first\u0010\t \u0001*\u0003any",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
-            "3951af39c7b249232008d383bffdf0ec": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "3951af39c7b249232008d383bffdf0ec",
+                    "Key": "3e14408f442353c597e2631a8e48a98d",
                     "Kind": 9,
                     "Children": {},
                     "Predicates": {
@@ -47,15 +29,15 @@
                         "tdg-member-resolved-type": "any",
                         "tdg-member-signature": "\n\u0005third\u0010\t \u0001*\u0003any",
                         "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
             },
-            "c11c3e3313a0c563754eeb0c517d7046": {
+            "8af9e30929b1cccf44fc67cb202844cc": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "c11c3e3313a0c563754eeb0c517d7046",
+                    "Key": "8af9e30929b1cccf44fc67cb202844cc",
                     "Kind": 9,
                     "Children": {},
                     "Predicates": {
@@ -65,7 +47,25 @@
                         "tdg-member-resolved-type": "any",
                         "tdg-member-signature": "\n\u0006second\u0010\t \u0001*\u0003any",
                         "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
+            "a4c55e2cfca4439905a8e5086a3a330f": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "a4c55e2cfca4439905a8e5086a3a330f",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "First",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "any",
+                        "tdg-member-signature": "\n\u0005first\u0010\t \u0001*\u0003any",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -73,7 +73,7 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "ISomeCollapsedType",

--- a/webidl/typeconstructor/tests/collapsedinheritance.json
+++ b/webidl/typeconstructor/tests/collapsedinheritance.json
@@ -1,4 +1,50 @@
 {
+    "19ca698d1c0981b629f07f94b20ee99b": {
+        "Key": "19ca698d1c0981b629f07f94b20ee99b",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "IBaseType",
+            "tdg-type-name": "IBaseType"
+        }
+    },
+    "286530626ae1f174a91ad4d4f9701bd8": {
+        "Key": "286530626ae1f174a91ad4d4f9701bd8",
+        "Kind": 3,
+        "Children": {
+            "a4c55e2cfca4439905a8e5086a3a330f": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "a4c55e2cfca4439905a8e5086a3a330f",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "First",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "any",
+                        "tdg-member-signature": "\n\u0005first\u0010\t \u0001*\u0003any",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-parent-type": "IBaseType",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "ISomeCollapsedType",
+            "tdg-type-name": "ISomeCollapsedType"
+        }
+    },
     "a12b238f5e2bd0e620d5ca1771fe66d1": {
         "Key": "a12b238f5e2bd0e620d5ca1771fe66d1",
         "Kind": 8,
@@ -10,52 +56,6 @@
             "tdg-type-exported": "true",
             "tdg-type-globalid": "96f01e59",
             "tdg-type-name": "ISomeCollapsedType"
-        }
-    },
-    "c08be35b8130b4a3371741b91ae62cfc": {
-        "Key": "c08be35b8130b4a3371741b91ae62cfc",
-        "Kind": 3,
-        "Children": {
-            "386f3d463c204cc0af01b7ee26485ffa": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "386f3d463c204cc0af01b7ee26485ffa",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "First",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "any",
-                        "tdg-member-signature": "\n\u0005first\u0010\t \u0001*\u0003any",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            }
-        },
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-parent-type": "IBaseType",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "ISomeCollapsedType",
-            "tdg-type-name": "ISomeCollapsedType"
-        }
-    },
-    "e66ecddf0d1facb324434e27a46cf69c": {
-        "Key": "e66ecddf0d1facb324434e27a46cf69c",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "IBaseType",
-            "tdg-type-name": "IBaseType"
         }
     }
 }

--- a/webidl/typeconstructor/tests/constructors.json
+++ b/webidl/typeconstructor/tests/constructors.json
@@ -1,4 +1,103 @@
 {
+    "03d66d2e09d58fa7e634d8511281e6c3": {
+        "Key": "03d66d2e09d58fa7e634d8511281e6c3",
+        "Kind": 3,
+        "Children": {
+            "0156808bb49c3ac907587b7a8713e500": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "0156808bb49c3ac907587b7a8713e500",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "new",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cAnotherInterface\u003e(SomeInterface)",
+                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*)function\u003cAnotherInterface\u003e(SomeInterface)",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "AnotherInterface",
+            "tdg-type-name": "AnotherInterface"
+        }
+    },
+    "05dda789aabd0a20de33b375057e98c1": {
+        "Key": "05dda789aabd0a20de33b375057e98c1",
+        "Kind": 3,
+        "Children": {
+            "ba13dac7f37d579cb17a134d9da0f749": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "ba13dac7f37d579cb17a134d9da0f749",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "new",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cFourthInterface\u003e(any)",
+                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*\u001efunction\u003cFourthInterface\u003e(any)",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "FourthInterface",
+            "tdg-type-name": "FourthInterface"
+        }
+    },
+    "064b00fb75a0e4c373deddd2d887be07": {
+        "Key": "064b00fb75a0e4c373deddd2d887be07",
+        "Kind": 3,
+        "Children": {
+            "2263e7826011182c5fc77f6b8a6be69d": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "2263e7826011182c5fc77f6b8a6be69d",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "new",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cThirdInterface\u003e(SomeInterface, AnotherInterface?)",
+                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*:function\u003cThirdInterface\u003e(SomeInterface, AnotherInterface?)",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "ThirdInterface",
+            "tdg-type-name": "ThirdInterface"
+        }
+    },
     "1bf800ab8a3822e1c6b693e1bb800835": {
         "Key": "1bf800ab8a3822e1c6b693e1bb800835",
         "Kind": 8,
@@ -25,105 +124,6 @@
             "tdg-type-name": "AnotherInterface"
         }
     },
-    "520a4ffc18eb8daf459e0e353b5a7372": {
-        "Key": "520a4ffc18eb8daf459e0e353b5a7372",
-        "Kind": 3,
-        "Children": {
-            "7aea22aecf516239386d1e9acba5bc2e": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "7aea22aecf516239386d1e9acba5bc2e",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "new",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "function\u003cFourthInterface\u003e(any)",
-                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*\u001efunction\u003cFourthInterface\u003e(any)",
-                        "tdg-member-static": "true",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            }
-        },
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "FourthInterface",
-            "tdg-type-name": "FourthInterface"
-        }
-    },
-    "5c9700b7b82c7033c03ee5303bd91eb2": {
-        "Key": "5c9700b7b82c7033c03ee5303bd91eb2",
-        "Kind": 3,
-        "Children": {
-            "0943317975f0eec85c79cd9756dbdb93": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "0943317975f0eec85c79cd9756dbdb93",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "new",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "function\u003cSomeInterface\u003e",
-                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*\u0017function\u003cSomeInterface\u003e",
-                        "tdg-member-static": "true",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            }
-        },
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "SomeInterface",
-            "tdg-type-name": "SomeInterface"
-        }
-    },
-    "60959f9be08309fd49e91d64a4dd6634": {
-        "Key": "60959f9be08309fd49e91d64a4dd6634",
-        "Kind": 3,
-        "Children": {
-            "df2f7639281f7d744fd5d28d472dff17": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "df2f7639281f7d744fd5d28d472dff17",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "new",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "function\u003cAnotherInterface\u003e(SomeInterface)",
-                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*)function\u003cAnotherInterface\u003e(SomeInterface)",
-                        "tdg-member-static": "true",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            }
-        },
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "AnotherInterface",
-            "tdg-type-name": "AnotherInterface"
-        }
-    },
     "6d49b8c543cd6d8354934efa4a56f06c": {
         "Key": "6d49b8c543cd6d8354934efa4a56f06c",
         "Kind": 8,
@@ -137,6 +137,39 @@
             "tdg-type-name": "SomeInterface"
         }
     },
+    "9ed9815726334eab6b37167300d688d7": {
+        "Key": "9ed9815726334eab6b37167300d688d7",
+        "Kind": 3,
+        "Children": {
+            "80e3c29f1dc9b030b632757756429179": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "80e3c29f1dc9b030b632757756429179",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "new",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cSomeInterface\u003e",
+                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*\u0017function\u003cSomeInterface\u003e",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "SomeInterface",
+            "tdg-type-name": "SomeInterface"
+        }
+    },
     "c05161ea9876cd4dbed958336a2548ad": {
         "Key": "c05161ea9876cd4dbed958336a2548ad",
         "Kind": 8,
@@ -147,39 +180,6 @@
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "a689b0b9",
-            "tdg-type-name": "ThirdInterface"
-        }
-    },
-    "d162675f87bb6ef82ea09c7794529041": {
-        "Key": "d162675f87bb6ef82ea09c7794529041",
-        "Kind": 3,
-        "Children": {
-            "aa6afbffbd2ad9a0bb306d9e79a423d5": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "aa6afbffbd2ad9a0bb306d9e79a423d5",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "new",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "function\u003cThirdInterface\u003e(SomeInterface, AnotherInterface?)",
-                        "tdg-member-signature": "\n\u0003new\u0010\u0006 \u0001*:function\u003cThirdInterface\u003e(SomeInterface, AnotherInterface?)",
-                        "tdg-member-static": "true",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            }
-        },
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "ThirdInterface",
             "tdg-type-name": "ThirdInterface"
         }
     }

--- a/webidl/typeconstructor/tests/customop.json
+++ b/webidl/typeconstructor/tests/customop.json
@@ -1,6 +1,19 @@
 {
-    "5c9700b7b82c7033c03ee5303bd91eb2": {
-        "Key": "5c9700b7b82c7033c03ee5303bd91eb2",
+    "6486d85e2bc5f5e277e003a13536dffb": {
+        "Key": "6486d85e2bc5f5e277e003a13536dffb",
+        "Kind": 8,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "8|NodeType|tdg",
+            "tdg-source-module": "tests/customop.webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "320ced89",
+            "tdg-type-name": "SomeInterface"
+        }
+    },
+    "9ed9815726334eab6b37167300d688d7": {
+        "Key": "9ed9815726334eab6b37167300d688d7",
         "Kind": 3,
         "Children": {
             "613ee9436c9bee469ae906675f136bb7": {
@@ -18,23 +31,10 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "SomeInterface",
-            "tdg-type-name": "SomeInterface"
-        }
-    },
-    "6486d85e2bc5f5e277e003a13536dffb": {
-        "Key": "6486d85e2bc5f5e277e003a13536dffb",
-        "Kind": 8,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "8|NodeType|tdg",
-            "tdg-source-module": "tests/customop.webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "320ced89",
             "tdg-type-name": "SomeInterface"
         }
     }

--- a/webidl/typeconstructor/tests/indexer.json
+++ b/webidl/typeconstructor/tests/indexer.json
@@ -1,4 +1,17 @@
 {
+    "16855de29c64ffec23f0285f981b93b7": {
+        "Key": "16855de29c64ffec23f0285f981b93b7",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "First",
+            "tdg-type-name": "First"
+        }
+    },
     "20623e84a0ded118976d43a723bc9e44": {
         "Key": "20623e84a0ded118976d43a723bc9e44",
         "Kind": 8,
@@ -12,14 +25,66 @@
             "tdg-type-name": "Fourth"
         }
     },
-    "22f996265a8fbc38c06163c340bf8702": {
-        "Key": "22f996265a8fbc38c06163c340bf8702",
+    "300e485be685d53fb0be0bd497a08362": {
+        "Key": "300e485be685d53fb0be0bd497a08362",
+        "Kind": 8,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "8|NodeType|tdg",
+            "tdg-source-module": "tests/indexer.webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "da77d421",
+            "tdg-type-name": "Third"
+        }
+    },
+    "a407807f0b6b3cac6bf6959fbbd0432e": {
+        "Key": "a407807f0b6b3cac6bf6959fbbd0432e",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "Fourth",
+            "tdg-type-name": "Fourth"
+        }
+    },
+    "b42d254d4612d1ef9251e481aa7871c6": {
+        "Key": "b42d254d4612d1ef9251e481aa7871c6",
+        "Kind": 8,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "8|NodeType|tdg",
+            "tdg-source-module": "tests/indexer.webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "84a4692e",
+            "tdg-type-name": "Second"
+        }
+    },
+    "ce71dad6c0ba0c460264fb9f825c0be5": {
+        "Key": "ce71dad6c0ba0c460264fb9f825c0be5",
+        "Kind": 8,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "8|NodeType|tdg",
+            "tdg-source-module": "tests/indexer.webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "8ab6475b",
+            "tdg-type-name": "MyInterface"
+        }
+    },
+    "d1a086e75a04386ecbebe0a59ae67830": {
+        "Key": "d1a086e75a04386ecbebe0a59ae67830",
         "Kind": 3,
         "Children": {
-            "0cafb9dfc8563d9a570fbd7a263582db": {
+            "6e0116ad5cfb18848b442435020bae45": {
                 "Predicate": "tdg-declaration-operator",
                 "Child": {
-                    "Key": "0cafb9dfc8563d9a570fbd7a263582db",
+                    "Key": "6e0116ad5cfb18848b442435020bae45",
                     "Kind": 10,
                     "Children": {
                         "007ce2ceb013d11b4222fdaa26a9deec": {
@@ -59,15 +124,15 @@
                         "tdg-node-kind": "10|NodeType|tdg",
                         "tdg-operator-name": "index",
                         "tdg-operator-native": "true",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
             },
-            "d6275e240a384d282baa0cea757c467c": {
+            "852d544efaf453de3d1c6cb5a0a43f1c": {
                 "Predicate": "tdg-declaration-operator",
                 "Child": {
-                    "Key": "d6275e240a384d282baa0cea757c467c",
+                    "Key": "852d544efaf453de3d1c6cb5a0a43f1c",
                     "Kind": 10,
                     "Children": {
                         "0ab7ff81f5d66766e19e204a04b5f724": {
@@ -120,7 +185,7 @@
                         "tdg-node-kind": "10|NodeType|tdg",
                         "tdg-operator-name": "setindex",
                         "tdg-operator-native": "true",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -128,89 +193,37 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "MyInterface",
             "tdg-type-name": "MyInterface"
         }
     },
-    "300e485be685d53fb0be0bd497a08362": {
-        "Key": "300e485be685d53fb0be0bd497a08362",
-        "Kind": 8,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "8|NodeType|tdg",
-            "tdg-source-module": "tests/indexer.webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "da77d421",
-            "tdg-type-name": "Third"
-        }
-    },
-    "67e5d13c9fdb1cfbdc90f499303ed60e": {
-        "Key": "67e5d13c9fdb1cfbdc90f499303ed60e",
+    "db2fa464e8bac086f79804279a79dbaf": {
+        "Key": "db2fa464e8bac086f79804279a79dbaf",
         "Kind": 3,
         "Children": {},
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "Second",
+            "tdg-type-name": "Second"
+        }
+    },
+    "e6a896074ca1b312ee583137b35ffcc9": {
+        "Key": "e6a896074ca1b312ee583137b35ffcc9",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "Third",
             "tdg-type-name": "Third"
-        }
-    },
-    "7376123131fb210291eef5b457d06ec5": {
-        "Key": "7376123131fb210291eef5b457d06ec5",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "First",
-            "tdg-type-name": "First"
-        }
-    },
-    "b42d254d4612d1ef9251e481aa7871c6": {
-        "Key": "b42d254d4612d1ef9251e481aa7871c6",
-        "Kind": 8,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "8|NodeType|tdg",
-            "tdg-source-module": "tests/indexer.webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "84a4692e",
-            "tdg-type-name": "Second"
-        }
-    },
-    "ce71dad6c0ba0c460264fb9f825c0be5": {
-        "Key": "ce71dad6c0ba0c460264fb9f825c0be5",
-        "Kind": 8,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "8|NodeType|tdg",
-            "tdg-source-module": "tests/indexer.webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "8ab6475b",
-            "tdg-type-name": "MyInterface"
-        }
-    },
-    "d42658a83268d3e2262cd4b36d2faef6": {
-        "Key": "d42658a83268d3e2262cd4b36d2faef6",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "Fourth",
-            "tdg-type-name": "Fourth"
         }
     },
     "ec6895cb48465b43b07e4b10ef5e5197": {
@@ -224,19 +237,6 @@
             "tdg-type-exported": "true",
             "tdg-type-globalid": "53841263",
             "tdg-type-name": "First"
-        }
-    },
-    "fdbe2e63bdd302a82a9cb46953ebae3f": {
-        "Key": "fdbe2e63bdd302a82a9cb46953ebae3f",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "Second",
-            "tdg-type-name": "Second"
         }
     }
 }

--- a/webidl/typeconstructor/tests/inheritance.json
+++ b/webidl/typeconstructor/tests/inheritance.json
@@ -1,25 +1,25 @@
 {
-    "3382bcb4d9c9e64dea63086dd65bd9e0": {
-        "Key": "3382bcb4d9c9e64dea63086dd65bd9e0",
+    "59adf6ec791cdfe2f6f7dcd8c49fc0b5": {
+        "Key": "59adf6ec791cdfe2f6f7dcd8c49fc0b5",
         "Kind": 3,
         "Children": {},
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
             "tdg-parent-type": "Node",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "Element",
             "tdg-type-name": "Element"
         }
     },
-    "4b606cdb254830ef6aa51f4a42ef0321": {
-        "Key": "4b606cdb254830ef6aa51f4a42ef0321",
+    "844f8c34aacaa43093b607dd52136c3d": {
+        "Key": "844f8c34aacaa43093b607dd52136c3d",
         "Kind": 3,
         "Children": {},
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "Node",

--- a/webidl/typeconstructor/tests/nativetypes.json
+++ b/webidl/typeconstructor/tests/nativetypes.json
@@ -1,4 +1,82 @@
 {
+    "0d2136f65ab63960ec1331bd6a9b0276": {
+        "Key": "0d2136f65ab63960ec1331bd6a9b0276",
+        "Kind": 3,
+        "Children": {
+            "9479eb07b93d0a447a16ead865dc0ad7": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "9479eb07b93d0a447a16ead865dc0ad7",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "SomeBoolean",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "Boolean",
+                        "tdg-member-signature": "\n\u000bsomeboolean\u0010\t \u0001*\u0007Boolean",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
+            "a0f5c3ada82d94e2645b7f6053880450": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "a0f5c3ada82d94e2645b7f6053880450",
+                    "Kind": 9,
+                    "Children": {
+                        "43bddee5131f5667d682f192dfac7d19": {
+                            "Predicate": "tdg-member-parameter",
+                            "Child": {
+                                "Key": "43bddee5131f5667d682f192dfac7d19",
+                                "Kind": 11,
+                                "Children": {},
+                                "Predicates": {
+                                    "tdg-node-kind": "11|NodeType|tdg",
+                                    "tdg-parameter-name": "someParam",
+                                    "tdg-parameter-type": "Number",
+                                    "tdg-source-node": "(NodeRef)"
+                                }
+                            }
+                        }
+                    },
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-name": "SomeFunction",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "function\u003cNumber\u003e(Number)",
+                        "tdg-member-signature": "\n\u000csomefunction\u0010\u0007 \u0001*\u0018function\u003cNumber\u003e(Number)",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/(root).webidl",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            }
+        },
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "ISomeInterface",
+            "tdg-type-name": "ISomeInterface"
+        }
+    },
+    "3b235cb65ee97c2110aff3e9f9553e70": {
+        "Key": "3b235cb65ee97c2110aff3e9f9553e70",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "Boolean",
+            "tdg-type-name": "Boolean"
+        }
+    },
     "54394882767c2f4228409909547043c7": {
         "Key": "54394882767c2f4228409909547043c7",
         "Kind": 8,
@@ -25,95 +103,17 @@
             "tdg-type-name": "Number"
         }
     },
-    "70d1d5daaebf2bfb856e49f50135ea7c": {
-        "Key": "70d1d5daaebf2bfb856e49f50135ea7c",
+    "9eb088be2647465b65e92ea9c0dafdbc": {
+        "Key": "9eb088be2647465b65e92ea9c0dafdbc",
         "Kind": 3,
         "Children": {},
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "Boolean",
-            "tdg-type-name": "Boolean"
-        }
-    },
-    "c391b500005af637be92889eaddd4874": {
-        "Key": "c391b500005af637be92889eaddd4874",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "Number",
             "tdg-type-name": "Number"
-        }
-    },
-    "c4b4b6dd4924f76e18725266316c8e09": {
-        "Key": "c4b4b6dd4924f76e18725266316c8e09",
-        "Kind": 3,
-        "Children": {
-            "18b32ae47c7dde8df8d828d4aa81bc55": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "18b32ae47c7dde8df8d828d4aa81bc55",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "SomeBoolean",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "Boolean",
-                        "tdg-member-signature": "\n\u000bsomeboolean\u0010\t \u0001*\u0007Boolean",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
-            "f18927d8e97826df280ac35141e4a1a7": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "f18927d8e97826df280ac35141e4a1a7",
-                    "Kind": 9,
-                    "Children": {
-                        "43bddee5131f5667d682f192dfac7d19": {
-                            "Predicate": "tdg-member-parameter",
-                            "Child": {
-                                "Key": "43bddee5131f5667d682f192dfac7d19",
-                                "Kind": 11,
-                                "Children": {},
-                                "Predicates": {
-                                    "tdg-node-kind": "11|NodeType|tdg",
-                                    "tdg-parameter-name": "someParam",
-                                    "tdg-parameter-type": "Number",
-                                    "tdg-source-node": "(NodeRef)"
-                                }
-                            }
-                        }
-                    },
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-name": "SomeFunction",
-                        "tdg-member-readonly": "true",
-                        "tdg-member-resolved-type": "function\u003cNumber\u003e(Number)",
-                        "tdg-member-signature": "\n\u000csomefunction\u0010\u0007 \u0001*\u0018function\u003cNumber\u003e(Number)",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            }
-        },
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "ISomeInterface",
-            "tdg-type-name": "ISomeInterface"
         }
     },
     "f7fa9f9cddec931a94d9bf0790fcb0c5": {

--- a/webidl/typeconstructor/tests/operator.json
+++ b/webidl/typeconstructor/tests/operator.json
@@ -1,12 +1,25 @@
 {
-    "5c9700b7b82c7033c03ee5303bd91eb2": {
-        "Key": "5c9700b7b82c7033c03ee5303bd91eb2",
+    "94ed69734988cb02f1ae43ae0d2f9c4b": {
+        "Key": "94ed69734988cb02f1ae43ae0d2f9c4b",
+        "Kind": 8,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "8|NodeType|tdg",
+            "tdg-source-module": "tests/operator.webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "a9fcf475",
+            "tdg-type-name": "SomeInterface"
+        }
+    },
+    "9ed9815726334eab6b37167300d688d7": {
+        "Key": "9ed9815726334eab6b37167300d688d7",
         "Kind": 3,
         "Children": {
-            "07986046f92fee1efb279e9e858f7d11": {
+            "399dec42d103d1e10fea51761f869f53": {
                 "Predicate": "tdg-declaration-operator",
                 "Child": {
-                    "Key": "07986046f92fee1efb279e9e858f7d11",
+                    "Key": "399dec42d103d1e10fea51761f869f53",
                     "Kind": 10,
                     "Children": {
                         "e4aa70201f3e500c3be8e9b70115884f": {
@@ -33,15 +46,15 @@
                         "tdg-node-kind": "10|NodeType|tdg",
                         "tdg-operator-name": "plus",
                         "tdg-operator-native": "true",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
             },
-            "bb6598f210190017a9e42302acfc3f5a": {
+            "d8589945460f534396180b3cd07be4d8": {
                 "Predicate": "tdg-declaration-operator",
                 "Child": {
-                    "Key": "bb6598f210190017a9e42302acfc3f5a",
+                    "Key": "d8589945460f534396180b3cd07be4d8",
                     "Kind": 10,
                     "Children": {
                         "e4aa70201f3e500c3be8e9b70115884f": {
@@ -68,7 +81,7 @@
                         "tdg-node-kind": "10|NodeType|tdg",
                         "tdg-operator-name": "minus",
                         "tdg-operator-native": "true",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -76,23 +89,10 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "SomeInterface",
-            "tdg-type-name": "SomeInterface"
-        }
-    },
-    "94ed69734988cb02f1ae43ae0d2f9c4b": {
-        "Key": "94ed69734988cb02f1ae43ae0d2f9c4b",
-        "Kind": 8,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "8|NodeType|tdg",
-            "tdg-source-module": "tests/operator.webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "a9fcf475",
             "tdg-type-name": "SomeInterface"
         }
     }

--- a/webidl/typeconstructor/tests/optionalparam.json
+++ b/webidl/typeconstructor/tests/optionalparam.json
@@ -12,14 +12,27 @@
             "tdg-type-name": "SomeInterface"
         }
     },
-    "5c9700b7b82c7033c03ee5303bd91eb2": {
-        "Key": "5c9700b7b82c7033c03ee5303bd91eb2",
+    "73bd3823ac5e52c2dcb58022cbb73848": {
+        "Key": "73bd3823ac5e52c2dcb58022cbb73848",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "Foo",
+            "tdg-type-name": "Foo"
+        }
+    },
+    "9ed9815726334eab6b37167300d688d7": {
+        "Key": "9ed9815726334eab6b37167300d688d7",
         "Kind": 3,
         "Children": {
-            "31d6362ede827447c00ed6461603c40e": {
+            "e8c8f52134993c7d2f0cb6c9685bc418": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "31d6362ede827447c00ed6461603c40e",
+                    "Key": "e8c8f52134993c7d2f0cb6c9685bc418",
                     "Kind": 9,
                     "Children": {
                         "6833a3464d1974be735ad93c78c377fc": {
@@ -86,7 +99,7 @@
                         "tdg-member-resolved-type": "function\u003cvoid\u003e(Foo, Foo, Foo?, Foo?)",
                         "tdg-member-signature": "\n\u000csomefunction\u0010\u0007 \u0001*$function\u003cvoid\u003e(Foo, Foo, Foo?, Foo?)",
                         "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -94,7 +107,7 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "SomeInterface",
@@ -111,19 +124,6 @@
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "6757ffcf",
-            "tdg-type-name": "Foo"
-        }
-    },
-    "ce541d21d4db40e6822609bef1d1ff73": {
-        "Key": "ce541d21d4db40e6822609bef1d1ff73",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "Foo",
             "tdg-type-name": "Foo"
         }
     }

--- a/webidl/typeconstructor/tests/serializable.json
+++ b/webidl/typeconstructor/tests/serializable.json
@@ -1,6 +1,19 @@
 {
-    "4e462df8efb4756983de987743080fff": {
-        "Key": "4e462df8efb4756983de987743080fff",
+    "af6f2440d6763d7d83614ac4c636583e": {
+        "Key": "af6f2440d6763d7d83614ac4c636583e",
+        "Kind": 8,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "8|NodeType|tdg",
+            "tdg-source-module": "tests/serializable.webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "d8b7cc1d",
+            "tdg-type-name": "ISomeSerializable"
+        }
+    },
+    "bd9bcf6666268b4ba823dc89914c4994": {
+        "Key": "bd9bcf6666268b4ba823dc89914c4994",
         "Kind": 3,
         "Children": {
             "613ee9436c9bee469ae906675f136bb7": {
@@ -18,23 +31,10 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "ISomeSerializable",
-            "tdg-type-name": "ISomeSerializable"
-        }
-    },
-    "af6f2440d6763d7d83614ac4c636583e": {
-        "Key": "af6f2440d6763d7d83614ac4c636583e",
-        "Kind": 8,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "8|NodeType|tdg",
-            "tdg-source-module": "tests/serializable.webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "d8b7cc1d",
             "tdg-type-name": "ISomeSerializable"
         }
     }

--- a/webidl/typeconstructor/tests/window.json
+++ b/webidl/typeconstructor/tests/window.json
@@ -1,4 +1,17 @@
 {
+    "0fd1a78c883ac612f8acde7c272efb10": {
+        "Key": "0fd1a78c883ac612f8acde7c272efb10",
+        "Kind": 3,
+        "Children": {},
+        "Predicates": {
+            "tdg-node-kind": "3|NodeType|tdg",
+            "tdg-source-module": "tests/(root).webidl",
+            "tdg-source-node": "(NodeRef)",
+            "tdg-type-exported": "true",
+            "tdg-type-globalid": "HTMLDocument",
+            "tdg-type-name": "HTMLDocument"
+        }
+    },
     "1b5ba4a88d4b3121f2ed24180d32462d": {
         "Key": "1b5ba4a88d4b3121f2ed24180d32462d",
         "Kind": 8,
@@ -12,14 +25,14 @@
             "tdg-type-name": "HTMLWindow"
         }
     },
-    "a9b6b17ba8ca64b527f74253bd8e8c05": {
-        "Key": "a9b6b17ba8ca64b527f74253bd8e8c05",
+    "4585d20056dffee190cfde9a9f83bada": {
+        "Key": "4585d20056dffee190cfde9a9f83bada",
         "Kind": 3,
         "Children": {
-            "207af0dfb98906d99d38cd5a346c0fad": {
+            "f8901e93b13d45d8c5b47c661a223d4f": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "207af0dfb98906d99d38cd5a346c0fad",
+                    "Key": "f8901e93b13d45d8c5b47c661a223d4f",
                     "Kind": 9,
                     "Children": {},
                     "Predicates": {
@@ -29,7 +42,7 @@
                         "tdg-member-resolved-type": "HTMLDocument",
                         "tdg-member-signature": "\n\u0008document\u0010\t \u0001*\u000cHTMLDocument",
                         "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "(root).webidl",
+                        "tdg-source-module": "tests/(root).webidl",
                         "tdg-source-node": "(NodeRef)"
                     }
                 }
@@ -37,24 +50,11 @@
         },
         "Predicates": {
             "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
+            "tdg-source-module": "tests/(root).webidl",
             "tdg-source-node": "(NodeRef)",
             "tdg-type-exported": "true",
             "tdg-type-globalid": "HTMLWindow",
             "tdg-type-name": "HTMLWindow"
-        }
-    },
-    "bed415bc7e5dc84aada58cb833aa8442": {
-        "Key": "bed415bc7e5dc84aada58cb833aa8442",
-        "Kind": 3,
-        "Children": {},
-        "Predicates": {
-            "tdg-node-kind": "3|NodeType|tdg",
-            "tdg-source-module": "(root).webidl",
-            "tdg-source-node": "(NodeRef)",
-            "tdg-type-exported": "true",
-            "tdg-type-globalid": "HTMLDocument",
-            "tdg-type-name": "HTMLDocument"
         }
     },
     "e72add5c504f926800c8bb060fee5724": {

--- a/webidl/typeconstructor/typeconstructor_test.go
+++ b/webidl/typeconstructor/typeconstructor_test.go
@@ -86,6 +86,7 @@ func TestGraphs(t *testing.T) {
 		graph, err := compilergraph.NewGraph("tests/" + test.entrypoint + ".webidl")
 		if err != nil {
 			t.Errorf("Got error on test %s: %v", test.name, err)
+			continue
 		}
 
 		testIRG := webidl.NewIRG(graph)
@@ -99,7 +100,9 @@ func TestGraphs(t *testing.T) {
 		irgResult := loader.Load(secondaryLibs...)
 
 		// Make sure we had no errors during construction.
-		assert.True(t, irgResult.Status, "Got error for IRG construction %v: %s", test.name, irgResult.Errors)
+		if !assert.True(t, irgResult.Status, "Got error for IRG construction %v: %s", test.name, irgResult.Errors) {
+			continue
+		}
 
 		// Construct the type graph.
 		result, _ := typegraph.BuildTypeGraphWithOption(graph, typegraph.BuildForTesting, GetConstructor(testIRG), typegraph.NewBasicTypesConstructorForTesting(graph))
@@ -111,7 +114,7 @@ func TestGraphs(t *testing.T) {
 			}
 
 			currentLayerView := result.Graph.GetFilteredJSONForm(
-				[]string{"tests/" + test.entrypoint + ".webidl", "(root).webidl"},
+				[]string{"tests/" + test.entrypoint + ".webidl", "tests/(root).webidl"},
 				[]compilergraph.TaggedValue{typegraph.NodeTypeModule})
 
 			if os.Getenv("REGEN") == "true" {

--- a/webidl/typeconstructor/util.go
+++ b/webidl/typeconstructor/util.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package typeconstructor
+
+import (
+	"path"
+	"strings"
+)
+
+// determineSharedRootDirectory returns the shared root directory for all the path strings
+// given. If there is none, returns an empty string.
+func determineSharedRootDirectory(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+
+	var commonPath = path.Dir(paths[0])
+	for _, current := range paths[1:] {
+		cleaned := path.Dir(current)
+		commonPath = commonPieces(cleaned, commonPath, "/")
+		if len(commonPath) == 0 {
+			break
+		}
+	}
+
+	if len(commonPath) == 0 {
+		return ""
+	}
+
+	return commonPath + "/"
+}
+
+// commonPieces returns the common prefix pieces of the given strings, broken into
+// pieces using the sep separator.
+func commonPieces(first string, second string, sep string) string {
+	firstPieces := strings.Split(first, sep)
+	secondPieces := strings.Split(second, sep)
+
+	var length = len(firstPieces)
+	if len(secondPieces) < len(firstPieces) {
+		length = len(secondPieces)
+	}
+
+	var collected = make([]string, 0, length)
+	for i := 0; i < length; i++ {
+		if firstPieces[i] != secondPieces[i] {
+			break
+		}
+
+		collected = append(collected, firstPieces[i])
+	}
+
+	return strings.Join(collected, sep)
+}

--- a/webidl/typeconstructor/util_test.go
+++ b/webidl/typeconstructor/util_test.go
@@ -1,0 +1,75 @@
+// Copyright 2017 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package typeconstructor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type sharedRootDirectoryTest struct {
+	paths        []string
+	expectedPath string
+}
+
+var sharedRootDirectoryTests = []sharedRootDirectoryTest{
+	sharedRootDirectoryTest{
+		[]string{"foo/bar"},
+		"foo/",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar", "foo/meh"},
+		"foo/",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar/baz", "foo/meh"},
+		"foo/",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar/baz", "something/meh"},
+		"",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar/baz/yarg", "foo/bar/baz", "foo/bar/something/else"},
+		"foo/bar/",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar/baz/yarg", "foo/baz", "foo/bar/something/else"},
+		"foo/",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/baz", "foo/bar/baz/yarg", "foo/bar/something/else"},
+		"foo/",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar/baz/yarg", "foo/bar/something/else", "foo/baz"},
+		"foo/",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar/baz/yarg", "bar/baz", "foo/bar/something/else"},
+		"",
+	},
+
+	sharedRootDirectoryTest{
+		[]string{"foo/bar/baz/yarg", "foo/bar/baz/something/else"},
+		"foo/bar/baz/",
+	},
+}
+
+func TestDetermineSharedRootDirectory(t *testing.T) {
+	for _, test := range sharedRootDirectoryTests {
+		result := determineSharedRootDirectory(test.paths)
+		assert.Equal(t, test.expectedPath, result, "Mismatch in root directory test `%s`", test.paths)
+	}
+}


### PR DESCRIPTION
Adds support for the new `package diff` command, which performs a diff-ing of a Serulian package, between its version at HEAD in the local client, and the latest released semantic version of that package. The diff displays to the user all changes, and whether the changes are breaking or not.

For example:

```sh
serulian package diff . -v
INFO: Listing versions for package...
INFO: Cloning version `v0.0.1+pre`...
INFO: Analyzing version `v0.0.1+pre`...
INFO: Analyzing HEAD...
INFO: Computing Diff...

v0.0.1+pre → HEAD: Breaking changes found
  Change summary:
    [Breaking]   An exported member in the package was removed
    [Compatible] An exported member in the package was added

  Detailed changes:
    [X] module member Span
    [+] module member Spans
```