### PR TITLE
Add new toolkit command: package rev

### DIFF
--- a/cmd/serulian/main.go
+++ b/cmd/serulian/main.go
@@ -29,6 +29,7 @@ var (
 	profile                   bool
 	addr                      string
 	verbose                   bool
+	revisionNote              string
 )
 
 func disableGC() {
@@ -235,7 +236,27 @@ func main() {
 		},
 	}
 
+	var cmdRev = &cobra.Command{
+		Use:   "rev [package path] (compare-version)",
+		Short: "Tags this package with a semantic version computed against latest tagged",
+		Long:  `Tags this package with a semantic version computed against latest tagged (or that specified)`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				fmt.Println("Expected package path")
+				os.Exit(-1)
+			}
+
+			compareVersion := ""
+			if len(args) > 1 {
+				compareVersion = args[1]
+			}
+
+			packagetools.Revise(args[0], compareVersion, revisionNote, verbose, debug, vcsDevelopmentDirectories...)
+		},
+	}
+
 	cmdPackage.AddCommand(cmdDiff)
+	cmdPackage.AddCommand(cmdRev)
 
 	// Register command-specific flags.
 	cmdBuild.PersistentFlags().StringSliceVar(&vcsDevelopmentDirectories, "vcs-dev-dir", []string{},
@@ -257,6 +278,12 @@ func main() {
 
 	cmdDiff.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
 		"Whether to show full diff output")
+
+	cmdRev.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
+		"Whether to show full diff output")
+
+	cmdRev.PersistentFlags().StringVarP(&revisionNote, "revision-note", "n", "",
+		"If specified, the note to use when tagging the new version")
 
 	// Decorate the test commands.
 	tester.DecorateRunners(cmdTest, &vcsDevelopmentDirectories)

--- a/compilerutil/semver.go
+++ b/compilerutil/semver.go
@@ -16,8 +16,54 @@ const (
 	UpdateVersionMinor UpdateVersionOption = "minor"
 
 	// UpdateVersionMajor indicates the both minor and major version updates are allowed.
-	UpdateVersionMajor = "major"
+	UpdateVersionMajor UpdateVersionOption = "major"
 )
+
+// NextVersionOption defines the options for the NextSemanticVersion method.
+type NextVersionOption string
+
+const (
+	// NextMajorVersion indicates that the major version field should be incremented.
+	NextMajorVersion NextVersionOption = "major"
+
+	// NextMinorVersion indicates that the minor version field should be incremented.
+	NextMinorVersion NextVersionOption = "minor"
+
+	// NextPatchVersion indicates that the patch version field should be incremented.
+	NextPatchVersion NextVersionOption = "patch"
+)
+
+// NextSemanticVersion returns the next logic semantic version from the current version, given the
+// update option.
+func NextSemanticVersion(currentVersionString string, option NextVersionOption) (string, error) {
+	version, err := semver.ParseTolerant(currentVersionString)
+	if err != nil {
+		return "", err
+	}
+
+	// Clear the Pre and Build fields.
+	version.Pre = []semver.PRVersion{}
+	version.Build = []string{}
+
+	switch option {
+	case NextMajorVersion:
+		version.Major++
+		version.Minor = 0
+		version.Patch = 0
+
+	case NextMinorVersion:
+		version.Minor++
+		version.Patch = 0
+
+	case NextPatchVersion:
+		version.Patch++
+
+	default:
+		panic("Unknown NextVersionOption")
+	}
+
+	return version.String(), nil
+}
 
 // LatestSemanticVersion returns the latest non-patch semantic version found in the list of available
 // versions, if any.

--- a/compilerutil/semver_test.go
+++ b/compilerutil/semver_test.go
@@ -10,7 +10,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type semvarUpdateTest struct {
+type semverNextTest struct {
+	currentVersion string
+	option         NextVersionOption
+	resultVersion  string
+}
+
+var semverNextTests = []semverNextTest{
+	semverNextTest{"1.0.0", NextPatchVersion, "1.0.1"},
+	semverNextTest{"1.0.0", NextMinorVersion, "1.1.0"},
+	semverNextTest{"1.0.0", NextMajorVersion, "2.0.0"},
+
+	semverNextTest{"1.1.2", NextPatchVersion, "1.1.3"},
+	semverNextTest{"1.1.2", NextMinorVersion, "1.2.0"},
+	semverNextTest{"1.1.2", NextMajorVersion, "2.0.0"},
+
+	semverNextTest{"1.1.2-foo", NextPatchVersion, "1.1.3"},
+	semverNextTest{"1.1.2-foo", NextMinorVersion, "1.2.0"},
+	semverNextTest{"1.1.2-foo", NextMajorVersion, "2.0.0"},
+
+	semverNextTest{"1.1.2+foo", NextPatchVersion, "1.1.3"},
+	semverNextTest{"1.1.2+foo", NextMinorVersion, "1.2.0"},
+	semverNextTest{"1.1.2+foo", NextMajorVersion, "2.0.0"},
+}
+
+func TestNextSemanticVersion(t *testing.T) {
+	for _, test := range semverNextTests {
+		resultVersion, err := NextSemanticVersion(test.currentVersion, test.option)
+		if !assert.Nil(t, err, "Mismatch in status for next test `%s`", test.currentVersion) {
+			continue
+		}
+
+		if !assert.Equal(t, test.resultVersion, resultVersion, "Mismatch in result version for next test `%s`", test.currentVersion) {
+			continue
+		}
+	}
+}
+
+type semverUpdateTest struct {
 	currentVersion    string
 	availableVersions []string
 	option            UpdateVersionOption
@@ -18,29 +55,29 @@ type semvarUpdateTest struct {
 	status            bool
 }
 
-var semvarUpdateTests = []semvarUpdateTest{
+var semverUpdateTests = []semverUpdateTest{
 	// Success tests.
-	semvarUpdateTest{"1.0.0", []string{}, UpdateVersionMinor, "1.0.0", true},
-	semvarUpdateTest{"1.0.0", []string{"1.0.0"}, UpdateVersionMinor, "1.0.0", true},
-	semvarUpdateTest{"1.0.0", []string{"1.1.0"}, UpdateVersionMinor, "1.1.0", true},
-	semvarUpdateTest{"1.0.0", []string{"1.1.0pre"}, UpdateVersionMinor, "1.0.0", true},
+	semverUpdateTest{"1.0.0", []string{}, UpdateVersionMinor, "1.0.0", true},
+	semverUpdateTest{"1.0.0", []string{"1.0.0"}, UpdateVersionMinor, "1.0.0", true},
+	semverUpdateTest{"1.0.0", []string{"1.1.0"}, UpdateVersionMinor, "1.1.0", true},
+	semverUpdateTest{"1.0.0", []string{"1.1.0pre"}, UpdateVersionMinor, "1.0.0", true},
 
-	semvarUpdateTest{"1.0.0", []string{"1.1.0", "2.0.0"}, UpdateVersionMinor, "1.1.0", true},
-	semvarUpdateTest{"1.0.0", []string{"2.1.0", "1.1.0"}, UpdateVersionMinor, "1.1.0", true},
-	semvarUpdateTest{"1.0.0", []string{"1.1.0", "2.0.0"}, UpdateVersionMajor, "2.0.0", true},
-	semvarUpdateTest{"1.0.0", []string{"3.1.4", "1.1.0", "2.0.0"}, UpdateVersionMajor, "3.1.4", true},
+	semverUpdateTest{"1.0.0", []string{"1.1.0", "2.0.0"}, UpdateVersionMinor, "1.1.0", true},
+	semverUpdateTest{"1.0.0", []string{"2.1.0", "1.1.0"}, UpdateVersionMinor, "1.1.0", true},
+	semverUpdateTest{"1.0.0", []string{"1.1.0", "2.0.0"}, UpdateVersionMajor, "2.0.0", true},
+	semverUpdateTest{"1.0.0", []string{"3.1.4", "1.1.0", "2.0.0"}, UpdateVersionMajor, "3.1.4", true},
 
 	// Failure tests.
-	semvarUpdateTest{"", []string{}, UpdateVersionMinor, "", false},
-	semvarUpdateTest{"a.b.c", []string{}, UpdateVersionMinor, "", false},
-	semvarUpdateTest{"1.03.0", []string{}, UpdateVersionMinor, "", false},
-	semvarUpdateTest{"v1.03.0", []string{}, UpdateVersionMinor, "", false},
+	semverUpdateTest{"", []string{}, UpdateVersionMinor, "", false},
+	semverUpdateTest{"a.b.c", []string{}, UpdateVersionMinor, "", false},
+	semverUpdateTest{"1.03.0", []string{}, UpdateVersionMinor, "", false},
+	semverUpdateTest{"v1.03.0", []string{}, UpdateVersionMinor, "", false},
 }
 
 func TestSemanticUpdateVersion(t *testing.T) {
-	for _, test := range semvarUpdateTests {
+	for _, test := range semverUpdateTests {
 		resultVersion, err := SemanticUpdateVersion(test.currentVersion, test.availableVersions, test.option)
-		if !assert.Equal(t, test.status, err == nil, "Mismatch in status for test `%s`", test.currentVersion) {
+		if !assert.Equal(t, test.status, err == nil, "Mismatch in status for update test `%s`", test.currentVersion) {
 			continue
 		}
 
@@ -48,7 +85,7 @@ func TestSemanticUpdateVersion(t *testing.T) {
 			continue
 		}
 
-		if !assert.Equal(t, test.resultVersion, resultVersion, "Mismatch in result version for test `%s`", test.currentVersion) {
+		if !assert.Equal(t, test.resultVersion, resultVersion, "Mismatch in result version for update test `%s`", test.currentVersion) {
 			continue
 		}
 	}

--- a/vcs/handler_fakegit.go
+++ b/vcs/handler_fakegit.go
@@ -25,7 +25,7 @@ func (fgv fakeGitVcs) Checkout(path vcsPackagePath, downloadPath string, checkou
 	panic("Fake git!")
 }
 
-func (fgv fakeGitVcs) HasLocalChanges(checkoutDir string) bool {
+func (fgv fakeGitVcs) HasLocalChanges(checkoutDir string, ignoreEntries ...string) bool {
 	panic("Fake git!")
 }
 
@@ -46,5 +46,9 @@ func (fgv fakeGitVcs) IsDetached(checkoutDir string) (bool, error) {
 }
 
 func (fgv fakeGitVcs) GetPackagePath(checkoutDir string) (vcsPackagePath, error) {
+	panic("Fake git!")
+}
+
+func (fgv fakeGitVcs) Tag(checkoutDir string, tag string, message string) error {
 	panic("Fake git!")
 }

--- a/vcs/handlers.go
+++ b/vcs/handlers.go
@@ -16,7 +16,7 @@ type VCSHandler interface {
 	Checkout(path vcsPackagePath, downloadPath string, checkoutDir string) error
 
 	// HasLocalChanges detects whether the directory has uncommitted code changes.
-	HasLocalChanges(checkoutDir string) bool
+	HasLocalChanges(checkoutDir string, ignoreEntries ...string) bool
 
 	// Update performs a pull/update of a checked out directory.
 	Update(checkoutDir string) error
@@ -32,6 +32,9 @@ type VCSHandler interface {
 
 	// GetPackagePath returns the VCS Package Path information for the checked out directory.
 	GetPackagePath(checkoutDir string) (vcsPackagePath, error)
+
+	// Tag tags the revision in the checked out directory with the given tag.
+	Tag(checkoutDir string, tag string, message string) error
 }
 
 var vcsByKind = map[string]VCSHandler{


### PR DESCRIPTION
The `package rev` command allows for easy revision and tagging, with automatic version detection, of a package:

```sh
serulian package rev . -v -n "This is the new version"
INFO: Listing versions for package...
INFO: Cloning version `v0.0.1+pre`...
INFO: Analyzing version `v0.0.1+pre`...
INFO: Analyzing HEAD...
INFO: Computing Diff...

v0.0.1+pre → HEAD: No changes found

SUCCESS: Package `.` tagged with revised version `0.0.2`
```