### PR TITLE
Fix panic in SRG if given a type path with more than 2 segments

### DIFF
--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1611,6 +1611,10 @@ var scopeGraphTests = []scopegraphTest{
 	scopegraphTest{"known issue panic test", "knownissues", "knownissue1",
 		[]expectedScopeEntry{},
 		"Operator 'equals' is not defined on type 'T'", ""},
+
+	scopegraphTest{"known issue 2 panic test", "knownissues", "knownissue2",
+		[]expectedScopeEntry{},
+		"Type 'foo.bar.baz' could not be found", ""},
 }
 
 func TestGraphs(t *testing.T) {

--- a/graphs/scopegraph/tests/knownissues/knownissue2.seru
+++ b/graphs/scopegraph/tests/knownissues/knownissue2.seru
@@ -1,0 +1,1 @@
+var SomeVar foo.bar.baz?

--- a/graphs/srg/modules_typeresolver.go
+++ b/graphs/srg/modules_typeresolver.go
@@ -54,8 +54,13 @@ func (m SRGModule) ResolveTypePath(path string) (TypeResolutionResult, bool) {
 func (m SRGModule) resolveTypePathNoCaching(path string) (TypeResolutionResult, bool) {
 	pieces := strings.Split(path, ".")
 
-	if len(pieces) < 1 || len(pieces) > 2 {
-		panic(fmt.Sprintf("Expected type string with one or two pieces, found: %v", pieces))
+	if len(pieces) < 1 {
+		panic(fmt.Sprintf("Expected type string with at least one piece, found: %v", pieces))
+	}
+
+	if len(pieces) > 2 {
+		// Parseable but can never resolve.
+		return TypeResolutionResult{}, false
 	}
 
 	// If there is only a single piece, this is a local-module type, alias or reference to


### PR DESCRIPTION
This is technically parseable, but will never refer to a valid type (under current typing rules), so we simply return it cannot be found