### PR TITLE
Add support for constant fields at the module level

### DIFF
--- a/generator/es5/tests/module/basic.js
+++ b/generator/es5/tests/module/basic.js
@@ -4,7 +4,7 @@ $module('basic', function () {
     return $g.basic.someBool;
   };
   $static.TEST = function () {
-    return $g.basic.anotherBool;
+    return $t.fastbox($g.basic.anotherBool.$wrapped && ($g.basic.anotherInt.$wrapped == 42), $g.________testlib.basictypes.Boolean);
   };
   this.$init(function () {
     return $promise.new(function (resolve) {
@@ -18,4 +18,10 @@ $module('basic', function () {
       resolve();
     });
   }, '0893c862', ['af4b3683']);
+  this.$init(function () {
+    return $promise.new(function (resolve) {
+      $static.anotherInt = $t.fastbox(42, $g.________testlib.basictypes.Integer);
+      resolve();
+    });
+  }, '02c976cb', []);
 });

--- a/generator/es5/tests/module/basic.seru
+++ b/generator/es5/tests/module/basic.seru
@@ -4,4 +4,6 @@ function AnotherFunction() bool { return someBool }
 
 var anotherBool bool = AnotherFunction()
 
-function TEST() any { return anotherBool }
+const anotherInt int  = 42
+
+function TEST() any { return anotherBool && anotherInt == 42 }

--- a/graphs/scopegraph/promise_labeler_test.go
+++ b/graphs/scopegraph/promise_labeler_test.go
@@ -214,7 +214,7 @@ var promisingLabelTests = []promisingLabelTest{
 
 	promisingLabelTest{"async var does not cause promising test", "asyncvarnotpromising",
 		[]expectedPromiseLabel{
-			expectedPromiseLabel{"SomeVar", proto.ScopeLabel_SML_PROMISING_YES},
+			expectedPromiseLabel{"someVar", proto.ScopeLabel_SML_PROMISING_YES},
 			expectedPromiseLabel{"TEST", proto.ScopeLabel_SML_PROMISING_NO},
 		},
 	},

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1584,6 +1584,18 @@ var scopeGraphTests = []scopegraphTest{
 		[]expectedScopeEntry{},
 		"Initialization cycle found on module member foo: module member foo -> module member DoSomething -> module member DoSomethingElse -> module member foo", ""},
 
+	/////////// const var tests /////////////////
+
+	scopegraphTest{"const var success test", "constvar", "success",
+		[]expectedScopeEntry{
+			expectedScopeEntry{"somestring", expectedScope{true, proto.ScopeKind_VALUE, "String", "void"}},
+		},
+		"", ""},
+
+	scopegraphTest{"const var assignment failure test", "constvar", "assignfailure",
+		[]expectedScopeEntry{},
+		"Cannot assign to non-assignable module member SomeString", ""},
+
 	/////////// agent tests /////////////////
 
 	scopegraphTest{"agent constructor success test", "agent", "constructor",

--- a/graphs/scopegraph/tests/constvar/assignfailure.seru
+++ b/graphs/scopegraph/tests/constvar/assignfailure.seru
@@ -1,0 +1,5 @@
+const SomeString string = 'hello world'
+
+function DoSomething() {
+    SomeString = 'foo'
+}

--- a/graphs/scopegraph/tests/constvar/success.seru
+++ b/graphs/scopegraph/tests/constvar/success.seru
@@ -1,0 +1,5 @@
+const SomeString string = 'hello world'
+
+function DoSomething() {
+    /* somestring */SomeString
+}

--- a/graphs/scopegraph/tests/knownissues/knownissue2.seru
+++ b/graphs/scopegraph/tests/knownissues/knownissue2.seru
@@ -1,1 +1,1 @@
-var SomeVar foo.bar.baz?
+var someVar foo.bar.baz?

--- a/graphs/scopegraph/tests/memberaccess/anothermodule.seru
+++ b/graphs/scopegraph/tests/memberaccess/anothermodule.seru
@@ -1,4 +1,4 @@
-var SomeInt int = 2
+const SomeInt int = 2
 
 var someUnexportedThing int = 4
 

--- a/graphs/scopegraph/tests/promising/asyncvarnotpromising.seru
+++ b/graphs/scopegraph/tests/promising/asyncvarnotpromising.seru
@@ -1,5 +1,5 @@
 function DoSomethingAsync() int { return 42 }
 
-var SomeVar int = <- DoSomethingAsync()
+var someVar int = <- DoSomethingAsync()
 
-function TEST() int { return SomeVar + 10 }
+function TEST() int { return someVar + 10 }

--- a/graphs/srg/members.go
+++ b/graphs/srg/members.go
@@ -194,7 +194,14 @@ func (m SRGMember) AsImplementable() SRGImplementable {
 	return SRGImplementable{m.GraphNode, m.srg}
 }
 
-// IsReadOnly returns whether the member is marked as explicitly read-only.
+// IsConstant returns whether the member is marked as explicitly constant. Only applies to variables
+// under modules.
+func (m SRGMember) IsConstant() bool {
+	_, exists := m.GraphNode.TryGet(sourceshape.NodeVariableStatementConstant)
+	return exists
+}
+
+// IsReadOnly returns whether the member is marked as explicitly read-only. Only applies to properties.
 func (m SRGMember) IsReadOnly() bool {
 	_, exists := m.GraphNode.TryGet(sourceshape.NodePropertyReadOnly)
 	return exists

--- a/graphs/srg/typeconstructor/tests/modulelevel/module.json
+++ b/graphs/srg/typeconstructor/tests/modulelevel/module.json
@@ -3,27 +3,6 @@
         "Key": "397026063ed7ec70d02fafaf759e4a68",
         "Kind": 7,
         "Children": {
-            "251c4a5593b49ba10ea8ddc12f43b888": {
-                "Predicate": "tdg-node-member",
-                "Child": {
-                    "Key": "251c4a5593b49ba10ea8ddc12f43b888",
-                    "Kind": 9,
-                    "Children": {},
-                    "Predicates": {
-                        "tdg-member-exported": "true",
-                        "tdg-member-field": "true",
-                        "tdg-member-hasdefault": "true",
-                        "tdg-member-name": "SomeVar",
-                        "tdg-member-promising": "1",
-                        "tdg-member-resolved-type": "Integer",
-                        "tdg-member-signature": "\n\u0007somevar\u0010\u0005\u0018\u0001 \u0001*\u0007Integer",
-                        "tdg-member-static": "true",
-                        "tdg-node-kind": "9|NodeType|tdg",
-                        "tdg-source-module": "tests/modulelevel/module.seru",
-                        "tdg-source-node": "(NodeRef)"
-                    }
-                }
-            },
             "5245507d7fabdbbef61cac86597788c2": {
                 "Predicate": "tdg-node-member",
                 "Child": {
@@ -51,6 +30,26 @@
                         "tdg-member-readonly": "true",
                         "tdg-member-resolved-type": "function\u003cAwaitable\u003cvoid\u003e\u003e",
                         "tdg-member-signature": "\n\u0010dosomethingasync\u0010\u0002 \u0001*\u0019function\u003cAwaitable\u003cvoid\u003e\u003e",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/modulelevel/module.seru",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
+            "5d2f9d85c7be526fcea02014301d22d5": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "5d2f9d85c7be526fcea02014301d22d5",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-field": "true",
+                        "tdg-member-hasdefault": "true",
+                        "tdg-member-name": "someVar",
+                        "tdg-member-promising": "1",
+                        "tdg-member-resolved-type": "Integer",
+                        "tdg-member-signature": "\n\u0007somevar\u0010\u0005\u0018\u0001*\u0007Integer",
                         "tdg-member-static": "true",
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/modulelevel/module.seru",

--- a/graphs/srg/typeconstructor/tests/modulelevel/module.json
+++ b/graphs/srg/typeconstructor/tests/modulelevel/module.json
@@ -3,6 +3,27 @@
         "Key": "397026063ed7ec70d02fafaf759e4a68",
         "Kind": 7,
         "Children": {
+            "251c4a5593b49ba10ea8ddc12f43b888": {
+                "Predicate": "tdg-node-member",
+                "Child": {
+                    "Key": "251c4a5593b49ba10ea8ddc12f43b888",
+                    "Kind": 9,
+                    "Children": {},
+                    "Predicates": {
+                        "tdg-member-exported": "true",
+                        "tdg-member-field": "true",
+                        "tdg-member-hasdefault": "true",
+                        "tdg-member-name": "SomeVar",
+                        "tdg-member-promising": "1",
+                        "tdg-member-resolved-type": "Integer",
+                        "tdg-member-signature": "\n\u0007somevar\u0010\u0005\u0018\u0001 \u0001*\u0007Integer",
+                        "tdg-member-static": "true",
+                        "tdg-node-kind": "9|NodeType|tdg",
+                        "tdg-source-module": "tests/modulelevel/module.seru",
+                        "tdg-source-node": "(NodeRef)"
+                    }
+                }
+            },
             "5245507d7fabdbbef61cac86597788c2": {
                 "Predicate": "tdg-node-member",
                 "Child": {
@@ -37,18 +58,21 @@
                     }
                 }
             },
-            "6c882d400479b080a744d54cf04550a1": {
+            "ce03ab8d4cf52aae6ba9f0502e6700ec": {
                 "Predicate": "tdg-node-member",
                 "Child": {
-                    "Key": "6c882d400479b080a744d54cf04550a1",
+                    "Key": "ce03ab8d4cf52aae6ba9f0502e6700ec",
                     "Kind": 9,
                     "Children": {},
                     "Predicates": {
                         "tdg-member-exported": "true",
                         "tdg-member-field": "true",
-                        "tdg-member-name": "SomeVar",
-                        "tdg-member-resolved-type": "Integer",
-                        "tdg-member-signature": "\n\u0007somevar\u0010\u0005\u0018\u0001 \u0001*\u0007Integer",
+                        "tdg-member-hasdefault": "true",
+                        "tdg-member-name": "SomeConstant",
+                        "tdg-member-promising": "1",
+                        "tdg-member-readonly": "true",
+                        "tdg-member-resolved-type": "String",
+                        "tdg-member-signature": "\n\u000csomeconstant\u0010\u0005 \u0001*\u0006String",
                         "tdg-member-static": "true",
                         "tdg-node-kind": "9|NodeType|tdg",
                         "tdg-source-module": "tests/modulelevel/module.seru",

--- a/graphs/srg/typeconstructor/tests/modulelevel/module.seru
+++ b/graphs/srg/typeconstructor/tests/modulelevel/module.seru
@@ -1,4 +1,5 @@
-var SomeVar int
+var SomeVar int = 42
+const SomeConstant string = 'hello world'
 
 function DoSomething() int {}
 

--- a/graphs/srg/typeconstructor/tests/modulelevel/module.seru
+++ b/graphs/srg/typeconstructor/tests/modulelevel/module.seru
@@ -1,4 +1,4 @@
-var SomeVar int = 42
+var someVar int = 42
 const SomeConstant string = 'hello world'
 
 function DoSomething() int {}

--- a/graphs/srg/typeconstructor/typeconstructor.go
+++ b/graphs/srg/typeconstructor/typeconstructor.go
@@ -299,11 +299,11 @@ func (stc *srgTypeConstructor) decorateMember(member srg.SRGMember, parent typeg
 	var memberType typegraph.TypeReference = graph.AnyTypeReference()
 	var memberKind typegraph.MemberSignatureKind = typegraph.CustomMemberSignature
 
-	var isReadOnly bool = true
-	var isStatic bool = false
+	var isReadOnly = true
+	var isStatic = false
 	var isPromising = typegraph.MemberPromisingDynamic
-	var isImplicitlyCalled bool = false
-	var hasDefaultValue bool = false
+	var isImplicitlyCalled = false
+	var hasDefaultValue = false
 	var isField = false
 
 	switch member.MemberKind() {
@@ -312,7 +312,7 @@ func (stc *srgTypeConstructor) decorateMember(member srg.SRGMember, parent typeg
 		memberType, _ = stc.resolvePossibleType(member.Node(), member.DeclaredType, graph, reporter)
 		memberKind = typegraph.FieldMemberSignature
 
-		isReadOnly = false
+		isReadOnly = member.IsConstant()
 		isField = true
 
 		_, hasDefaultValue = member.Node().TryGetNode(sourceshape.NodePredicateTypeFieldDefaultValue)

--- a/parser/v1/lex.go
+++ b/parser/v1/lex.go
@@ -178,6 +178,7 @@ var keywords = map[string]bool{
 	"var":         true,
 	"constructor": true,
 	"operator":    true,
+	"const":       true,
 
 	"static": true,
 	"void":   true,

--- a/parser/v1/parser_test.go
+++ b/parser/v1/parser_test.go
@@ -115,6 +115,7 @@ var parserTests = []parserTest{
 	// Module success tests.
 	{"module variable test", "module/module_var"},
 	{"module variable no declared type test", "module/module_var_nodeclare"},
+	{"module const no declared type test", "module/module_const_nodeclare"},
 	{"module function test", "module/module_function"},
 	{"void function test", "module/void_function"},
 
@@ -170,6 +171,7 @@ var parserTests = []parserTest{
 	{"class fields test", "class/fields"},
 	{"basic class operator with return type test", "class/operator_returns"},
 	{"class constructor no params stest", "class/constructor_noparams"},
+	{"class const not allowed test", "class/class_const"},
 
 	// Interface member success tests.
 	{"basic interface function test", "interface/basic_function"},

--- a/parser/v1/tests/class/class_const.seru
+++ b/parser/v1/tests/class/class_const.seru
@@ -1,0 +1,3 @@
+class SomeClass {
+    const someConst bool = true
+}

--- a/parser/v1/tests/class/class_const.tree
+++ b/parser/v1/tests/class/class_const.tree
@@ -1,0 +1,16 @@
+NodeTypeFile
+  end-rune = 50
+  input-source = class const not allowed test
+  start-rune = 0
+  child-node =>
+    NodeTypeClass
+      end-rune = 50
+      input-source = class const not allowed test
+      named = SomeClass
+      start-rune = 0
+      child-node =>
+        NodeTypeError
+          end-rune = 16
+          error-message = Expected type member, found const
+          input-source = class const not allowed test
+          start-rune = 22

--- a/parser/v1/tests/module/module_const_nodeclare.seru
+++ b/parser/v1/tests/module/module_const_nodeclare.seru
@@ -1,0 +1,1 @@
+const foo = 2

--- a/parser/v1/tests/module/module_const_nodeclare.tree
+++ b/parser/v1/tests/module/module_const_nodeclare.tree
@@ -1,0 +1,23 @@
+NodeTypeFile
+  end-rune = 12
+  input-source = module const no declared type test
+  start-rune = 0
+  child-node =>
+    NodeTypeVariable
+      end-rune = 12
+      input-source = module const no declared type test
+      named = foo
+      start-rune = 0
+      var-const = true
+      child-node =>
+        NodeTypeError
+          end-rune = 8
+          error-message = Member or class-level constant foo requires an explicitly declared type
+          input-source = module const no declared type test
+          start-rune = 10
+      typemember-field-default-value =>
+        NodeNumericLiteralExpression
+          end-rune = 12
+          input-source = module const no declared type test
+          literal-value = 2
+          start-rune = 12

--- a/parser/v1/tests/module/module_var.seru
+++ b/parser/v1/tests/module/module_var.seru
@@ -1,1 +1,2 @@
 var something int = 2
+const someConst string = 'hello world'

--- a/parser/v1/tests/module/module_var.tree
+++ b/parser/v1/tests/module/module_var.tree
@@ -1,5 +1,5 @@
 NodeTypeFile
-  end-rune = 20
+  end-rune = 60
   input-source = module variable test
   start-rune = 0
   child-node =>
@@ -30,3 +30,31 @@ NodeTypeFile
           input-source = module variable test
           literal-value = 2
           start-rune = 20
+    NodeTypeVariable
+      end-rune = 59
+      input-source = module variable test
+      named = someConst
+      start-rune = 22
+      var-const = true
+      typemember-declared-type =>
+        NodeTypeTypeReference
+          end-rune = 43
+          input-source = module variable test
+          start-rune = 38
+          typereference-path =>
+            NodeTypeIdentifierPath
+              end-rune = 43
+              input-source = module variable test
+              start-rune = 38
+              identifierpath-root =>
+                NodeTypeIdentifierAccess
+                  end-rune = 43
+                  identifieraccess-name = string
+                  input-source = module variable test
+                  start-rune = 38
+      typemember-field-default-value =>
+        NodeStringLiteralExpression
+          end-rune = 59
+          input-source = module variable test
+          literal-value = 'hello world'
+          start-rune = 47

--- a/sourceshape/sourceshape.go
+++ b/sourceshape/sourceshape.go
@@ -385,6 +385,7 @@ const (
 	NodeVariableStatementDeclaredType = "var-declared-type"
 	NodeVariableStatementName         = "named"
 	NodeVariableStatementExpression   = "var-expr"
+	NodeVariableStatementConstant     = "var-const"
 
 	//
 	// NodeTypeSmlExpression


### PR DESCRIPTION
This PR adds support for constant fields at the module level, declared using the `const` keyword:

```
const SomeConstant int = 42
```

In addition to supporting constant fields at this level, the type graph now **requires** exported module fields to be constant, to ensure good coding practices