### PR TITLE
Allow lambda parameters in inline lambdas to have explicitly declared types

### DIFF
--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1325,6 +1325,12 @@ var scopeGraphTests = []scopegraphTest{
 		},
 		"", ""},
 
+	scopegraphTest{"lambda expression mixed inference test", "lambda", "mixed",
+		[]expectedScopeEntry{
+			expectedScopeEntry{"varref", expectedScope{true, proto.ScopeKind_VALUE, "function<Boolean>(Integer, String?)", "void"}},
+		},
+		"", ""},
+
 	scopegraphTest{"lambda expression full definition test", "lambda", "full",
 		[]expectedScopeEntry{
 			expectedScopeEntry{"implicitreturn", expectedScope{true, proto.ScopeKind_VALUE, "function<Integer>(Integer, Boolean)", "void"}},

--- a/graphs/scopegraph/tests/lambda/mixed.seru
+++ b/graphs/scopegraph/tests/lambda/mixed.seru
@@ -1,0 +1,4 @@
+function DoSomething() {
+	var someVar = /* varref */(a, b string?) => true
+	someVar(1)
+}

--- a/parser/v1/tests/expression/lambda.seru
+++ b/parser/v1/tests/expression/lambda.seru
@@ -2,4 +2,7 @@ function SomeFunction() {
 	() => someExpr
 	(a) => someOtherExpr
 	(a, b) => someThirdExpr
+	(a int, b string*) => someTypedExpr
+	(a, b []string, c) => anotherExpr
+	(a, b foo.bar, c) => anotherExpr
 }

--- a/parser/v1/tests/expression/lambda.tree
+++ b/parser/v1/tests/expression/lambda.tree
@@ -1,16 +1,16 @@
 NodeTypeFile
-  end-rune = 89
+  end-rune = 195
   input-source = lambda expr test
   start-rune = 0
   child-node =>
     NodeTypeFunction
-      end-rune = 89
+      end-rune = 195
       input-source = lambda expr test
       named = SomeFunction
       start-rune = 0
       definition-body =>
         NodeTypeStatementBlock
-          end-rune = 89
+          end-rune = 195
           input-source = lambda expr test
           start-rune = 24
           block-child =>
@@ -76,3 +76,171 @@ NodeTypeFile
                       input-source = lambda expr test
                       named = b
                       start-rune = 69
+            NodeTypeExpressionStatement
+              end-rune = 125
+              input-source = lambda expr test
+              start-rune = 90
+              expr-statement-expr =>
+                NodeTypeLambdaExpression
+                  end-rune = 124
+                  input-source = lambda expr test
+                  start-rune = 90
+                  lambda-expression-child-expr =>
+                    NodeTypeIdentifierExpression
+                      end-rune = 124
+                      identexpr-name = someTypedExpr
+                      input-source = lambda expr test
+                      start-rune = 112
+                  lambda-expression-inferred-parameter =>
+                    NodeTypeLambdaParameter
+                      end-rune = 95
+                      input-source = lambda expr test
+                      named = a
+                      start-rune = 91
+                      lambda-expression-parameter-explicit-type =>
+                        NodeTypeTypeReference
+                          end-rune = 95
+                          input-source = lambda expr test
+                          start-rune = 93
+                          typereference-path =>
+                            NodeTypeIdentifierPath
+                              end-rune = 95
+                              input-source = lambda expr test
+                              start-rune = 93
+                              identifierpath-root =>
+                                NodeTypeIdentifierAccess
+                                  end-rune = 95
+                                  identifieraccess-name = int
+                                  input-source = lambda expr test
+                                  start-rune = 93
+                    NodeTypeLambdaParameter
+                      end-rune = 106
+                      input-source = lambda expr test
+                      named = b
+                      start-rune = 98
+                      lambda-expression-parameter-explicit-type =>
+                        NodeTypeStream
+                          end-rune = 106
+                          input-source = lambda expr test
+                          start-rune = 100
+                          typereference-inner-type =>
+                            NodeTypeTypeReference
+                              end-rune = 105
+                              input-source = lambda expr test
+                              start-rune = 100
+                              typereference-path =>
+                                NodeTypeIdentifierPath
+                                  end-rune = 105
+                                  input-source = lambda expr test
+                                  start-rune = 100
+                                  identifierpath-root =>
+                                    NodeTypeIdentifierAccess
+                                      end-rune = 105
+                                      identifieraccess-name = string
+                                      input-source = lambda expr test
+                                      start-rune = 100
+            NodeTypeExpressionStatement
+              end-rune = 160
+              input-source = lambda expr test
+              start-rune = 127
+              expr-statement-expr =>
+                NodeTypeLambdaExpression
+                  end-rune = 159
+                  input-source = lambda expr test
+                  start-rune = 127
+                  lambda-expression-child-expr =>
+                    NodeTypeIdentifierExpression
+                      end-rune = 159
+                      identexpr-name = anotherExpr
+                      input-source = lambda expr test
+                      start-rune = 149
+                  lambda-expression-inferred-parameter =>
+                    NodeTypeLambdaParameter
+                      end-rune = 128
+                      input-source = lambda expr test
+                      named = a
+                      start-rune = 128
+                    NodeTypeLambdaParameter
+                      end-rune = 140
+                      input-source = lambda expr test
+                      named = b
+                      start-rune = 131
+                      lambda-expression-parameter-explicit-type =>
+                        NodeTypeSlice
+                          end-rune = 140
+                          input-source = lambda expr test
+                          start-rune = 133
+                          typereference-inner-type =>
+                            NodeTypeTypeReference
+                              end-rune = 140
+                              input-source = lambda expr test
+                              start-rune = 135
+                              typereference-path =>
+                                NodeTypeIdentifierPath
+                                  end-rune = 140
+                                  input-source = lambda expr test
+                                  start-rune = 135
+                                  identifierpath-root =>
+                                    NodeTypeIdentifierAccess
+                                      end-rune = 140
+                                      identifieraccess-name = string
+                                      input-source = lambda expr test
+                                      start-rune = 135
+                    NodeTypeLambdaParameter
+                      end-rune = 143
+                      input-source = lambda expr test
+                      named = c
+                      start-rune = 143
+            NodeTypeExpressionStatement
+              end-rune = 194
+              input-source = lambda expr test
+              start-rune = 162
+              expr-statement-expr =>
+                NodeTypeLambdaExpression
+                  end-rune = 193
+                  input-source = lambda expr test
+                  start-rune = 162
+                  lambda-expression-child-expr =>
+                    NodeTypeIdentifierExpression
+                      end-rune = 193
+                      identexpr-name = anotherExpr
+                      input-source = lambda expr test
+                      start-rune = 183
+                  lambda-expression-inferred-parameter =>
+                    NodeTypeLambdaParameter
+                      end-rune = 163
+                      input-source = lambda expr test
+                      named = a
+                      start-rune = 163
+                    NodeTypeLambdaParameter
+                      end-rune = 174
+                      input-source = lambda expr test
+                      named = b
+                      start-rune = 166
+                      lambda-expression-parameter-explicit-type =>
+                        NodeTypeTypeReference
+                          end-rune = 174
+                          input-source = lambda expr test
+                          start-rune = 168
+                          typereference-path =>
+                            NodeTypeIdentifierPath
+                              end-rune = 174
+                              input-source = lambda expr test
+                              start-rune = 168
+                              identifierpath-root =>
+                                NodeTypeIdentifierAccess
+                                  end-rune = 174
+                                  identifieraccess-name = bar
+                                  input-source = lambda expr test
+                                  start-rune = 172
+                                  identifieraccess-source =>
+                                    NodeTypeIdentifierAccess
+                                      end-rune = 170
+                                      identifieraccess-name = foo
+                                      input-source = lambda expr test
+                                      start-rune = 168
+                    NodeTypeLambdaParameter
+                      end-rune = 177
+                      input-source = lambda expr test
+                      named = c
+                      start-rune = 177

--- a/sourceshape/sourceshape.go
+++ b/sourceshape/sourceshape.go
@@ -521,7 +521,8 @@ const (
 	//
 	//	NodeTypeLambdaParameter
 	//
-	NodeLambdaExpressionParameterName = "named"
+	NodeLambdaExpressionParameterName         = "named"
+	NodeLambdaExpressionParameterExplicitType = "lambda-expression-parameter-explicit-type"
 
 	//
 	// Binary expressions.


### PR DESCRIPTION
This change introduces the ability to explicitly type lambda parameters in the *inline* form:

```seru
(a, b withSomeType) => a.foo(b)
```

This is useful if, due to the lack of call sites, the system cannot infer the type of the parameter, or explicit readability is preferred.