### PR TITLE
Fix type completion in Grok

### DIFF
--- a/grok/completion_test.go
+++ b/grok/completion_test.go
@@ -129,12 +129,12 @@ var grokCompletionTests = []grokCompletionTest{
 	grokCompletionTest{"types",
 		[]grokCompletionSubTest{
 			// Type completions.
-			/*grokCompletionSubTest{"sl", "var<", []expectedCompletion{
+			grokCompletionSubTest{"sl", "var SomeVar ", []expectedCompletion{
 				expectedCompletion{TypeCompletion, "T", "T", "", "void"},
 				expectedCompletion{TypeCompletion, "SomeClass", "SomeClass", "", "void"},
 				expectedCompletion{TypeCompletion, "AnotherClass", "AnotherClass", "", "void"},
 				expectedCompletion{TypeCompletion, "ThirdClass", "ThirdClass", "", "void"},
-			}},*/
+			}},
 
 			// Context completions.
 			grokCompletionSubTest{"sl", "a", []expectedCompletion{
@@ -181,9 +181,13 @@ var grokCompletionTests = []grokCompletionTest{
 	grokCompletionTest{"imports",
 		[]grokCompletionSubTest{
 			// Type completions.
-			/*grokCompletionSubTest{"af3", "var<", []expectedCompletion{
+			grokCompletionSubTest{"af3", "var SomeVar ", []expectedCompletion{
 				expectedCompletion{TypeCompletion, "SomeClass", "SomeClass", "", "void"},
-			}},*/
+			}},
+
+			grokCompletionSubTest{"af3", "function SomeFunction() ", []expectedCompletion{
+				expectedCompletion{TypeCompletion, "SomeClass", "SomeClass", "", "void"},
+			}},
 
 			// Context completions.
 			grokCompletionSubTest{"af3", "", []expectedCompletion{

--- a/grok/handle_completion.go
+++ b/grok/handle_completion.go
@@ -12,6 +12,7 @@ import (
 	"github.com/serulian/compiler/graphs/scopegraph/proto"
 	"github.com/serulian/compiler/graphs/srg"
 	"github.com/serulian/compiler/packageloader"
+	"github.com/serulian/compiler/parser"
 	"github.com/serulian/compiler/sourceshape"
 )
 
@@ -60,18 +61,18 @@ func (gh Handle) GetCompletions(activationString string, sourcePosition compiler
 		// Autocomplete under an expression.
 		gh.addAccessCompletions(node, activationString, builder)
 
-	case strings.HasSuffix(activationString, "<"):
-		// Autocomplete of types.
-		gh.addContextCompletions(node, builder, func(scope srg.SRGContextScopeName) bool {
-			return scope.NamedScope().ScopeKind() == srg.NamedScopeType
-		})
-
 	case strings.HasPrefix(activationString, "from ") || strings.HasPrefix(activationString, "import "):
 		// Imports.
 		importSnippet, ok := buildImportSnippet(activationString)
 		if ok {
 			importSnippet.populateCompletions(builder, sourcePosition.Source())
 		}
+
+	case parser.IsTypePrefix(activationString):
+		// Autocomplete of types.
+		gh.addContextCompletions(node, builder, func(scope srg.SRGContextScopeName) bool {
+			return scope.NamedScope().ScopeKind() == srg.NamedScopeType
+		})
 
 	default:
 		// Context autocomplete.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -32,6 +32,13 @@ func ParseExpression(builder shared.NodeBuilder, source compilercommon.InputSour
 	return v1parser.ParseExpression(builder, source, startIndex, input)
 }
 
+// IsTypePrefix returns whether the given input string is a prefix that supports a type reference declared right
+// after it. For example, the string `function DoSomething() ` will return `true`, as a type can be specified right
+// after that code snippet.
+func IsTypePrefix(input string) bool {
+	return v1parser.IsTypePrefix(input)
+}
+
 // ParseWithCompatability performs parsing of the given input string and returns the root AST node. Unlike the normal Parse,
 // this method will try *all* parser versions, starting at the latest and working backwards, until a parse succeeds or there
 // are no additional versions.

--- a/parser/v1/typeprefix.go
+++ b/parser/v1/typeprefix.go
@@ -1,0 +1,129 @@
+// Copyright 2018 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package parser
+
+import (
+	"container/list"
+
+	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/packageloader"
+	"github.com/serulian/compiler/parser/shared"
+	"github.com/serulian/compiler/sourceshape"
+)
+
+// IsTypePrefix returns whether the given input string is a prefix that supports a type reference declared right
+// after it. For example, the string `function DoSomething() ` will return `true`, as a type can be specified right
+// after that code snippet.
+func IsTypePrefix(input string) bool {
+	return checkForTypePrefix(input,
+		// Check for type members.
+		func(p *sourceParser) *typePrefixAstNode {
+			rootNode := typePrefixAstNodeBuilder(compilercommon.InputSource(""), sourceshape.NodeTypeFile)
+			p.consumeToken()
+			p.consumeImplementedTypeMembers(rootNode)
+			return rootNode.(*typePrefixAstNode)
+		},
+
+		// Check for types.
+		func(p *sourceParser) *typePrefixAstNode {
+			p.consumeToken()
+			return p.consumeTypeDefinition().(*typePrefixAstNode)
+		},
+
+		// Check within expressions.
+		func(p *sourceParser) *typePrefixAstNode {
+			p.consumeToken()
+			return p.consumeExpression(consumeExpressionAllowBraces).(*typePrefixAstNode)
+		})
+}
+
+type consumeCaller func(p *sourceParser) *typePrefixAstNode
+
+// checkForTypePrefix invokes each of the given caller functions to construct a small AST with the sentinal. The callers each return the
+// root node from the parse tree, which is then checked for the presence of the `sentinal` under a type reference. If the `sentinal` is
+// found under a type reference, then that token (which is placed right after the input snippet) is supported as a type reference.
+func checkForTypePrefix(input string, callers ...consumeCaller) bool {
+	for _, caller := range callers {
+		p := buildParser(typePrefixAstNodeBuilder, noopReportImport, compilercommon.InputSource(""), bytePosition(0), input+"sentinal")
+		rootNode := caller(p)
+		if rootNode.hasSentinaledTypeReference() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// typePrefixAstNode defines an AST node constructed by the parser for finding the sentinal under a type reference.
+type typePrefixAstNode struct {
+	nodeType sourceshape.NodeType
+	children *list.List
+
+	hasSentinal bool
+}
+
+func typePrefixAstNodeBuilder(source compilercommon.InputSource, kind sourceshape.NodeType) shared.AstNode {
+	return &typePrefixAstNode{
+		nodeType: kind,
+		children: list.New(),
+	}
+}
+
+func (tn *typePrefixAstNode) GetType() sourceshape.NodeType {
+	return tn.nodeType
+}
+
+func (tn *typePrefixAstNode) Connect(predicate string, other shared.AstNode) shared.AstNode {
+	tn.children.PushBack(other)
+	return tn
+}
+
+func (tn *typePrefixAstNode) Decorate(property string, value string) shared.AstNode {
+	// We only care if we find the `sentinal` as part of an identifier access.
+	if property == sourceshape.NodeIdentifierAccessName && value == "sentinal" {
+		tn.hasSentinal = true
+	}
+
+	return tn
+}
+
+func (tn *typePrefixAstNode) DecorateWithInt(property string, value int) shared.AstNode {
+	return tn
+}
+
+// hasSentinaledTypeReference returns true if the parse tree contains a sentinal-ed type reference
+// anywhere in the tree.
+func (tn *typePrefixAstNode) hasSentinaledTypeReference() bool {
+	if tn.nodeType == sourceshape.NodeTypeTypeReference && tn.hasSentinalIdentifierOrChild() {
+		return true
+	}
+
+	for e := tn.children.Front(); e != nil; e = e.Next() {
+		if e.Value.(*typePrefixAstNode).hasSentinaledTypeReference() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasSentinalOrChild returns true if the parse tree contains an identifier with the `sentinal` value.
+func (tn *typePrefixAstNode) hasSentinalIdentifierOrChild() bool {
+	if tn.hasSentinal {
+		return true
+	}
+
+	for e := tn.children.Front(); e != nil; e = e.Next() {
+		if e.Value.(*typePrefixAstNode).hasSentinalIdentifierOrChild() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func noopReportImport(sourceKind string, importPath string, importType packageloader.PackageImportType, importSource compilercommon.InputSource, runePosition int) string {
+	return ""
+}

--- a/parser/v1/typeprefix_test.go
+++ b/parser/v1/typeprefix_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type typePrefixTest struct {
+	snippet  string
+	isPrefix bool
+}
+
+var typePrefixTests = []typePrefixTest{
+	typePrefixTest{"class DoSomething<T: ", true},
+	typePrefixTest{"interface DoSomething<T: ", true},
+
+	typePrefixTest{"type SomeType : ", true},
+
+	typePrefixTest{"agent SomeAgent for ", true},
+	typePrefixTest{"agent SomeAgent for a", false},
+
+	typePrefixTest{"class DoSomething with ", true},
+	typePrefixTest{"class DoSomething with a + ", true},
+	typePrefixTest{"class DoSomething with a + b", false},
+
+	typePrefixTest{"function DoSomething(something int)", true},
+	typePrefixTest{"function DoSomething(something int, ", false},
+	typePrefixTest{"function DoSomething(something int, a ", true},
+
+	typePrefixTest{"function DoSomething<T>(something int)", true},
+	typePrefixTest{"function DoSomething<T>(something int, ", false},
+	typePrefixTest{"function DoSomething<T>(something int, a ", true},
+
+	typePrefixTest{"operator DoSomething(something int)", true},
+	typePrefixTest{"operator DoSomething(something int, ", false},
+	typePrefixTest{"operator DoSomething(something int, a ", true},
+
+	typePrefixTest{"function DoSomething<T:", true},
+	typePrefixTest{"function DoSomething<T: ", true},
+	typePrefixTest{"function DoSomething<Q, T: ", true},
+	typePrefixTest{"function DoSomething<Q, T: s", false},
+
+	typePrefixTest{"property Something ", true},
+	typePrefixTest{"var Something ", true},
+
+	typePrefixTest{"foo.(", true},
+	typePrefixTest{"foo.(a", false},
+
+	typePrefixTest{"[]", true},
+	typePrefixTest{"[]{", true},
+}
+
+func TestIsTypePrefix(t *testing.T) {
+	for _, test := range typePrefixTests {
+		t.Run(test.snippet, func(t *testing.T) {
+			assert.Equal(t, test.isPrefix, IsTypePrefix(test.snippet))
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new function to the parser called `IsTypePrefix`, which makes use of the existing parsing code to determine if the next token in a snippet of code is within a type reference. If so, we return true, and Grok can use this as a signal to display type completion.

Since this reuses the existing parsing infrastructure, the code is a bit wonky, but it has the nice side effect of making any changes to the syntax automatically reflected in Grok's understanding