### PR TITLE
Anonymous function and SML fixes

### DIFF
--- a/generator/es5/codedom/codedom.go
+++ b/generator/es5/codedom/codedom.go
@@ -29,10 +29,12 @@ func IsMaybePromisingMember(member typegraph.TGMember) bool {
 func InvokeFunction(callExpr Expression, arguments []Expression, callType scopegraph.PromisingAccessType, sg *scopegraph.ScopeGraph, basisNode compilergraph.GraphNode) Expression {
 	functionCall := FunctionCall(callExpr, arguments, basisNode)
 
-	// Check if the expression references a member. If not, this is a simple function call.
+	// Check if the expression references a member. If not, this is a simple function call, and we need to
+	// always await a possible promise.
 	referencedMember, isMemberRef := callExpr.ReferencedMember()
 	if !isMemberRef {
-		return functionCall
+		functionCall = RuntimeFunctionCall(MaybePromiseFunction, []Expression{functionCall}, basisNode)
+		return AwaitPromise(functionCall, basisNode)
 	}
 
 	// If the member is promising, await on its result.

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -186,6 +186,7 @@ var generationTests = []generationTest{
 	generationTest{"function call", "opexpr", "functioncall", integrationTestSuccessExpected, ""},
 	generationTest{"function call nullable", "opexpr", "functioncallnullable", integrationTestSuccessExpected, ""},
 	generationTest{"async function call nullable", "opexpr", "asyncfunctioncallnullable", integrationTestSuccessExpected, ""},
+	generationTest{"anonymous function call", "opexpr", "anonymousfunctioncall", integrationTestSuccessExpected, ""},
 	generationTest{"boolean operators", "opexpr", "boolean", integrationTestSuccessExpected, ""},
 	generationTest{"binary op expressions", "opexpr", "binary", integrationTestSuccessExpected, ""},
 	generationTest{"unary op expressions", "opexpr", "unary", integrationTestNone, ""},
@@ -302,6 +303,7 @@ var generationTests = []generationTest{
 	generationTest{"sml inline loop test", "sml", "inlineloop", integrationTestSuccessExpected, ""},
 	generationTest{"sml loop and elements test", "sml", "loopandelements", integrationTestSuccessExpected, ""},
 	generationTest{"sml inline loop async test", "sml", "inlineloopasync", integrationTestSuccessExpected, ""},
+	generationTest{"sml inline loop broken test", "sml", "inlineloopbroken", integrationTestSuccessExpected, ""},
 
 	generationTest{"native new integration test", "nativenew", "nativenew", integrationTestSuccessExpected, ""},
 	generationTest{"dynamic access non-promising test", "dynamicaccess", "nonpromising", integrationTestSuccessExpected, ""},

--- a/generator/es5/runtime.go
+++ b/generator/es5/runtime.go
@@ -247,6 +247,10 @@ this.Serulian = (function($global) {
         case 'interface':
           // Check if the other type implements the interface by comparing type signatures.
           var targetSignature = type.$typesig();
+          if (!value.constructor.$typesig) {
+            return false;
+          }
+
           var valueSignature = value.constructor.$typesig();
 
           var expectedKeys = Object.keys(targetSignature);

--- a/generator/es5/tests/accessexpr/asyncnullaccess.js
+++ b/generator/es5/tests/accessexpr/asyncnullaccess.js
@@ -43,7 +43,7 @@ $module('asyncnullaccess', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|5e61c39d": true,
+        "SomeProperty|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/cast.js
+++ b/generator/es5/tests/accessexpr/cast.js
@@ -16,7 +16,7 @@ $module('cast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Result|3|5e61c39d": true,
+        "Result|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/dynamicprop.js
+++ b/generator/es5/tests/accessexpr/dynamicprop.js
@@ -22,7 +22,7 @@ $module('dynamicprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProp|3|f22a98b6": true,
+        "SomeProp|3|db1c26c2": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/memberaccess.js
+++ b/generator/es5/tests/accessexpr/memberaccess.js
@@ -25,9 +25,9 @@ $module('memberaccess', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Build|1|0b2e6e78<a95b5789>": true,
-        "InstanceFunc|2|0b2e6e78<void>": true,
-        "SomeProp|3|f22a98b6": true,
+        "Build|1|fb1385bf<a95b5789>": true,
+        "InstanceFunc|2|fb1385bf<void>": true,
+        "SomeProp|3|db1c26c2": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/accessexpr/nullaccess.js
+++ b/generator/es5/tests/accessexpr/nullaccess.js
@@ -16,7 +16,7 @@ $module('nullaccess', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeBool|3|5e61c39d": true,
+        "SomeBool|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/agent/basic.js
+++ b/generator/es5/tests/agent/basic.js
@@ -26,9 +26,9 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Declare|1|0b2e6e78<eaf2f2d0>": true,
-        "GetValue|2|0b2e6e78<f22a98b6>": true,
-        "GetMainValue|2|0b2e6e78<f22a98b6>": true,
+        "Declare|1|fb1385bf<eaf2f2d0>": true,
+        "GetValue|2|fb1385bf<db1c26c2>": true,
+        "GetMainValue|2|fb1385bf<db1c26c2>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -41,7 +41,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|0b2e6e78<f22a98b6>": true,
+        "GetValue|2|fb1385bf<db1c26c2>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -63,7 +63,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetMainValue|2|0b2e6e78<f22a98b6>": true,
+        "GetMainValue|2|fb1385bf<db1c26c2>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/agent/field.js
+++ b/generator/es5/tests/agent/field.js
@@ -25,7 +25,7 @@ $module('field', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Declare|1|0b2e6e78<6c0ca75a>": true,
+        "Declare|1|fb1385bf<6c0ca75a>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/arrowexpr/arrow.js
+++ b/generator/es5/tests/arrowexpr/arrow.js
@@ -7,11 +7,37 @@ $module('arrow', function () {
       var instance = new $static();
       return instance;
     };
-    $instance.Then = function (resolve) {
+    $instance.Then = $t.markpromising(function (resolve) {
       var $this = this;
-      resolve($t.fastbox(true, $g.________testlib.basictypes.Boolean));
-      return $this;
-    };
+      var $result;
+      var $current = 0;
+      var $continue = function ($resolve, $reject) {
+        localasyncloop: while (true) {
+          switch ($current) {
+            case 0:
+              $promise.maybe(resolve($t.fastbox(true, $g.________testlib.basictypes.Boolean))).then(function ($result0) {
+                $result = $result0;
+                $current = 1;
+                $continue($resolve, $reject);
+                return;
+              }).catch(function (err) {
+                $reject(err);
+                return;
+              });
+              return;
+
+            case 1:
+              $resolve($this);
+              return;
+
+            default:
+              $resolve();
+              return;
+          }
+        }
+      };
+      return $promise.new($continue);
+    });
     $instance.Catch = function (rejection) {
       var $this = this;
       return $this;
@@ -21,8 +47,8 @@ $module('arrow', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Then|2|0b2e6e78<9fc228ba<5e61c39d>>": true,
-        "Catch|2|0b2e6e78<9fc228ba<5e61c39d>>": true,
+        "Then|2|fb1385bf<414fa52a<71258460>>": true,
+        "Catch|2|fb1385bf<414fa52a<71258460>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/arrowexpr/await.js
+++ b/generator/es5/tests/arrowexpr/await.js
@@ -7,11 +7,37 @@ $module('await', function () {
       var instance = new $static();
       return instance;
     };
-    $instance.Then = function (resolve) {
+    $instance.Then = $t.markpromising(function (resolve) {
       var $this = this;
-      resolve($t.fastbox(true, $g.________testlib.basictypes.Boolean));
-      return $this;
-    };
+      var $result;
+      var $current = 0;
+      var $continue = function ($resolve, $reject) {
+        localasyncloop: while (true) {
+          switch ($current) {
+            case 0:
+              $promise.maybe(resolve($t.fastbox(true, $g.________testlib.basictypes.Boolean))).then(function ($result0) {
+                $result = $result0;
+                $current = 1;
+                $continue($resolve, $reject);
+                return;
+              }).catch(function (err) {
+                $reject(err);
+                return;
+              });
+              return;
+
+            case 1:
+              $resolve($this);
+              return;
+
+            default:
+              $resolve();
+              return;
+          }
+        }
+      };
+      return $promise.new($continue);
+    });
     $instance.Catch = function (rejection) {
       var $this = this;
       return $this;
@@ -21,8 +47,8 @@ $module('await', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Then|2|0b2e6e78<9fc228ba<5e61c39d>>": true,
-        "Catch|2|0b2e6e78<9fc228ba<5e61c39d>>": true,
+        "Then|2|fb1385bf<414fa52a<71258460>>": true,
+        "Catch|2|fb1385bf<414fa52a<71258460>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/arrowexpr/multiawait.js
+++ b/generator/es5/tests/arrowexpr/multiawait.js
@@ -15,7 +15,7 @@ $module('multiawait', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "plus|4|0b2e6e78<5965b3f7>": true,
+        "plus|4|fb1385bf<5965b3f7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/async/asyncstruct.js
+++ b/generator/es5/tests/async/asyncstruct.js
@@ -28,12 +28,12 @@ $module('asyncstruct', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<4e1a7940>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<4e1a7940>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<4e1a7940>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<4e1a7940>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/genericinterfacecast.js
+++ b/generator/es5/tests/cast/genericinterfacecast.js
@@ -16,7 +16,7 @@ $module('genericinterfacecast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|5e61c39d": true,
+        "SomeValue|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/interfacecast.js
+++ b/generator/es5/tests/cast/interfacecast.js
@@ -16,7 +16,7 @@ $module('interfacecast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|5e61c39d": true,
+        "SomeValue|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -29,7 +29,7 @@ $module('interfacecast', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|5e61c39d": true,
+        "SomeValue|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/interfacecastfail.js
+++ b/generator/es5/tests/cast/interfacecastfail.js
@@ -16,7 +16,7 @@ $module('interfacecastfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|f22a98b6": true,
+        "SomeValue|3|db1c26c2": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -29,7 +29,7 @@ $module('interfacecastfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|5e61c39d": true,
+        "SomeValue|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/cast/nominalautobox.js
+++ b/generator/es5/tests/cast/nominalautobox.js
@@ -33,7 +33,7 @@ $module('nominalautobox', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|5e61c39d": true,
+        "SomeValue|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/class/basic.js
+++ b/generator/es5/tests/class/basic.js
@@ -18,7 +18,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherFunction|2|0b2e6e78<void>": true,
+        "AnotherFunction|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/class/generic.js
+++ b/generator/es5/tests/class/generic.js
@@ -17,7 +17,7 @@ $module('generic', function () {
       }
       var computed = {
       };
-      computed[("Something|2|0b2e6e78<" + $t.typeid(T)) + ">"] = true;
+      computed[("Something|2|fb1385bf<" + $t.typeid(T)) + ">"] = true;
       return this.$cachedtypesig = computed;
     };
   });
@@ -55,7 +55,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Something|2|0b2e6e78<92ebaa06>": true,
+        "Something|2|fb1385bf<92ebaa06>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -68,7 +68,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Something|2|0b2e6e78<eff03fa4>": true,
+        "Something|2|fb1385bf<eff03fa4>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/class/property.js
+++ b/generator/es5/tests/class/property.js
@@ -22,7 +22,7 @@ $module('property', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProp|3|5e61c39d": true,
+        "SomeProp|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/condexpr/calls.js
+++ b/generator/es5/tests/condexpr/calls.js
@@ -16,7 +16,7 @@ $module('calls', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|c509e19d": true,
+        "Message|3|b2b53db7": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/dynamicaccess/nonpromising.js
+++ b/generator/es5/tests/dynamicaccess/nonpromising.js
@@ -22,12 +22,12 @@ $module('nonpromising', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<5d13a931>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<5d13a931>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<5d13a931>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<5d13a931>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/generator/resource.js
+++ b/generator/es5/tests/generator/resource.js
@@ -18,7 +18,7 @@ $module('resource', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|0b2e6e78<void>": true,
+        "Release|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/interface/constructable.js
+++ b/generator/es5/tests/interface/constructable.js
@@ -19,8 +19,8 @@ $module('constructable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Get|1|0b2e6e78<5fd250f1>": true,
-        "SomeBool|3|5e61c39d": true,
+        "Get|1|fb1385bf<5fd250f1>": true,
+        "SomeBool|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -36,8 +36,8 @@ $module('constructable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Get|1|0b2e6e78<cd09b8fb>": true,
-        "SomeBool|3|5e61c39d": true,
+        "Get|1|fb1385bf<cd09b8fb>": true,
+        "SomeBool|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/interface/interfaceprop.js
+++ b/generator/es5/tests/interface/interfaceprop.js
@@ -22,7 +22,7 @@ $module('interfaceprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|5e61c39d": true,
+        "SomeProperty|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -75,7 +75,7 @@ $module('interfaceprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|5e61c39d": true,
+        "SomeProperty|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -88,7 +88,7 @@ $module('interfaceprop', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|5e61c39d": true,
+        "SomeProperty|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/lambdaexpr/full.js
+++ b/generator/es5/tests/lambdaexpr/full.js
@@ -1,10 +1,37 @@
 $module('full', function () {
   var $static = this;
-  $static.TEST = function () {
+  $static.TEST = $t.markpromising(function () {
+    var $result;
     var lambda;
-    lambda = function (firstParam, secondParam) {
-      return secondParam;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            lambda = function (firstParam, secondParam) {
+              return secondParam;
+            };
+            $promise.maybe(lambda($t.fastbox(123, $g.________testlib.basictypes.Integer), $t.fastbox(true, $g.________testlib.basictypes.Boolean))).then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            $resolve($result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
     };
-    return lambda($t.fastbox(123, $g.________testlib.basictypes.Integer), $t.fastbox(true, $g.________testlib.basictypes.Boolean));
-  };
+    return $promise.new($continue);
+  });
 });

--- a/generator/es5/tests/lambdaexpr/inline.js
+++ b/generator/es5/tests/lambdaexpr/inline.js
@@ -1,12 +1,38 @@
 $module('inline', function () {
   var $static = this;
-  $static.TEST = function () {
+  $static.TEST = $t.markpromising(function () {
+    var $result;
     var result;
-    result = $t.fastbox(false, $g.________testlib.basictypes.Boolean);
-    (function () {
-      result = $t.fastbox(true, $g.________testlib.basictypes.Boolean);
-      return;
-    })();
-    return result;
-  };
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            result = $t.fastbox(false, $g.________testlib.basictypes.Boolean);
+            $promise.maybe((function () {
+              result = $t.fastbox(true, $g.________testlib.basictypes.Boolean);
+              return;
+            })()).then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            $resolve(result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
 });

--- a/generator/es5/tests/lambdaexpr/mini.js
+++ b/generator/es5/tests/lambdaexpr/mini.js
@@ -1,10 +1,37 @@
 $module('mini', function () {
   var $static = this;
-  $static.TEST = function () {
+  $static.TEST = $t.markpromising(function () {
+    var $result;
     var lambda;
-    lambda = function (someParam) {
-      return $t.fastbox(!someParam.$wrapped, $g.________testlib.basictypes.Boolean);
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            lambda = function (someParam) {
+              return $t.fastbox(!someParam.$wrapped, $g.________testlib.basictypes.Boolean);
+            };
+            $promise.maybe(lambda($t.fastbox(false, $g.________testlib.basictypes.Boolean))).then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            $resolve($result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
     };
-    return lambda($t.fastbox(false, $g.________testlib.basictypes.Boolean));
-  };
+    return $promise.new($continue);
+  });
 });

--- a/generator/es5/tests/literals/structnew.js
+++ b/generator/es5/tests/literals/structnew.js
@@ -23,7 +23,7 @@ $module('structnew', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherField|3|5e61c39d": true,
+        "AnotherField|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/literals/this.js
+++ b/generator/es5/tests/literals/this.js
@@ -16,7 +16,7 @@ $module('this', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "DoSomething|2|0b2e6e78<void>": true,
+        "DoSomething|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/loopexpr/numeric.js
+++ b/generator/es5/tests/loopexpr/numeric.js
@@ -1,11 +1,37 @@
 $module('numeric', function () {
   var $static = this;
-  $static.doSomething = function () {
-    (function () {
-      return;
-    })();
-    return;
-  };
+  $static.doSomething = $t.markpromising(function () {
+    var $result;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            $promise.maybe((function () {
+              return;
+            })()).then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            $resolve();
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
   $static.TEST = $t.markpromising(function () {
     var $result;
     var $temp0;

--- a/generator/es5/tests/nominal/basic.js
+++ b/generator/es5/tests/nominal/basic.js
@@ -16,7 +16,7 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "DoSomething|2|0b2e6e78<5e61c39d>": true,
+        "DoSomething|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -46,8 +46,8 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherThing|2|0b2e6e78<5e61c39d>": true,
-        "SomeProp|3|5e61c39d": true,
+        "AnotherThing|2|fb1385bf<71258460>": true,
+        "SomeProp|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/generic.js
+++ b/generator/es5/tests/nominal/generic.js
@@ -16,7 +16,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "DoSomething|2|0b2e6e78<5e61c39d>": true,
+        "DoSomething|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -46,8 +46,8 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherThing|2|0b2e6e78<5e61c39d>": true,
-        "SomeProp|3|5e61c39d": true,
+        "AnotherThing|2|fb1385bf<71258460>": true,
+        "SomeProp|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/interface.js
+++ b/generator/es5/tests/nominal/interface.js
@@ -16,7 +16,7 @@ $module('interface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|f22a98b6": true,
+        "SomeValue|3|db1c26c2": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -29,7 +29,7 @@ $module('interface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|f22a98b6": true,
+        "SomeValue|3|db1c26c2": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,7 +55,7 @@ $module('interface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|0b2e6e78<f22a98b6>": true,
+        "GetValue|2|fb1385bf<db1c26c2>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/nominalbase.js
+++ b/generator/es5/tests/nominal/nominalbase.js
@@ -34,7 +34,7 @@ $module('nominalbase', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProp|3|5e61c39d": true,
+        "SomeProp|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -60,7 +60,7 @@ $module('nominalbase', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|0b2e6e78<5e61c39d>": true,
+        "GetValue|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/nominal/shortcut.js
+++ b/generator/es5/tests/nominal/shortcut.js
@@ -16,7 +16,7 @@ $module('shortcut', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Value|3|5e61c39d": true,
+        "Value|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/anonymousfunctioncall.js
+++ b/generator/es5/tests/opexpr/anonymousfunctioncall.js
@@ -1,29 +1,39 @@
-$module('funcref', function () {
+$module('anonymousfunctioncall', function () {
   var $static = this;
-  this.$class('41fdfa22', 'SomeClass', false, '', function () {
-    var $static = this;
-    var $instance = this.prototype;
-    $static.new = function (value) {
-      var instance = new $static();
-      instance.value = value;
-      return instance;
-    };
-    $instance.SomeFunction = function () {
-      var $this = this;
-      return $this.value;
-    };
-    this.$typesig = function () {
-      if (this.$cachedtypesig) {
-        return this.$cachedtypesig;
-      }
-      var computed = {
-        "SomeFunction|2|fb1385bf<71258460>": true,
-      };
-      return this.$cachedtypesig = computed;
-    };
+  $static.DoSomethingAsync = $t.workerwrap('743742ca', function () {
+    return $t.fastbox(32, $g.________testlib.basictypes.Integer);
   });
+  $static.SomeMethod = $t.markpromising(function () {
+    var $result;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            $promise.translate($g.anonymousfunctioncall.DoSomethingAsync()).then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
 
-  $static.AnotherFunction = $t.markpromising(function (toCall) {
+          case 1:
+            $resolve($result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+  $static.AnotherMethod = $t.markpromising(function (toCall) {
     var $result;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
@@ -31,7 +41,7 @@ $module('funcref', function () {
         switch ($current) {
           case 0:
             $promise.maybe(toCall()).then(function ($result0) {
-              $result = $result0;
+              $result = $t.fastbox($result0.$wrapped + 10, $g.________testlib.basictypes.Integer);
               $current = 1;
               $continue($resolve, $reject);
               return;
@@ -55,15 +65,13 @@ $module('funcref', function () {
   });
   $static.TEST = $t.markpromising(function () {
     var $result;
-    var sc;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
       localasyncloop: while (true) {
         switch ($current) {
           case 0:
-            sc = $g.funcref.SomeClass.new($t.fastbox(true, $g.________testlib.basictypes.Boolean));
-            $promise.maybe($g.funcref.AnotherFunction($t.dynamicaccess(sc, 'SomeFunction', false))).then(function ($result0) {
-              $result = $result0;
+            $promise.maybe($g.anonymousfunctioncall.AnotherMethod($g.anonymousfunctioncall.SomeMethod)).then(function ($result0) {
+              $result = $t.fastbox($result0.$wrapped == 42, $g.________testlib.basictypes.Boolean);
               $current = 1;
               $continue($resolve, $reject);
               return;

--- a/generator/es5/tests/opexpr/anonymousfunctioncall.seru
+++ b/generator/es5/tests/opexpr/anonymousfunctioncall.seru
@@ -1,0 +1,11 @@
+function DoSomethingAsync() int { return 32 }
+
+function SomeMethod() int {
+	return <- DoSomethingAsync()
+}
+
+function AnotherMethod(toCall function<int>()) int {
+	return toCall() + 10
+}
+
+function TEST() any { return AnotherMethod(SomeMethod) == 42 }

--- a/generator/es5/tests/opexpr/asyncfunctioncallnullable.js
+++ b/generator/es5/tests/opexpr/asyncfunctioncallnullable.js
@@ -43,7 +43,7 @@ $module('asyncfunctioncallnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeMethod|2|0b2e6e78<5e61c39d>": true,
+        "SomeMethod|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/functioncallnullable.js
+++ b/generator/es5/tests/opexpr/functioncallnullable.js
@@ -16,7 +16,7 @@ $module('functioncallnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeMethod|2|0b2e6e78<5e61c39d>": true,
+        "SomeMethod|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -38,7 +38,7 @@ $module('functioncallnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "AnotherMethod|2|0b2e6e78<5e61c39d>": true,
+        "AnotherMethod|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/generic.js
+++ b/generator/es5/tests/opexpr/generic.js
@@ -19,7 +19,7 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "BoolValue|3|5e61c39d": true,
+        "BoolValue|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/nullcomparecall.js
+++ b/generator/es5/tests/opexpr/nullcomparecall.js
@@ -16,7 +16,7 @@ $module('nullcomparecall', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|c509e19d": true,
+        "Message|3|b2b53db7": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/shortcircuit.js
+++ b/generator/es5/tests/opexpr/shortcircuit.js
@@ -16,7 +16,7 @@ $module('shortcircuit', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|c509e19d": true,
+        "Message|3|b2b53db7": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/unwrap.js
+++ b/generator/es5/tests/opexpr/unwrap.js
@@ -16,7 +16,7 @@ $module('unwrap', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|5e61c39d": true,
+        "SomeProperty|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/opexpr/unwrapnullable.js
+++ b/generator/es5/tests/opexpr/unwrapnullable.js
@@ -16,7 +16,7 @@ $module('unwrapnullable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeProperty|3|5e61c39d": true,
+        "SomeProperty|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/resolve/castignoreinterface.js
+++ b/generator/es5/tests/resolve/castignoreinterface.js
@@ -43,7 +43,7 @@ $module('castignoreinterface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeFunction|2|0b2e6e78<void>": true,
+        "SomeFunction|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -56,7 +56,7 @@ $module('castignoreinterface', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeFunction|2|0b2e6e78<void>": true,
+        "SomeFunction|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/resolve/expectrejection.js
+++ b/generator/es5/tests/resolve/expectrejection.js
@@ -16,7 +16,7 @@ $module('expectrejection', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Message|3|c509e19d": true,
+        "Message|3|b2b53db7": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/custom.js
+++ b/generator/es5/tests/serialization/custom.js
@@ -23,9 +23,9 @@ $module('custom', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Get|1|0b2e6e78<38a26367>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Parse|2|0b2e6e78<204295f9<any>>": true,
+        "Get|1|fb1385bf<38a26367>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Parse|2|fb1385bf<204295f9<any>>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -53,12 +53,12 @@ $module('custom', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<ba519ef3>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<ba519ef3>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<ba519ef3>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<ba519ef3>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -98,12 +98,12 @@ $module('custom', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<be88a8fa>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<be88a8fa>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<be88a8fa>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<be88a8fa>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/json.js
+++ b/generator/es5/tests/serialization/json.js
@@ -22,12 +22,12 @@ $module('json', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<143c410b>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<143c410b>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<143c410b>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<143c410b>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -67,12 +67,12 @@ $module('json', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<8c772f6d>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<8c772f6d>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<8c772f6d>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<8c772f6d>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/jsondefault.js
+++ b/generator/es5/tests/serialization/jsondefault.js
@@ -28,12 +28,12 @@ $module('jsondefault', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<d610e0b2>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<d610e0b2>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<d610e0b2>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<d610e0b2>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/jsonfail.js
+++ b/generator/es5/tests/serialization/jsonfail.js
@@ -22,12 +22,12 @@ $module('jsonfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<8c9ddb23>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<8c9ddb23>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<8c9ddb23>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<8c9ddb23>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -67,12 +67,12 @@ $module('jsonfail', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<9251ae6e>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<9251ae6e>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<9251ae6e>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<9251ae6e>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/nominaljson.js
+++ b/generator/es5/tests/serialization/nominaljson.js
@@ -20,7 +20,7 @@ $module('nominaljson', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "GetValue|2|0b2e6e78<5e61c39d>": true,
+        "GetValue|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -48,12 +48,12 @@ $module('nominaljson', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<c267cdf9>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<c267cdf9>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<c267cdf9>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<c267cdf9>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -81,12 +81,12 @@ $module('nominaljson', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<eda8a36d>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<eda8a36d>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<eda8a36d>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<eda8a36d>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/slice.js
+++ b/generator/es5/tests/serialization/slice.js
@@ -22,12 +22,12 @@ $module('slice', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<9b59dab3>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<9b59dab3>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<9b59dab3>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<9b59dab3>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,12 +55,12 @@ $module('slice', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<a7573ae2>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<a7573ae2>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<a7573ae2>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<a7573ae2>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/serialization/tagged.js
+++ b/generator/es5/tests/serialization/tagged.js
@@ -22,12 +22,12 @@ $module('tagged', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<bad44f92>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<bad44f92>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<bad44f92>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<bad44f92>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sml/inlineloopbroken.js
+++ b/generator/es5/tests/sml/inlineloopbroken.js
@@ -1,0 +1,206 @@
+$module('inlineloopbroken', function () {
+  var $static = this;
+  $static.Value = $t.markpromising(function (props, value) {
+    var $result;
+    var $temp0;
+    var $temp1;
+    var v;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            $current = 1;
+            continue localasyncloop;
+
+          case 1:
+            $temp1 = value;
+            $current = 2;
+            continue localasyncloop;
+
+          case 2:
+            $promise.maybe($temp1.Next()).then(function ($result0) {
+              $temp0 = $result0;
+              $result = $temp0;
+              $current = 3;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 3:
+            v = $temp0.First;
+            if ($temp0.Second.$wrapped) {
+              $current = 4;
+              continue localasyncloop;
+            } else {
+              $current = 5;
+              continue localasyncloop;
+            }
+            break;
+
+          case 4:
+            $resolve($t.cast(v, $g.________testlib.basictypes.String, false));
+            return;
+
+          case 5:
+            $resolve($t.fastbox('', $g.________testlib.basictypes.String));
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+  $static.Collector = $t.markpromising(function (props, chars) {
+    var $result;
+    var $temp0;
+    var $temp1;
+    var c;
+    var final;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            final = $t.fastbox('', $g.________testlib.basictypes.String);
+            $current = 1;
+            continue localasyncloop;
+
+          case 1:
+            $temp1 = chars;
+            $current = 2;
+            continue localasyncloop;
+
+          case 2:
+            $promise.maybe($temp1.Next()).then(function ($result0) {
+              $temp0 = $result0;
+              $result = $temp0;
+              $current = 3;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 3:
+            c = $temp0.First;
+            if ($temp0.Second.$wrapped) {
+              $current = 4;
+              continue localasyncloop;
+            } else {
+              $current = 5;
+              continue localasyncloop;
+            }
+            break;
+
+          case 4:
+            final = $g.________testlib.basictypes.String.$plus($t.cast(c, $g.________testlib.basictypes.String, false), final);
+            $current = 2;
+            continue localasyncloop;
+
+          case 5:
+            $resolve(final);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+  $static.TEST = $t.markpromising(function () {
+    var $result;
+    var characters;
+    var result;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            characters = $t.fastbox('hello world', $g.________testlib.basictypes.String);
+            $promise.maybe($g.inlineloopbroken.Collector($g.________testlib.basictypes.Mapping($t.any).Empty(), $g.________testlib.basictypes.MapStream($g.________testlib.basictypes.Integer, $g.________testlib.basictypes.String)($g.________testlib.basictypes.Integer.$exclusiverange($t.fastbox(0, $g.________testlib.basictypes.Integer), characters.Length()), $t.markpromising(function (index) {
+              var $result;
+              var $current = 0;
+              var $continue = function ($resolve, $reject) {
+                localasyncloop: while (true) {
+                  switch ($current) {
+                    case 0:
+                      $promise.maybe($g.inlineloopbroken.Value($g.________testlib.basictypes.Mapping($t.any).Empty(), (function () {
+                        var $current = 0;
+                        var $continue = function ($yield, $yieldin, $reject, $done) {
+                          while (true) {
+                            switch ($current) {
+                              case 0:
+                                $yield(characters.$slice(index, $t.fastbox(index.$wrapped + 1, $g.________testlib.basictypes.Integer)));
+                                $current = 1;
+                                return;
+
+                              case 1:
+                                $done();
+                                return;
+
+                              default:
+                                $done();
+                                return;
+                            }
+                          }
+                        };
+                        return $generator.new($continue, false);
+                      })())).then(function ($result0) {
+                        $result = $result0;
+                        $current = 1;
+                        $continue($resolve, $reject);
+                        return;
+                      }).catch(function (err) {
+                        $reject(err);
+                        return;
+                      });
+                      return;
+
+                    case 1:
+                      $resolve($result);
+                      return;
+
+                    default:
+                      $resolve();
+                      return;
+                  }
+                }
+              };
+              return $promise.new($continue);
+            })))).then(function ($result0) {
+              $result = $result0;
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            result = $result;
+            $resolve($g.________testlib.basictypes.String.$equals(result, $t.fastbox('dlrow olleh', $g.________testlib.basictypes.String)));
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+});

--- a/generator/es5/tests/sml/inlineloopbroken.seru
+++ b/generator/es5/tests/sml/inlineloopbroken.seru
@@ -1,0 +1,21 @@
+function Value(props []{any}, value any*) string {
+	for v in value { return v.(string) }
+	return ''
+}
+
+function Collector(props []{any}, chars any*) string {
+	var final = ''
+	for c in chars {
+		final = c.(string) + final
+	}
+
+	return final
+}
+
+function TEST() any {
+	characters := 'hello world'
+	result := <Collector>
+		<Value [for index in 0 ..< characters.Length]>{characters[index:index + 1]}</Value>
+	</Collector>
+	return result == 'dlrow olleh'
+}

--- a/generator/es5/tests/sml/maybeasyncfunction.js
+++ b/generator/es5/tests/sml/maybeasyncfunction.js
@@ -43,7 +43,7 @@ $module('maybeasyncfunction', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SimpleFunction|2|0b2e6e78<5e61c39d>": true,
+        "SimpleFunction|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -65,7 +65,7 @@ $module('maybeasyncfunction', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SimpleFunction|2|0b2e6e78<5e61c39d>": true,
+        "SimpleFunction|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -78,7 +78,7 @@ $module('maybeasyncfunction', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SimpleFunction|2|0b2e6e78<5e61c39d>": true,
+        "SimpleFunction|2|fb1385bf<71258460>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sml/simpleclass.js
+++ b/generator/es5/tests/sml/simpleclass.js
@@ -19,8 +19,8 @@ $module('simpleclass', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Declare|1|0b2e6e78<f6e326a6>": true,
-        "Value|3|5e61c39d": true,
+        "Declare|1|fb1385bf<f6e326a6>": true,
+        "Value|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sml/structprops.js
+++ b/generator/es5/tests/sml/structprops.js
@@ -33,12 +33,12 @@ $module('structprops', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<3f6b14fb>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<3f6b14fb>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<3f6b14fb>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<3f6b14fb>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/sourcemapping/basic.js
+++ b/generator/es5/tests/sourcemapping/basic.js
@@ -155,6 +155,9 @@ this.Serulian = (function ($global) {
 
         case 'interface':
           var targetSignature = type.$typesig();
+          if (!value.constructor.$typesig) {
+            return false;
+          }
           var valueSignature = value.constructor.$typesig();
           var expectedKeys = Object.keys(targetSignature);
           for (var i = 0; i < expectedKeys.length; ++i) {
@@ -813,12 +816,12 @@ this.Serulian = (function ($global) {
         }
         var computed = {
         };
-        computed[((("Build|1|0b2e6e78<8abdfedc<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
+        computed[((("Build|1|fb1385bf<8abdfedc<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('0b2e6e78', 'Function', true, 'function', function (T) {
+    this.$class('fb1385bf', 'Function', true, 'function', function (T) {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -831,7 +834,7 @@ this.Serulian = (function ($global) {
       };
     });
 
-    this.$class('990f1337', 'IntStream', false, '$intstream', function () {
+    this.$class('c3969c0e', 'IntStream', false, '$intstream', function () {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -883,14 +886,14 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "OverRange|1|0b2e6e78<990f1337>": true,
-          "Next|2|0b2e6e78<8abdfedc<f22a98b6,5e61c39d>>": true,
+          "OverRange|1|fb1385bf<c3969c0e>": true,
+          "Next|2|fb1385bf<8abdfedc<db1c26c2,71258460>>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('b210add1', 'List', true, 'list', function (T) {
+    this.$class('4ec9534c', 'List', true, 'list', function (T) {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -981,15 +984,15 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Count|3|f22a98b6": true,
+          "Count|3|db1c26c2": true,
         };
-        computed[("index|4|0b2e6e78<" + $t.typeid(T)) + ">"] = true;
-        computed[("slice|4|0b2e6e78<add4a088<" + $t.typeid(T)) + ">>"] = true;
+        computed[("index|4|fb1385bf<" + $t.typeid(T)) + ">"] = true;
+        computed[("slice|4|fb1385bf<774e9986<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('627b0944', 'Map', true, 'map', function (T, Q) {
+    this.$class('001cd66f', 'Map', true, 'map', function (T, Q) {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -1093,16 +1096,16 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "setindex|4|0b2e6e78<void>": true,
+          "setindex|4|fb1385bf<void>": true,
         };
-        computed[((("Empty|1|0b2e6e78<627b0944<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
-        computed[("Mapping|2|0b2e6e78<204295f9<" + $t.typeid(Q)) + ">>"] = true;
-        computed[("index|4|0b2e6e78<" + $t.typeid(Q)) + ">"] = true;
+        computed[((("Empty|1|fb1385bf<001cd66f<" + $t.typeid(T)) + ",") + $t.typeid(Q)) + ">>"] = true;
+        computed[("Mapping|2|fb1385bf<204295f9<" + $t.typeid(Q)) + ">>"] = true;
+        computed[("index|4|fb1385bf<" + $t.typeid(Q)) + ">"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$class('6ae32d67', 'JSON', false, 'json', function () {
+    this.$class('c366f729', 'JSON', false, 'json', function () {
       var $static = this;
       var $instance = this.prototype;
       $static.new = function () {
@@ -1125,41 +1128,28 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Get|1|0b2e6e78<6ae32d67>": true,
-          "Stringify|2|0b2e6e78<c509e19d>": true,
-          "Parse|2|0b2e6e78<204295f9<any>>": true,
+          "Get|1|fb1385bf<c366f729>": true,
+          "Stringify|2|fb1385bf<b2b53db7>": true,
+          "Parse|2|fb1385bf<204295f9<any>>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('e403222d', 'Stringable', false, 'stringable', function () {
+    this.$interface('f877b763', 'Stringable', false, 'stringable', function () {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "String|2|0b2e6e78<c509e19d>": true,
+          "String|2|fb1385bf<b2b53db7>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('9fefaaf9', 'Stream', true, 'stream', function (T) {
-      var $static = this;
-      this.$typesig = function () {
-        if (this.$cachedtypesig) {
-          return this.$cachedtypesig;
-        }
-        var computed = {
-        };
-        computed[("Next|2|0b2e6e78<8abdfedc<" + $t.typeid(T)) + ",5e61c39d>>"] = true;
-        return this.$cachedtypesig = computed;
-      };
-    });
-
-    this.$interface('0d4528b3', 'Streamable', true, 'streamable', function (T) {
+    this.$interface('ba03a392', 'Stream', true, 'stream', function (T) {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
@@ -1167,25 +1157,12 @@ this.Serulian = (function ($global) {
         }
         var computed = {
         };
-        computed[("Stream|2|0b2e6e78<9fefaaf9<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Next|2|fb1385bf<8abdfedc<" + $t.typeid(T)) + ",71258460>>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('18a79690', 'Error', false, 'error', function () {
-      var $static = this;
-      this.$typesig = function () {
-        if (this.$cachedtypesig) {
-          return this.$cachedtypesig;
-        }
-        var computed = {
-          "Message|3|c509e19d": true,
-        };
-        return this.$cachedtypesig = computed;
-      };
-    });
-
-    this.$interface('9fc228ba', 'Awaitable', true, 'awaitable', function (T) {
+    this.$interface('0f7d3e22', 'Streamable', true, 'streamable', function (T) {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
@@ -1193,56 +1170,65 @@ this.Serulian = (function ($global) {
         }
         var computed = {
         };
-        computed[("Then|2|0b2e6e78<9fc228ba<" + $t.typeid(T)) + ">>"] = true;
-        computed[("Catch|2|0b2e6e78<9fc228ba<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Stream|2|fb1385bf<ba03a392<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('6882bfe7', 'Releasable', false, 'releasable', function () {
+    this.$interface('bfddac97', 'Error', false, 'error', function () {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Release|2|0b2e6e78<void>": true,
+          "Message|3|b2b53db7": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('b5bea91f', 'Mappable', false, 'mappable', function () {
+    this.$interface('414fa52a', 'Awaitable', true, 'awaitable', function (T) {
       var $static = this;
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "MapKey|3|e403222d": true,
         };
+        computed[("Then|2|fb1385bf<414fa52a<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Catch|2|fb1385bf<414fa52a<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('09600da0', 'Stringifier', false, '$stringifier', function () {
+    this.$interface('feb06e14', 'Releasable', false, 'releasable', function () {
       var $static = this;
-      $static.Get = function () {
-        return $g.________testlib.basictypes.JSON.new();
-      };
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Get|1|0b2e6e78<09600da0>": true,
-          "Stringify|2|0b2e6e78<c509e19d>": true,
+          "Release|2|fb1385bf<void>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$interface('3d8ab1ed', 'Parser', false, '$parser', function () {
+    this.$interface('ac1bf8e5', 'Mappable', false, 'mappable', function () {
+      var $static = this;
+      this.$typesig = function () {
+        if (this.$cachedtypesig) {
+          return this.$cachedtypesig;
+        }
+        var computed = {
+          "MapKey|3|f877b763": true,
+        };
+        return this.$cachedtypesig = computed;
+      };
+    });
+
+    this.$interface('bdb570a9', 'Stringifier', false, '$stringifier', function () {
       var $static = this;
       $static.Get = function () {
         return $g.________testlib.basictypes.JSON.new();
@@ -1252,8 +1238,25 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Get|1|0b2e6e78<3d8ab1ed>": true,
-          "Parse|2|0b2e6e78<204295f9<any>>": true,
+          "Get|1|fb1385bf<bdb570a9>": true,
+          "Stringify|2|fb1385bf<b2b53db7>": true,
+        };
+        return this.$cachedtypesig = computed;
+      };
+    });
+
+    this.$interface('70e119f3', 'Parser', false, '$parser', function () {
+      var $static = this;
+      $static.Get = function () {
+        return $g.________testlib.basictypes.JSON.new();
+      };
+      this.$typesig = function () {
+        if (this.$cachedtypesig) {
+          return this.$cachedtypesig;
+        }
+        var computed = {
+          "Get|1|fb1385bf<70e119f3>": true,
+          "Parse|2|fb1385bf<204295f9<any>>": true,
         };
         return this.$cachedtypesig = computed;
       };
@@ -1287,7 +1290,7 @@ this.Serulian = (function ($global) {
         syncloop: while (true) {
           switch ($current) {
             case 0:
-              value = /*#this))[NativeString(key)]#*/$this.$wrapped[/*#key)]#*/key.$wrapped];
+              value = /*#this)[NativeString(key)]#*/$this.$wrapped[/*#key)]#*/key.$wrapped];
 /*#null { return null }#*/              if (/*#value is null { return null }#*/value == /*#null { return null }#*/null) /*#null { return null }#*/{
                 $current = 1;
                 continue syncloop;
@@ -1313,15 +1316,15 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Keys|3|add4a088<c509e19d>": true,
+          "Keys|3|774e9986<b2b53db7>": true,
         };
-        computed[("Empty|1|0b2e6e78<204295f9<" + $t.typeid(T)) + ">>"] = true;
-        computed[("index|4|0b2e6e78<" + $t.typeid(T)) + ">"] = true;
+        computed[("Empty|1|fb1385bf<204295f9<" + $t.typeid(T)) + ">>"] = true;
+        computed[("index|4|fb1385bf<" + $t.typeid(T)) + ">"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('add4a088', 'Slice', true, 'slice', function (T) {
+    this.$type('774e9986', 'Slice', true, 'slice', function (T) {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1415,16 +1418,16 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Length|3|f22a98b6": true,
+          "Length|3|db1c26c2": true,
         };
-        computed[("Empty|1|0b2e6e78<add4a088<" + $t.typeid(T)) + ">>"] = true;
-        computed[("index|4|0b2e6e78<" + $t.typeid(T)) + ">"] = true;
-        computed[("slice|4|0b2e6e78<add4a088<" + $t.typeid(T)) + ">>"] = true;
+        computed[("Empty|1|fb1385bf<774e9986<" + $t.typeid(T)) + ">>"] = true;
+        computed[("index|4|fb1385bf<" + $t.typeid(T)) + ">"] = true;
+        computed[("slice|4|fb1385bf<774e9986<" + $t.typeid(T)) + ">>"] = true;
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('f22a98b6', 'Integer', false, 'int', function () {
+    this.$type('db1c26c2', 'Integer', false, 'int', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1476,23 +1479,23 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "range|4|0b2e6e78<9fefaaf9<f22a98b6>>": true,
-          "exclusiverange|4|0b2e6e78<9fefaaf9<f22a98b6>>": true,
-          "compare|4|0b2e6e78<f22a98b6>": true,
-          "equals|4|0b2e6e78<5e61c39d>": true,
-          "plus|4|0b2e6e78<f22a98b6>": true,
-          "times|4|0b2e6e78<f22a98b6>": true,
-          "div|4|0b2e6e78<f22a98b6>": true,
-          "minus|4|0b2e6e78<f22a98b6>": true,
-          "Release|2|0b2e6e78<void>": true,
-          "MapKey|3|e403222d": true,
-          "String|2|0b2e6e78<c509e19d>": true,
+          "range|4|fb1385bf<ba03a392<db1c26c2>>": true,
+          "exclusiverange|4|fb1385bf<ba03a392<db1c26c2>>": true,
+          "compare|4|fb1385bf<db1c26c2>": true,
+          "equals|4|fb1385bf<71258460>": true,
+          "plus|4|fb1385bf<db1c26c2>": true,
+          "times|4|fb1385bf<db1c26c2>": true,
+          "div|4|fb1385bf<db1c26c2>": true,
+          "minus|4|fb1385bf<db1c26c2>": true,
+          "Release|2|fb1385bf<void>": true,
+          "MapKey|3|f877b763": true,
+          "String|2|fb1385bf<b2b53db7>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('5e61c39d', 'Boolean', false, 'bool', function () {
+    this.$type('71258460', 'Boolean', false, 'bool', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1544,16 +1547,16 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "compare|4|0b2e6e78<f22a98b6>": true,
-          "equals|4|0b2e6e78<5e61c39d>": true,
-          "String|2|0b2e6e78<c509e19d>": true,
-          "MapKey|3|e403222d": true,
+          "compare|4|fb1385bf<db1c26c2>": true,
+          "equals|4|fb1385bf<71258460>": true,
+          "String|2|fb1385bf<b2b53db7>": true,
+          "MapKey|3|f877b763": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('4bb5f076', 'Float64', false, 'float64', function () {
+    this.$type('0eae6f1c', 'Float64', false, 'float64', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1573,13 +1576,13 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "Floor|2|0b2e6e78<f22a98b6>": true,
+          "Floor|2|fb1385bf<db1c26c2>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('c509e19d', 'String', false, 'string', function () {
+    this.$type('b2b53db7', 'String', false, 'string', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1608,22 +1611,87 @@ this.Serulian = (function ($global) {
         var $this = this;
         return $t.fastbox($this.$wrapped.length, $g.________testlib.basictypes.Integer);
       });
+      $instance.$slice = function (startindex, endindex) {
+        var $this = this;
+        var end;
+        var start;
+        var $current = 0;
+        syncloop: while (true) {
+          switch ($current) {
+            case 0:
+              start = /*#startindex ?? 0#*/$t.syncnullcompare(/*#startindex ?? 0#*/startindex, function () {
+                return $t.fastbox(0, $g.________testlib.basictypes.Integer);
+              });
+              end = /*#endindex ?? this.Length#*/$t.syncnullcompare(/*#endindex ?? this.Length#*/endindex, function () {
+                return $this.Length();
+              });
+/*#start < 0 {#*/              if (/*#start < 0 {#*/start.$wrapped < /*#start < 0 {#*/0) /*#start < 0 {#*/{
+                $current = 1;
+                continue syncloop;
+              } else {
+                $current = 2;
+                continue syncloop;
+              }
+              break;
+
+            case 1:
+/*#start = start + this.Length#*/              start = /*#start + this.Length#*/$t.fastbox(/*#start + this.Length#*/start.$wrapped + /*#this.Length#*/$this.Length().$wrapped, /*#start + this.Length#*/$g.________testlib.basictypes.Integer);
+              $current = 2;
+              continue syncloop;
+
+            case 2:
+/*#end < 0 {#*/              if (/*#end < 0 {#*/end.$wrapped < /*#end < 0 {#*/0) /*#end < 0 {#*/{
+                $current = 3;
+                continue syncloop;
+              } else {
+                $current = 4;
+                continue syncloop;
+              }
+              break;
+
+            case 3:
+/*#end = end + this.Length#*/              end = /*#end + this.Length#*/$t.fastbox(/*#end + this.Length#*/end.$wrapped + /*#this.Length#*/$this.Length().$wrapped, /*#end + this.Length#*/$g.________testlib.basictypes.Integer);
+              $current = 4;
+              continue syncloop;
+
+            case 4:
+/*#end { return '' }#*/              if (/*#start >= end { return '' }#*/start.$wrapped >= /*#end { return '' }#*/end.$wrapped) /*#end { return '' }#*/{
+                $current = 5;
+                continue syncloop;
+              } else {
+                $current = 6;
+                continue syncloop;
+              }
+              break;
+
+            case 5:
+              return $t.fastbox('', $g.________testlib.basictypes.String);
+
+            case 6:
+              return $t.fastbox($this.$wrapped.substring(start.$wrapped, end.$wrapped), $g.________testlib.basictypes.String);
+
+            default:
+              return;
+          }
+        }
+      };
       this.$typesig = function () {
         if (this.$cachedtypesig) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "String|2|0b2e6e78<c509e19d>": true,
-          "equals|4|0b2e6e78<5e61c39d>": true,
-          "plus|4|0b2e6e78<c509e19d>": true,
-          "MapKey|3|e403222d": true,
-          "Length|3|f22a98b6": true,
+          "String|2|fb1385bf<b2b53db7>": true,
+          "equals|4|fb1385bf<71258460>": true,
+          "plus|4|fb1385bf<b2b53db7>": true,
+          "MapKey|3|f877b763": true,
+          "Length|3|db1c26c2": true,
+          "slice|4|fb1385bf<b2b53db7>": true,
         };
         return this.$cachedtypesig = computed;
       };
     });
 
-    this.$type('f01ea3c6', 'WrappedError', false, 'wrappederror', function () {
+    this.$type('6484768c', 'WrappedError', false, 'wrappederror', function () {
       var $instance = this.prototype;
       var $static = this;
       this.$box = function ($wrapped) {
@@ -1646,8 +1714,8 @@ this.Serulian = (function ($global) {
           return this.$cachedtypesig;
         }
         var computed = {
-          "For|1|0b2e6e78<f01ea3c6>": true,
-          "Message|3|c509e19d": true,
+          "For|1|fb1385bf<6484768c>": true,
+          "Message|3|b2b53db7": true,
         };
         return this.$cachedtypesig = computed;
       };
@@ -1751,18 +1819,29 @@ this.Serulian = (function ($global) {
                   $continue($yield, $yieldin, $reject, $done);
                   return;
                 } else {
-                  $current = 6;
+                  $current = 7;
                   $continue($yield, $yieldin, $reject, $done);
                   return;
                 }
                 break;
 
               case 4:
-                $yield(/*#mapper(item)#*/mapper(/*#item)#*/item));
-                $current = 5;
+/*#mapper(item)#*/                $promise.maybe(/*#mapper(item)#*/mapper(/*#item)#*/item)).then(/*#item)#*/function (/*#item)#*/$result0) /*#item)#*/{
+                  $result = /*#mapper(item)#*/$result0;
+                  $current = 5;
+                  $continue($yield, $yieldin, $reject, $done);
+                  return;
+                }).catch(function (err) {
+                  throw err;
+                });
                 return;
 
               case 5:
+                $yield($result);
+                $current = 6;
+                return;
+
+              case 6:
                 $current = 2;
                 $continue($yield, $yieldin, $reject, $done);
                 return;

--- a/generator/es5/tests/statements/autounboxassign.js
+++ b/generator/es5/tests/statements/autounboxassign.js
@@ -16,7 +16,7 @@ $module('autounboxassign', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "SomeValue|3|f22a98b6": true,
+        "SomeValue|3|db1c26c2": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/loopstreamable.js
+++ b/generator/es5/tests/statements/loopstreamable.js
@@ -16,7 +16,7 @@ $module('loopstreamable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Stream|2|0b2e6e78<9fefaaf9<5e61c39d>>": true,
+        "Stream|2|fb1385bf<ba03a392<71258460>>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -42,7 +42,7 @@ $module('loopstreamable', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Next|2|0b2e6e78<8abdfedc<5e61c39d,5e61c39d>>": true,
+        "Next|2|fb1385bf<8abdfedc<71258460,71258460>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/loopvar.js
+++ b/generator/es5/tests/statements/loopvar.js
@@ -20,7 +20,7 @@ $module('loopvar', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Next|2|0b2e6e78<8abdfedc<5e61c39d,5e61c39d>>": true,
+        "Next|2|fb1385bf<8abdfedc<71258460,71258460>>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/match.js
+++ b/generator/es5/tests/statements/match.js
@@ -16,7 +16,7 @@ $module('match', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Value|3|5e61c39d": true,
+        "Value|3|71258460": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/with.js
+++ b/generator/es5/tests/statements/with.js
@@ -17,7 +17,7 @@ $module('with', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|0b2e6e78<void>": true,
+        "Release|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/withasync.js
+++ b/generator/es5/tests/statements/withasync.js
@@ -43,7 +43,7 @@ $module('withasync', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|0b2e6e78<void>": true,
+        "Release|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/statements/withexit.js
+++ b/generator/es5/tests/statements/withexit.js
@@ -17,7 +17,7 @@ $module('withexit', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Release|2|0b2e6e78<void>": true,
+        "Release|2|fb1385bf<void>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/basic.js
+++ b/generator/es5/tests/struct/basic.js
@@ -22,12 +22,12 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<a76166f4>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<a76166f4>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<a76166f4>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<a76166f4>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -67,12 +67,12 @@ $module('basic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<1a1b7840>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<1a1b7840>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<1a1b7840>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<1a1b7840>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/clone.js
+++ b/generator/es5/tests/struct/clone.js
@@ -28,12 +28,12 @@ $module('clone', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<be48fdbe>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<be48fdbe>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<be48fdbe>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<be48fdbe>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/defaults.js
+++ b/generator/es5/tests/struct/defaults.js
@@ -22,12 +22,12 @@ $module('defaults', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<6cbd0ebf>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<6cbd0ebf>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<6cbd0ebf>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<6cbd0ebf>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -77,12 +77,12 @@ $module('defaults', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<41f59c9b>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<41f59c9b>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<41f59c9b>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<41f59c9b>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/equals.js
+++ b/generator/es5/tests/struct/equals.js
@@ -28,12 +28,12 @@ $module('equals', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<9285bf36>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<9285bf36>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<9285bf36>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<9285bf36>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -61,12 +61,12 @@ $module('equals', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<4fb96a52>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<4fb96a52>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<4fb96a52>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<4fb96a52>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/generic.js
+++ b/generator/es5/tests/struct/generic.js
@@ -22,12 +22,12 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<6b885b52>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<6b885b52>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<6b885b52>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<6b885b52>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,13 +55,13 @@ $module('generic', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
-      computed[("Parse|1|0b2e6e78<d34106e1<" + $t.typeid(T)) + ">>"] = true;
-      computed[("Clone|2|0b2e6e78<d34106e1<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Parse|1|fb1385bf<d34106e1<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Clone|2|fb1385bf<d34106e1<" + $t.typeid(T)) + ">>"] = true;
       return this.$cachedtypesig = computed;
     };
   });

--- a/generator/es5/tests/struct/innergeneric.js
+++ b/generator/es5/tests/struct/innergeneric.js
@@ -22,12 +22,12 @@ $module('innergeneric', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<078feecd>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<078feecd>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<078feecd>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<078feecd>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };
@@ -55,13 +55,13 @@ $module('innergeneric', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
-      computed[("Parse|1|0b2e6e78<8369fb45<" + $t.typeid(T)) + ">>"] = true;
-      computed[("Clone|2|0b2e6e78<8369fb45<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Parse|1|fb1385bf<8369fb45<" + $t.typeid(T)) + ">>"] = true;
+      computed[("Clone|2|fb1385bf<8369fb45<" + $t.typeid(T)) + ">>"] = true;
       return this.$cachedtypesig = computed;
     };
   });

--- a/generator/es5/tests/struct/nominal.js
+++ b/generator/es5/tests/struct/nominal.js
@@ -39,12 +39,12 @@ $module('nominal', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<0d40ca4a>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<0d40ca4a>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<0d40ca4a>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<0d40ca4a>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/generator/es5/tests/struct/nullbox.js
+++ b/generator/es5/tests/struct/nullbox.js
@@ -21,12 +21,12 @@ $module('nullbox', function () {
         return this.$cachedtypesig;
       }
       var computed = {
-        "Parse|1|0b2e6e78<45b3c939>": true,
-        "equals|4|0b2e6e78<5e61c39d>": true,
-        "Stringify|2|0b2e6e78<c509e19d>": true,
-        "Mapping|2|0b2e6e78<204295f9<any>>": true,
-        "Clone|2|0b2e6e78<45b3c939>": true,
-        "String|2|0b2e6e78<c509e19d>": true,
+        "Parse|1|fb1385bf<45b3c939>": true,
+        "equals|4|fb1385bf<71258460>": true,
+        "Stringify|2|fb1385bf<b2b53db7>": true,
+        "Mapping|2|fb1385bf<204295f9<any>>": true,
+        "Clone|2|fb1385bf<45b3c939>": true,
+        "String|2|fb1385bf<b2b53db7>": true,
       };
       return this.$cachedtypesig = computed;
     };

--- a/graphs/scopegraph/scope_sml_expr.go
+++ b/graphs/scopegraph/scope_sml_expr.go
@@ -194,8 +194,10 @@ func (sb *scopeBuilder) scopeSmlExpression(node compilergraph.GraphNode, context
 		// Check if the children parameter is a stream. If so, we match the stream type. Otherwise,
 		// we check if the child matches the value expected.
 		if childsType.IsDirectReferenceTo(sb.sg.tdg.StreamType()) {
-			// If there is a single child that is also a matching stream, then we use the stream directly.
+			// If there is a single child that is also a matching stream (i.e. same type of stream or a Stream<subtype of childsType's stream generic>), then we use the stream directly.
 			if len(childrenTypes) == 1 && childrenTypes[0] == childsType {
+				childrenLabel = proto.ScopeLabel_SML_STREAM_CHILD
+			} else if len(childrenTypes) == 1 && childrenTypes[0].IsDirectReferenceTo(sb.sg.tdg.StreamType()) && childrenTypes[0].CheckSubTypeOf(childsType.Generics()[0]) == nil {
 				childrenLabel = proto.ScopeLabel_SML_STREAM_CHILD
 			} else {
 				// Otherwise, the children must either match the type of the stream, or the type of the *values*

--- a/testlib/basic.webidl
+++ b/testlib/basic.webidl
@@ -13,6 +13,7 @@ interface __serulian_internal {
 interface String {
 	serializer;
 	readonly attribute Number length;
+  String substring(any start, any end);
 };
 
 [Constructor(any value), NativeOperator=Equals]

--- a/testlib/basictypes.seru
+++ b/testlib/basictypes.seru
@@ -56,7 +56,7 @@ type Mapping<T> : Object {
 	}
 
 	operator Index(key string) T? {
-		var value = (Object(this))[NativeString(key)]
+		var value = Object(this)[NativeString(key)]
 		if value is null { return null }
 
 		return value.(T)
@@ -72,7 +72,7 @@ type Slice<T> : Array {
 	}
 
 	operator Index(index int) T {
-		return (Array(this))[Number(index)].(T)
+		return Array(this)[Number(index)].(T)
 	}
 
 	operator Slice(startindex int?, endindex int?) Slice<T> {
@@ -248,6 +248,23 @@ type String : NativeString {
 
 	property Length int {
 		get { return Integer(NativeString(this).length) }
+	}
+
+	operator Slice(startindex int?, endindex int?) string {
+		var start = startindex ?? 0
+		var end = endindex ?? this.Length
+
+		if start < 0 {
+			start = start + this.Length
+		}
+
+		if end < 0 {
+			end = end + this.Length
+		}
+
+		if start >= end { return '' }
+
+		return String(NativeString(this).substring(Number(start), Number(end)))
 	}
 }
 


### PR DESCRIPTION
1) Invocations of anonymous functions were not being generated as possibly promising
2) A single stream as a child of a SML tag was not being marked as such if it didn't *exactly* match the parent function's child parameter. Now we do a subtype check.