### PR TITLE
Enable support for casting streams

### DIFF
--- a/generator/es5/codedom/function.go
+++ b/generator/es5/codedom/function.go
@@ -8,6 +8,7 @@ import (
 	"github.com/serulian/compiler/compilergraph"
 	"github.com/serulian/compiler/graphs/scopegraph"
 	"github.com/serulian/compiler/graphs/srg"
+	"github.com/serulian/compiler/graphs/typegraph"
 )
 
 type SpecializedFunction int
@@ -27,13 +28,15 @@ const (
 // FunctionDefinitionNode represents the definition of a function.
 type FunctionDefinitionNode struct {
 	expressionBase
-	Generics       []string              // The names of the generics of the function, if any.
-	Parameters     []string              // The names of the parameters of the function, if any.
-	Body           StatementOrExpression // The body for the function.
-	RequiresThis   bool                  // Whether the function needs '$this' defined.
-	Specialization SpecializedFunction   // The specialization for this function, if any.
+	Generics           []string                 // The names of the generics of the function, if any.
+	Parameters         []string                 // The names of the parameters of the function, if any.
+	Body               StatementOrExpression    // The body for the function.
+	RequiresThis       bool                     // Whether the function needs '$this' defined.
+	GeneratorYieldType *typegraph.TypeReference // The type of items being yielded, if this is a generator.
+	Specialization     SpecializedFunction      // The specialization for this function, if any.
 }
 
+// FunctionDefinition constructs a new function definition.
 func FunctionDefinition(generics []string, parameters []string, body StatementOrExpression, requiresThis bool, specialization SpecializedFunction, basisNode compilergraph.GraphNode) *FunctionDefinitionNode {
 	return &FunctionDefinitionNode{
 		expressionBase{domBase{basisNode}},
@@ -41,7 +44,21 @@ func FunctionDefinition(generics []string, parameters []string, body StatementOr
 		parameters,
 		body,
 		requiresThis,
+		nil,
 		specialization,
+	}
+}
+
+// GeneratorDefinition constructs a new function definition for a generator function.
+func GeneratorDefinition(generics []string, parameters []string, body StatementOrExpression, requiresThis bool, yieldType typegraph.TypeReference, basisNode compilergraph.GraphNode) *FunctionDefinitionNode {
+	return &FunctionDefinitionNode{
+		expressionBase{domBase{basisNode}},
+		generics,
+		parameters,
+		body,
+		requiresThis,
+		&yieldType,
+		GeneratorFunction,
 	}
 }
 

--- a/generator/es5/dombuilder/build_lambda_expr.go
+++ b/generator/es5/dombuilder/build_lambda_expr.go
@@ -46,10 +46,12 @@ func (db *domBuilder) buildLambdaExpressionInternal(node compilergraph.GraphNode
 	}
 
 	// Check for a generator.
-	specialization := codedom.NormalFunction
 	if isGenerator {
-		specialization = codedom.GeneratorFunction
+		// Extract out the type yielded from the return type of the lambda.
+		lambdaScope, _ := db.scopegraph.GetScope(node)
+		lambdaType := lambdaScope.ResolvedTypeRef(db.scopegraph.TypeGraph())
+		return codedom.GeneratorDefinition(generics, parameters, body, false, lambdaType.StreamYieldTypeOrAny(), node)
 	}
 
-	return codedom.FunctionDefinition(generics, parameters, body, false, specialization, node)
+	return codedom.FunctionDefinition(generics, parameters, body, false, codedom.NormalFunction, node)
 }

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -270,6 +270,7 @@ var generationTests = []generationTest{
 	generationTest{"nested generator success test", "generator", "nested", integrationTestSuccessExpected, ""},
 	generationTest{"resource generator success test", "generator", "resource", integrationTestSuccessExpected, ""},
 	generationTest{"async generator success test", "generator", "async", integrationTestSuccessExpected, ""},
+	generationTest{"generator cast success test", "generator", "cast", integrationTestSuccessExpected, ""},
 
 	generationTest{"empty resolve statement test", "resolve", "empty", integrationTestNone, ""},
 	generationTest{"simple resolve statement test", "resolve", "simple", integrationTestSuccessExpected, ""},

--- a/generator/es5/statemachine/statemachine.go
+++ b/generator/es5/statemachine/statemachine.go
@@ -9,6 +9,8 @@ package statemachine
 import (
 	"fmt"
 
+	"github.com/serulian/compiler/graphs/typegraph"
+
 	"github.com/serulian/compiler/compilergraph"
 	"github.com/serulian/compiler/generator/es5/codedom"
 	"github.com/serulian/compiler/generator/es5/dombuilder"
@@ -22,12 +24,12 @@ var _ = fmt.Printf
 
 // FunctionDef defines the struct for a function accepted by GenerateFunctionSource.
 type FunctionDef struct {
-	Generics       []string                // Returns the names of the generics on the function, if any.
-	Parameters     []string                // Returns the names of the parameters on the function, if any.
-	RequiresThis   bool                    // Returns if this function is requires the "this" var to be added.
-	WorkerExecutes bool                    // Returns true if this function should be executed by a web worker.
-	IsGenerator    bool                    // Returns true if the function being generated is a generator.
-	BodyNode       compilergraph.GraphNode // The parser root node for the function body.
+	Generics           []string                 // Returns the names of the generics on the function, if any.
+	Parameters         []string                 // Returns the names of the parameters on the function, if any.
+	RequiresThis       bool                     // Returns if this function is requires the "this" var to be added.
+	WorkerExecutes     bool                     // Returns true if this function should be executed by a web worker.
+	GeneratorYieldType *typegraph.TypeReference // Returns a non-nil value if the function being generated is a generator.
+	BodyNode           compilergraph.GraphNode  // The parser root node for the function body.
 }
 
 // GenerateFunctionSource generates the source code for a function, including its internal state machine.
@@ -36,17 +38,12 @@ func GenerateFunctionSource(functionDef FunctionDef, scopegraph *scopegraph.Scop
 	funcBody := dombuilder.BuildStatement(scopegraph, functionDef.BodyNode)
 
 	// Instantiate a new state machine generator and use it to generate the function.
-	functionTraits := shared.FunctionTraits(codedom.IsAsynchronous(funcBody, scopegraph), functionDef.IsGenerator, codedom.IsManagingResources(funcBody))
+	functionTraits := shared.FunctionTraits(codedom.IsAsynchronous(funcBody, scopegraph), functionDef.GeneratorYieldType != nil, codedom.IsManagingResources(funcBody))
 	sg := buildGenerator(scopegraph, shared.NewTemplater(), functionTraits)
+
 	specialization := codedom.NormalFunction
-
-	// Generate the function expression.
-	switch {
-	case functionDef.WorkerExecutes:
+	if functionDef.WorkerExecutes {
 		specialization = codedom.AsynchronousWorkerFunction
-
-	case functionDef.IsGenerator:
-		specialization = codedom.GeneratorFunction
 	}
 
 	domDefinition := codedom.FunctionDefinition(
@@ -57,6 +54,17 @@ func GenerateFunctionSource(functionDef FunctionDef, scopegraph *scopegraph.Scop
 		specialization,
 		functionDef.BodyNode)
 
+	if functionDef.GeneratorYieldType != nil {
+		domDefinition = codedom.GeneratorDefinition(
+			functionDef.Generics,
+			functionDef.Parameters,
+			funcBody,
+			functionDef.RequiresThis,
+			*functionDef.GeneratorYieldType,
+			functionDef.BodyNode)
+	}
+
+	// Generate the function expression.
 	result := expressiongenerator.GenerateExpression(domDefinition, expressiongenerator.AllowedSync, scopegraph, sg.generateMachine)
 	return result.Build()
 }

--- a/generator/es5/tests/generator/async.js
+++ b/generator/es5/tests/generator/async.js
@@ -36,7 +36,7 @@ $module('async', function () {
         }
       }
     };
-    return $generator.new($continue, true);
+    return $generator.new($continue, true, $g.________testlib.basictypes.Boolean);
   };
   $static.TEST = $t.markpromising(function () {
     var $result;

--- a/generator/es5/tests/generator/cast.js
+++ b/generator/es5/tests/generator/cast.js
@@ -1,4 +1,4 @@
-$module('basic', function () {
+$module('cast', function () {
   var $static = this;
   $static.SomeGenerator = function () {
     var $current = 0;
@@ -6,18 +6,13 @@ $module('basic', function () {
       while (true) {
         switch ($current) {
           case 0:
-            $yield($t.fastbox(1, $g.________testlib.basictypes.Integer));
+            $yield($t.fastbox(false, $g.________testlib.basictypes.Boolean));
             $current = 1;
             return;
 
           case 1:
-            $yield($t.fastbox(2, $g.________testlib.basictypes.Integer));
+            $yield($t.fastbox(true, $g.________testlib.basictypes.Boolean));
             $current = 2;
-            return;
-
-          case 2:
-            $yield($t.fastbox(3, $g.________testlib.basictypes.Integer));
-            $current = 3;
             return;
 
           default:
@@ -26,29 +21,25 @@ $module('basic', function () {
         }
       }
     };
-    return $generator.new($continue, false, $g.________testlib.basictypes.Integer);
+    return $generator.new($continue, false, $g.________testlib.basictypes.Boolean);
   };
   $static.TEST = $t.markpromising(function () {
     var $result;
     var $temp0;
     var $temp1;
-    var counter;
-    var entry;
-    var s;
+    var v;
+    var value;
     var $current = 0;
     var $continue = function ($resolve, $reject) {
       localasyncloop: while (true) {
         switch ($current) {
           case 0:
-            s = $g.________testlib.basictypes.MapStream($g.________testlib.basictypes.Integer, $g.________testlib.basictypes.Integer)($g.basic.SomeGenerator(), function (s) {
-              return $t.fastbox(s.$wrapped + 1, $g.________testlib.basictypes.Integer);
-            });
-            counter = $t.fastbox(0, $g.________testlib.basictypes.Integer);
+            v = null;
             $current = 1;
             continue localasyncloop;
 
           case 1:
-            $temp1 = s;
+            $temp1 = $t.cast($g.cast.SomeGenerator(), $g.________testlib.basictypes.Stream($g.________testlib.basictypes.Boolean), false);
             $current = 2;
             continue localasyncloop;
 
@@ -66,7 +57,7 @@ $module('basic', function () {
             return;
 
           case 3:
-            entry = $temp0.First;
+            value = $temp0.First;
             if ($temp0.Second.$wrapped) {
               $current = 4;
               continue localasyncloop;
@@ -77,12 +68,12 @@ $module('basic', function () {
             break;
 
           case 4:
-            counter = $t.fastbox(counter.$wrapped + entry.$wrapped, $g.________testlib.basictypes.Integer);
+            v = value;
             $current = 2;
             continue localasyncloop;
 
           case 5:
-            $resolve($t.fastbox(counter.$wrapped == 9, $g.________testlib.basictypes.Boolean));
+            $resolve(v);
             return;
 
           default:

--- a/generator/es5/tests/generator/cast.seru
+++ b/generator/es5/tests/generator/cast.seru
@@ -1,0 +1,12 @@
+function SomeGenerator() bool* {
+	yield false
+	yield true
+}
+
+function TEST() bool? {
+	var v bool? = null
+	for value in SomeGenerator().(bool*) {
+		v = value
+	}
+	return v
+}

--- a/generator/es5/tests/generator/nested.js
+++ b/generator/es5/tests/generator/nested.js
@@ -53,7 +53,7 @@ $module('nested', function () {
         }
       }
     };
-    return $generator.new($continue, false);
+    return $generator.new($continue, false, $g.________testlib.basictypes.Integer);
   };
   $static.SomeGenerator = function () {
     var $current = 0;
@@ -76,7 +76,7 @@ $module('nested', function () {
         }
       }
     };
-    return $generator.new($continue, true);
+    return $generator.new($continue, true, $g.________testlib.basictypes.Integer);
   };
   $static.TEST = $t.markpromising(function () {
     var $result;

--- a/generator/es5/tests/generator/resource.js
+++ b/generator/es5/tests/generator/resource.js
@@ -51,7 +51,7 @@ $module('resource', function () {
         }
       }
     };
-    return $generator.new($continue, false);
+    return $generator.new($continue, false, $g.________testlib.basictypes.Integer);
   };
   $static.TEST = $t.markpromising(function () {
     var $result;

--- a/generator/es5/tests/generator/simple.js
+++ b/generator/es5/tests/generator/simple.js
@@ -21,7 +21,7 @@ $module('simple', function () {
         }
       }
     };
-    return $generator.new($continue, false);
+    return $generator.new($continue, false, $g.________testlib.basictypes.Boolean);
   };
   $static.TEST = $t.markpromising(function () {
     var $result;

--- a/generator/es5/tests/sml/asyncchildren.js
+++ b/generator/es5/tests/sml/asyncchildren.js
@@ -145,7 +145,7 @@ $module('asyncchildren', function () {
                   }
                 }
               };
-              return $generator.new($continue, true);
+              return $generator.new($continue, true, $g.________testlib.basictypes.Integer);
             })())).then(function ($result0) {
               $result = $result0;
               $current = 1;

--- a/generator/es5/tests/sml/children.js
+++ b/generator/es5/tests/sml/children.js
@@ -94,7 +94,7 @@ $module('children', function () {
                   }
                 }
               };
-              return $generator.new($continue, false);
+              return $generator.new($continue, false, $g.________testlib.basictypes.Integer);
             })())).then(function ($result0) {
               $result = $result0;
               $current = 1;

--- a/generator/es5/tests/sml/inlineloopbroken.js
+++ b/generator/es5/tests/sml/inlineloopbroken.js
@@ -156,7 +156,7 @@ $module('inlineloopbroken', function () {
                             }
                           }
                         };
-                        return $generator.new($continue, false);
+                        return $generator.new($continue, false, $g.________testlib.basictypes.String);
                       })())).then(function ($result0) {
                         $result = $result0;
                         $current = 1;

--- a/generator/es5/tests/sml/loopandelements.js
+++ b/generator/es5/tests/sml/loopandelements.js
@@ -100,7 +100,7 @@ $module('loopandelements', function () {
                   }
                 }
               };
-              return $generator.new($continue, true);
+              return $generator.new($continue, true, $g.________testlib.basictypes.Integer);
             })())).then(function ($result0) {
               $result = $result0;
               $current = 1;

--- a/generator/es5/tests/sml/streamchild.js
+++ b/generator/es5/tests/sml/streamchild.js
@@ -87,7 +87,7 @@ $module('streamchild', function () {
         }
       }
     };
-    return $generator.new($continue, false);
+    return $generator.new($continue, false, $g.________testlib.basictypes.Integer);
   };
   $static.TEST = $t.markpromising(function () {
     var $result;

--- a/generator/es5/tests/sourcemapping/basic.js
+++ b/generator/es5/tests/sourcemapping/basic.js
@@ -155,10 +155,10 @@ this.Serulian = (function ($global) {
 
         case 'interface':
           var targetSignature = type.$typesig();
-          if (!value.constructor.$typesig) {
-            return false;
+          var valueSignature = value.constructor.$typesig ? value.constructor.$typesig() : null;
+          if (!valueSignature && value.$streamType) {
+            valueSignature = $a.stream(value.$streamType).$typesig();
           }
-          var valueSignature = value.constructor.$typesig();
           var expectedKeys = Object.keys(targetSignature);
           for (var i = 0; i < expectedKeys.length; ++i) {
             var expectedKey = expectedKeys[i];
@@ -482,20 +482,22 @@ this.Serulian = (function ($global) {
     },
   };
   var $generator = {
-    directempty: function () {
+    directempty: function (opt_yieldType) {
       var stream = {
         Next: function () {
           return $a['tuple']($t.any, $a['bool']).Build(null, false);
         },
+        $streamType: opt_yieldType || $t.any,
       };
       return stream;
     },
-    empty: function () {
-      return $generator.directempty();
+    empty: function (yieldType) {
+      return $generator.directempty(yieldType);
     },
-    new: function (f, isAsync) {
+    new: function (f, isAsync, yieldType) {
       if (isAsync) {
         var stream = {
+          $streamType: yieldType,
           $is: null,
           Next: function () {
             return $promise.new(function (resolve, reject) {
@@ -529,6 +531,7 @@ this.Serulian = (function ($global) {
         return stream;
       } else {
         var stream = {
+          $streamType: yieldType,
           $is: null,
           Next: function () {
             if (stream.$is != null) {
@@ -1852,7 +1855,7 @@ this.Serulian = (function ($global) {
             }
           }
         };
-        return $generator.new($continue, true);
+        return $generator.new($continue, true, Q);
       };
       return $f;
     };

--- a/graphs/typegraph/typereference.go
+++ b/graphs/typegraph/typereference.go
@@ -1092,6 +1092,28 @@ func (tr TypeReference) AsNonNullable() TypeReference {
 	return tr.withFlag(trhSlotFlagNullable, nullableFlagFalse)
 }
 
+// StreamYieldType returns the type of items yielded by this stream or an error if
+// this type is not a concrete subtype of Stream<T>.
+func (tr TypeReference) StreamYieldType() (TypeReference, error) {
+	generics, err := tr.CheckConcreteSubtypeOf(tr.tdg.StreamType())
+	if err != nil {
+		return tr.tdg.VoidTypeReference(), err
+	}
+
+	return generics[0], nil
+}
+
+// StreamYieldTypeOrAny returns the type of the items yielded by this stream, or `any`
+// if none.
+func (tr TypeReference) StreamYieldTypeOrAny() TypeReference {
+	yieldType, err := tr.StreamYieldType()
+	if err != nil {
+		return tr.tdg.AnyTypeReference()
+	}
+
+	return yieldType
+}
+
 // Intersect returns the type common to both type references or any if they are uncommon.
 func (tr TypeReference) Intersect(other TypeReference) TypeReference {
 	if tr.IsVoid() {


### PR DESCRIPTION
Before, we didn't have the necessary type information at runtime to do so. Now, we annotate streams with their yielded item type, to allow casting to the stream type.