### PR TITLE
 Fix scope checks for lambda return types and add a generator test

### DIFF
--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -270,6 +270,7 @@ var generationTests = []generationTest{
 	generationTest{"nested generator success test", "generator", "nested", integrationTestSuccessExpected, ""},
 	generationTest{"resource generator success test", "generator", "resource", integrationTestSuccessExpected, ""},
 	generationTest{"async generator success test", "generator", "async", integrationTestSuccessExpected, ""},
+	generationTest{"lambda generator success test", "generator", "lambda", integrationTestSuccessExpected, ""},
 	generationTest{"generator cast success test", "generator", "cast", integrationTestSuccessExpected, ""},
 
 	generationTest{"empty resolve statement test", "resolve", "empty", integrationTestNone, ""},

--- a/generator/es5/tests/generator/lambda.js
+++ b/generator/es5/tests/generator/lambda.js
@@ -1,0 +1,130 @@
+$module('lambda', function () {
+  var $static = this;
+  $static.DoSomething = $t.markpromising(function () {
+    var $result;
+    var $temp0;
+    var $temp1;
+    var l;
+    var total;
+    var value;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            l = function () {
+              var $current = 0;
+              var $continue = function ($yield, $yieldin, $reject, $done) {
+                while (true) {
+                  switch ($current) {
+                    case 0:
+                      $yield($t.fastbox(1, $g.________testlib.basictypes.Integer));
+                      $current = 1;
+                      return;
+
+                    case 1:
+                      $yield($t.fastbox(2, $g.________testlib.basictypes.Integer));
+                      $current = 2;
+                      return;
+
+                    default:
+                      $done();
+                      return;
+                  }
+                }
+              };
+              return $generator.new($continue, false, $t.any);
+            };
+            total = $t.fastbox(0, $g.________testlib.basictypes.Integer);
+            $current = 1;
+            continue localasyncloop;
+
+          case 1:
+            $promise.maybe(l()).then(function ($result0) {
+              $result = $result0;
+              $current = 2;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 2:
+            $temp1 = $result;
+            $current = 3;
+            continue localasyncloop;
+
+          case 3:
+            $promise.maybe($temp1.Next()).then(function ($result0) {
+              $temp0 = $result0;
+              $result = $temp0;
+              $current = 4;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 4:
+            value = $temp0.First;
+            if ($temp0.Second.$wrapped) {
+              $current = 5;
+              continue localasyncloop;
+            } else {
+              $current = 6;
+              continue localasyncloop;
+            }
+            break;
+
+          case 5:
+            total = $t.fastbox(total.$wrapped + value.$wrapped, $g.________testlib.basictypes.Integer);
+            $current = 3;
+            continue localasyncloop;
+
+          case 6:
+            $resolve(total);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+  $static.TEST = $t.markpromising(function () {
+    var $result;
+    var $current = 0;
+    var $continue = function ($resolve, $reject) {
+      localasyncloop: while (true) {
+        switch ($current) {
+          case 0:
+            $promise.maybe($g.lambda.DoSomething()).then(function ($result0) {
+              $result = $t.fastbox($result0.$wrapped == 3, $g.________testlib.basictypes.Boolean);
+              $current = 1;
+              $continue($resolve, $reject);
+              return;
+            }).catch(function (err) {
+              $reject(err);
+              return;
+            });
+            return;
+
+          case 1:
+            $resolve($result);
+            return;
+
+          default:
+            $resolve();
+            return;
+        }
+      }
+    };
+    return $promise.new($continue);
+  });
+});

--- a/generator/es5/tests/generator/lambda.seru
+++ b/generator/es5/tests/generator/lambda.seru
@@ -1,0 +1,14 @@
+function DoSomething() int {
+	var l = function() int* {
+		yield 1
+		yield 2
+	}
+
+	var total = 0
+	for value in l() {
+		total = total + value
+	}
+	return total
+}
+
+function TEST() bool? { return DoSomething() == 3 }

--- a/graphs/scopegraph/scope_statements.go
+++ b/graphs/scopegraph/scope_statements.go
@@ -698,7 +698,7 @@ func (sb *scopeBuilder) scopeReturnStatement(node compilergraph.GraphNode, conte
 	}
 
 	// Ensure the return types match.
-	expectedReturnType, _ := sb.sg.tdg.LookupReturnType(context.parentImplemented)
+	expectedReturnType, _ := sb.sg.GetReturnType(context.parentImplemented)
 	if expectedReturnType.IsVoid() {
 		if !actualReturnType.IsVoid() {
 			sb.decorateWithError(node, "No return value expected here, found value of type '%v'", actualReturnType)
@@ -733,7 +733,7 @@ func (sb *scopeBuilder) scopeReturnStatement(node compilergraph.GraphNode, conte
 // scopeYieldStatement scopes a yield statement in the SRG.
 func (sb *scopeBuilder) scopeYieldStatement(node compilergraph.GraphNode, context scopeContext) proto.ScopeInfo {
 	// Ensure it returns a stream.
-	returnType, ok := sb.sg.tdg.LookupReturnType(context.parentImplemented)
+	returnType, ok := sb.sg.GetReturnType(context.parentImplemented)
 	if !ok || !returnType.IsDirectReferenceTo(sb.sg.tdg.StreamType()) {
 		sb.decorateWithError(node, "'yield' statement must be under a function or property returning a Stream. Found: %v", returnType)
 		return newScope().
@@ -863,7 +863,7 @@ func (sb *scopeBuilder) scopeStatementBlock(node compilergraph.GraphNode, contex
 		} else {
 			parentDef, hasParent := node.StartQuery().In(sourceshape.NodePredicateBody).TryGetNode()
 			if hasParent {
-				returnTypeExpected, hasReturnType := sb.sg.tdg.LookupReturnType(parentDef)
+				returnTypeExpected, hasReturnType := sb.sg.GetReturnType(parentDef)
 				if hasReturnType {
 					// If the return type expected is void, ensure no branch returned any values.
 					if returnTypeExpected.IsVoid() {

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -90,6 +90,10 @@ var scopeGraphTests = []scopegraphTest{
 	scopegraphTest{"async generator test", "generator", "async", []expectedScopeEntry{},
 		"Asynchronous function DoSomethingAsync must return a structural type: Stream<Integer> is not structural nor serializable", ""},
 
+	// Yield under lambda.
+	scopegraphTest{"lambda generator test", "generator", "lambda", []expectedScopeEntry{},
+		"", ""},
+
 	/////////// Settling (return and reject) ///////////
 
 	// Success test.
@@ -1337,6 +1341,10 @@ var scopeGraphTests = []scopegraphTest{
 			expectedScopeEntry{"explicitreturn", expectedScope{true, proto.ScopeKind_VALUE, "function<String>(Integer, Boolean)", "void"}},
 		},
 		"", ""},
+
+	scopegraphTest{"lambda expression defined return mismatch test", "lambda", "returnmismatch",
+		[]expectedScopeEntry{},
+		"Expected return value of type 'String': 'Integer' cannot be used in place of non-interface 'String'", ""},
 
 	/////////// chained inference test ///////////
 

--- a/graphs/scopegraph/tests/generator/lambda.seru
+++ b/graphs/scopegraph/tests/generator/lambda.seru
@@ -1,0 +1,8 @@
+function DoSomething(anotherStream int*) {
+	var l = function() int* {
+		yield 1
+		yield 2
+		yield in anotherStream
+		yield break
+	}
+}

--- a/graphs/scopegraph/tests/lambda/returnmismatch.seru
+++ b/graphs/scopegraph/tests/lambda/returnmismatch.seru
@@ -1,0 +1,3 @@
+function DoSomething() {
+	function(a int, b int) string { return a + b }
+}


### PR DESCRIPTION
Before, we were failing to lookup the proper defined return type (if one existed), thus the type check was not functioning.

This PR fixes the check and adds tests to both the scoping system and the code generator