### PR TITLE
Disallow repeated fields in structural new expressions

### DIFF
--- a/graphs/scopegraph/scope_literal_expr.go
+++ b/graphs/scopegraph/scope_literal_expr.go
@@ -147,6 +147,11 @@ func (sb *scopeBuilder) scopeStructuralNewEntries(node compilergraph.GraphNode, 
 			isValid = false
 		}
 
+		if _, ok := encountered[entryName]; ok {
+			sb.decorateWithError(eit.Node(), "Entry `%s` already defined in this expression", entryName)
+			isValid = false
+		}
+
 		encountered[entryName] = true
 	}
 

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -1558,6 +1558,10 @@ var scopeGraphTests = []scopegraphTest{
 		[]expectedScopeEntry{},
 		"Non-nullable type member 'SomeField' is required to construct type SomeClass", ""},
 
+	scopegraphTest{"structural new repeated field test", "structnew", "repeatedfield",
+		[]expectedScopeEntry{},
+		"Entry `SomeField` already defined in this expression", ""},
+
 	/////////// async function tests /////////////////
 
 	scopegraphTest{"async under class test", "async", "underclass",

--- a/graphs/scopegraph/tests/structnew/repeatedfield.seru
+++ b/graphs/scopegraph/tests/structnew/repeatedfield.seru
@@ -1,0 +1,7 @@
+class SomeClass {
+	var SomeField int
+}
+
+function DoSomething() {
+	SomeClass{SomeField: 2, SomeField: 2}
+}


### PR DESCRIPTION
They are confusing and the ordering, while maintained right now, is not defined behavior