### PR TITLE
Add support for cancelation

### DIFF
--- a/builder/bundle_test.go
+++ b/builder/bundle_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/serulian/compiler/bundle"
 	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/compilerutil"
 	"github.com/serulian/compiler/graphs/scopegraph"
 	"github.com/serulian/compiler/graphs/typegraph"
 	"github.com/serulian/compiler/integration"
@@ -68,10 +69,10 @@ func (t testParser) Parse(source compilercommon.InputSource, input string, impor
 	t.files[string(source)] = input
 }
 
-func (t testParser) Apply(packageMap packageloader.LoadedPackageMap, sourceTracker packageloader.SourceTracker) {
+func (t testParser) Apply(packageMap packageloader.LoadedPackageMap, sourceTracker packageloader.SourceTracker, cancelationHandle compilerutil.CancelationHandle) {
 }
 
-func (t testParser) Verify(errorReporter packageloader.ErrorReporter, warningReporter packageloader.WarningReporter) {
+func (t testParser) Verify(errorReporter packageloader.ErrorReporter, warningReporter packageloader.WarningReporter, cancelationHandle compilerutil.CancelationHandle) {
 }
 
 func TestBundling(t *testing.T) {

--- a/compilergraph/modifier.go
+++ b/compilergraph/modifier.go
@@ -32,6 +32,9 @@ type GraphLayerModifier interface {
 
 	// Close closes the modifier, discarding any enqueued changes.
 	Close()
+
+	// ApplyOrClose applies the modifier if the given apply bool is true.
+	ApplyOrClose(apply bool)
 }
 
 // createNewModifier creates a new, concrete graph modifier.
@@ -125,6 +128,15 @@ func (gl *graphLayerModifierStruct) Apply() {
 func (gl *graphLayerModifierStruct) Close() {
 	gl.wg.Wait()
 	gl.closeChannel <- true
+}
+
+// ApplyOrClose applies the modifier if the given apply bool is true.
+func (gl *graphLayerModifierStruct) ApplyOrClose(apply bool) {
+	if apply {
+		gl.Apply()
+	} else {
+		gl.Close()
+	}
 }
 
 // AsNode returns the ModifiableGraphNode as a GraphNode. Note that the node will not

--- a/compilerutil/cancelationhandle.go
+++ b/compilerutil/cancelationhandle.go
@@ -21,6 +21,11 @@ func NewCancelationHandle() CancelationHandle {
 	return &cancelationHandle{}
 }
 
+// NoopCancelationHandle returns a cancelation handle that cannot be canceled.
+func NoopCancelationHandle() CancelationHandle {
+	return noopCancelationHandle{}
+}
+
 // GetCancelationHandle returns either the existing cancelation handle (if not nil)
 // or a new no-op handle.
 func GetCancelationHandle(existing CancelationHandle) CancelationHandle {

--- a/compilerutil/cancelationhandle.go
+++ b/compilerutil/cancelationhandle.go
@@ -1,0 +1,54 @@
+// Copyright 2018 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package compilerutil
+
+// CancelFunction is a function that can be invoked to cancel the operation.
+type CancelFunction func()
+
+// CancelationHandle defines a handle for the cancelation of operations.
+type CancelationHandle interface {
+	// Cancel marks the operation as canceled.
+	Cancel()
+
+	// WasCanceled returns whether the operation was canceled.
+	WasCanceled() bool
+}
+
+// NewCancelationHandle returns a new handle for canceling an operation.
+func NewCancelationHandle() CancelationHandle {
+	return &cancelationHandle{}
+}
+
+// GetCancelationHandle returns either the existing cancelation handle (if not nil)
+// or a new no-op handle.
+func GetCancelationHandle(existing CancelationHandle) CancelationHandle {
+	if existing == nil {
+		return noopCancelationHandle{}
+	}
+
+	return existing
+}
+
+type cancelationHandle struct {
+	canceled bool
+}
+
+func (c *cancelationHandle) WasCanceled() bool {
+	return c.canceled
+}
+
+func (c *cancelationHandle) Cancel() {
+	c.canceled = true
+}
+
+type noopCancelationHandle struct{}
+
+func (noopCancelationHandle) WasCanceled() bool {
+	return false
+}
+
+func (noopCancelationHandle) Cancel() {
+	panic("Should never be called")
+}

--- a/generator/es5/generate_module.go
+++ b/generator/es5/generate_module.go
@@ -23,7 +23,7 @@ func (gen *es5generator) generateModules(modules []typegraph.TGModule) map[typeg
 	generatedSource := make([]esbuilder.SourceBuilder, len(modules))
 	queue := compilerutil.Queue()
 	for index, module := range modules {
-		fn := func(key interface{}, value interface{}) bool {
+		fn := func(key interface{}, value interface{}, cancel compilerutil.CancelFunction) bool {
 			generatedSource[key.(int)] = gen.generateModule(value.(typegraph.TGModule))
 			return true
 		}

--- a/graphs/scopegraph/config.go
+++ b/graphs/scopegraph/config.go
@@ -1,0 +1,56 @@
+// Copyright 2018 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package scopegraph
+
+import (
+	"github.com/serulian/compiler/compilerutil"
+	"github.com/serulian/compiler/integration"
+	"github.com/serulian/compiler/packageloader"
+)
+
+// Config defines the configuration for scoping.
+type Config struct {
+	// Entrypoint is the entrypoint path from which to begin scoping.
+	Entrypoint packageloader.Entrypoint
+
+	// VCSDevelopmentDirectories are the paths to the development directories, if any, that
+	// override VCS imports.
+	VCSDevelopmentDirectories []string
+
+	// Libraries defines the libraries, if any, to import along with the root source file.
+	Libraries []packageloader.Library
+
+	// Target defines the target of the scope building.
+	Target BuildTarget
+
+	// PathLoader defines the path loader to use when parsing.
+	PathLoader packageloader.PathLoader
+
+	// ScopeFilter defines the filter, if any, to use when scoping. If specified, only those entrypoints
+	// for which the filter returns true, will be scoped.
+	ScopeFilter ScopeFilter
+
+	// LanguageIntegration defines the language integrations to be used when performing parsing and scoping. If not specified,
+	// the integrations are loaded from the binary's directory.
+	LanguageIntegrations []integration.LanguageIntegration
+
+	// cancelationHandle is the handle to use for cancelation of the scopegraph, if any.
+	cancelationHandle compilerutil.CancelationHandle
+}
+
+// WithCancel returns the config with added support for cancelation.
+func (c Config) WithCancel() (Config, compilerutil.CancelFunction) {
+	handle := compilerutil.NewCancelationHandle()
+	return Config{
+		Entrypoint:                c.Entrypoint,
+		VCSDevelopmentDirectories: c.VCSDevelopmentDirectories,
+		Libraries:                 c.Libraries,
+		Target:                    c.Target,
+		PathLoader:                c.PathLoader,
+		ScopeFilter:               c.ScopeFilter,
+		LanguageIntegrations:      c.LanguageIntegrations,
+		cancelationHandle:         handle,
+	}, handle.Cancel
+}

--- a/graphs/srg/scopename.go
+++ b/graphs/srg/scopename.go
@@ -253,6 +253,9 @@ func (ns SRGNamedScope) ScopeKind() NamedScopeKind {
 	case sourceshape.NodeTypeProperty:
 		return NamedScopeMember
 
+	case sourceshape.NodeTypeOperator:
+		return NamedScopeMember
+
 	/* Parameter */
 	case sourceshape.NodeTypeParameter:
 		return NamedScopeParameter
@@ -389,6 +392,9 @@ func (ns SRGNamedScope) Name() (string, bool) {
 
 	case sourceshape.NodeTypeFunction:
 		return ns.TryGet(sourceshape.NodePredicateTypeMemberName)
+
+	case sourceshape.NodeTypeOperator:
+		return ns.TryGet(sourceshape.NodeOperatorName)
 
 	case sourceshape.NodeTypeParameter:
 		return ns.TryGet(sourceshape.NodeParameterName)

--- a/graphs/srg/testutil.go
+++ b/graphs/srg/testutil.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/serulian/compiler/compilercommon"
 	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/compilerutil"
 	"github.com/serulian/compiler/packageloader"
 )
 
@@ -69,10 +70,10 @@ func (t testTypePackageLoaderParser) Parse(source compilercommon.InputSource, in
 
 }
 
-func (t testTypePackageLoaderParser) Apply(packageMap packageloader.LoadedPackageMap, sourceTracker packageloader.SourceTracker) {
+func (t testTypePackageLoaderParser) Apply(packageMap packageloader.LoadedPackageMap, sourceTracker packageloader.SourceTracker, cancelationHandle compilerutil.CancelationHandle) {
 
 }
 
-func (t testTypePackageLoaderParser) Verify(errorReporter packageloader.ErrorReporter, warningReporter packageloader.WarningReporter) {
+func (t testTypePackageLoaderParser) Verify(errorReporter packageloader.ErrorReporter, warningReporter packageloader.WarningReporter, cancelationHandle compilerutil.CancelationHandle) {
 
 }

--- a/graphs/srg/typeconstructor/typeconstructor.go
+++ b/graphs/srg/typeconstructor/typeconstructor.go
@@ -191,7 +191,7 @@ func (stc *srgTypeConstructor) DefineMembers(builder typegraph.GetMemberBuilder,
 	}
 
 	// Define all type members.
-	buildTypeMembers := func(key interface{}, value interface{}) bool {
+	buildTypeMembers := func(key interface{}, value interface{}, cancel compilerutil.CancelFunction) bool {
 		data := value.(typeMemberWork)
 		for _, member := range data.srgType.GetMembers() {
 			parent, _ := graph.GetTypeOrModuleForSourceNode(data.srgType.Node())
@@ -222,7 +222,7 @@ func (stc *srgTypeConstructor) DecorateMembers(decorater typegraph.GetMemberDeco
 	}
 
 	// Decorate all type members.
-	buildTypeMembers := func(key interface{}, value interface{}) bool {
+	buildTypeMembers := func(key interface{}, value interface{}, cancel compilerutil.CancelFunction) bool {
 		data := value.(typeMemberWork)
 		for _, member := range data.srgType.GetMembers() {
 			_, hasMemberName := member.Name()
@@ -460,7 +460,7 @@ func (stc *srgTypeConstructor) decorateMember(member srg.SRGMember, parent typeg
 }
 
 func (stc *srgTypeConstructor) Validate(reporter typegraph.IssueReporter, graph *typegraph.TypeGraph) {
-	validateTyperef := func(key interface{}, value interface{}) bool {
+	validateTyperef := func(key interface{}, value interface{}, cancel compilerutil.CancelFunction) bool {
 		srgTypeRef := value.(srg.SRGTypeRef)
 		typeref, err := stc.BuildTypeRef(srgTypeRef, graph)
 

--- a/graphs/typegraph/testutil.go
+++ b/graphs/typegraph/testutil.go
@@ -6,6 +6,7 @@ package typegraph
 
 import (
 	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/compilerutil"
 )
 
 // ConstructTypeGraphWithBasicTypes constructs a type graph populated with the given testing modules
@@ -21,7 +22,7 @@ func ConstructTypeGraphWithBasicTypes(modules ...TestModule) *TypeGraph {
 	fsg := g.NewGraphLayer("test", fakeNodeTypeTagged)
 	constructors = append(constructors, &testBasicTypesConstructor{emptyTypeConstructor{}, fsg, nil})
 
-	built, _ := BuildTypeGraphWithOption(g, BuildForTesting, constructors...)
+	built, _ := BuildTypeGraphWithOption(g, BuildForTesting, compilerutil.NoopCancelationHandle(), constructors...)
 	return built.Graph
 }
 

--- a/graphs/typegraph/typegraph_test.go
+++ b/graphs/typegraph/typegraph_test.go
@@ -9,12 +9,24 @@ import (
 	"testing"
 
 	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/compilerutil"
 	"github.com/serulian/compiler/packageloader"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var _ = fmt.Printf
+
+func TestCancelation(t *testing.T) {
+	handle := compilerutil.NewCancelationHandle()
+	handle.Cancel()
+
+	g, _ := compilergraph.NewGraph("-")
+	result, err := BuildTypeGraphWithOption(g, BuildForTesting, handle, NewBasicTypesConstructorForTesting(g))
+	assert.False(t, result.Status, "Expected cancelation")
+	assert.Equal(t, err.Error(), "Construction was canceled")
+}
 
 func TestModules(t *testing.T) {
 	graph := ConstructTypeGraphWithBasicTypes(

--- a/grok/completion_test.go
+++ b/grok/completion_test.go
@@ -235,8 +235,14 @@ var grokCompletionTests = []grokCompletionTest{
 func TestGrokCompletion(t *testing.T) {
 	for _, grokCompletionTest := range grokCompletionTests {
 		testSourcePath := "tests/" + grokCompletionTest.name + "/" + grokCompletionTest.name + ".seru"
-		groker := NewGroker(testSourcePath, []string{}, []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, "", "testcore"}})
-		handle, err := groker.GetHandleWithOption(HandleMustBeFresh, compilercommon.InputSource(testSourcePath))
+		groker := NewGrokerWithConfig(Config{
+			EntrypointPath:            testSourcePath,
+			VCSDevelopmentDirectories: []string{},
+			Libraries:                 []packageloader.Library{packageloader.Library{TESTLIB_PATH, false, "", "testcore"}},
+			PathLoader:                packageloader.LocalFilePathLoader{},
+			ScopePaths:                []compilercommon.InputSource{compilercommon.InputSource(testSourcePath)},
+		})
+		handle, err := groker.GetHandleWithOption(HandleMustBeFresh)
 
 		// Ensure we have a valid groker.
 		if !assert.Nil(t, err, "Expected no error for test %s", grokCompletionTest.name) {

--- a/grok/grok.go
+++ b/grok/grok.go
@@ -166,9 +166,14 @@ func (g *Groker) BuildHandle() chan HandleResult {
 			return
 		}
 
+		scopeResult := result.scopeResult
+		if scopeResult.Graph == nil {
+			return
+		}
+
 		newHandle := Handle{
-			scopeResult:        result.scopeResult,
-			structureFinder:    result.scopeResult.Graph.SourceGraph().NewSourceStructureFinder(),
+			scopeResult:        scopeResult,
+			structureFinder:    scopeResult.Graph.SourceGraph().NewSourceStructureFinder(),
 			groker:             g,
 			importInspectCache: cmap.New(),
 			pathFiltersMap:     g.scopePathMap,

--- a/packageloader/config.go
+++ b/packageloader/config.go
@@ -1,0 +1,40 @@
+// Copyright 2018 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packageloader
+
+// Config defines configuration for a PackageLoader.
+type Config struct {
+	// The entrypoint from which loading will begin. Can be a file or a directory.
+	Entrypoint Entrypoint
+
+	// Paths of directories to check for local copies of remote packages
+	// before performing VCS checkout.
+	VCSDevelopmentDirectories []string
+
+	// The source handlers to use to parse and import the loaded source files.
+	SourceHandlers []SourceHandler
+
+	// The path loader to use to load source files and directories.
+	PathLoader PathLoader
+
+	// If true, validation will always be called.
+	AlwaysValidate bool
+
+	// If true, VCS forced refresh (for branches and HEAD) will be skipped if cache
+	// exists.
+	SkipVCSRefresh bool
+}
+
+// NewBasicConfig returns PackageLoader Config for a root source file and source handlers.
+func NewBasicConfig(rootSourceFilePath string, sourceHandlers ...SourceHandler) Config {
+	return Config{
+		Entrypoint:                Entrypoint(rootSourceFilePath),
+		VCSDevelopmentDirectories: []string{},
+		SourceHandlers:            sourceHandlers,
+		PathLoader:                LocalFilePathLoader{},
+		AlwaysValidate:            false,
+		SkipVCSRefresh:            false,
+	}
+}

--- a/packageloader/config.go
+++ b/packageloader/config.go
@@ -4,6 +4,10 @@
 
 package packageloader
 
+import (
+	"github.com/serulian/compiler/compilerutil"
+)
+
 // Config defines configuration for a PackageLoader.
 type Config struct {
 	// The entrypoint from which loading will begin. Can be a file or a directory.
@@ -25,6 +29,23 @@ type Config struct {
 	// If true, VCS forced refresh (for branches and HEAD) will be skipped if cache
 	// exists.
 	SkipVCSRefresh bool
+
+	// cancelationHandle holds a handle for cancelation of the package loading, if any.
+	cancelationHandle compilerutil.CancelationHandle
+}
+
+// WithCancel returns the config with added support for cancelation.
+func (c Config) WithCancel() (Config, compilerutil.CancelFunction) {
+	handle := compilerutil.NewCancelationHandle()
+	return Config{
+		Entrypoint:                c.Entrypoint,
+		VCSDevelopmentDirectories: c.VCSDevelopmentDirectories,
+		SourceHandlers:            c.SourceHandlers,
+		PathLoader:                c.PathLoader,
+		AlwaysValidate:            c.AlwaysValidate,
+		SkipVCSRefresh:            c.SkipVCSRefresh,
+		cancelationHandle:         handle,
+	}, handle.Cancel
 }
 
 // NewBasicConfig returns PackageLoader Config for a root source file and source handlers.

--- a/packageloader/config.go
+++ b/packageloader/config.go
@@ -37,6 +37,11 @@ type Config struct {
 // WithCancel returns the config with added support for cancelation.
 func (c Config) WithCancel() (Config, compilerutil.CancelFunction) {
 	handle := compilerutil.NewCancelationHandle()
+	return c.WithCancelationHandle(handle), handle.Cancel
+}
+
+// WithCancelationHandle returns the config with the cancelation handle set to that given.
+func (c Config) WithCancelationHandle(handle compilerutil.CancelationHandle) Config {
 	return Config{
 		Entrypoint:                c.Entrypoint,
 		VCSDevelopmentDirectories: c.VCSDevelopmentDirectories,
@@ -45,7 +50,7 @@ func (c Config) WithCancel() (Config, compilerutil.CancelFunction) {
 		AlwaysValidate:            c.AlwaysValidate,
 		SkipVCSRefresh:            c.SkipVCSRefresh,
 		cancelationHandle:         handle,
-	}, handle.Cancel
+	}
 }
 
 // NewBasicConfig returns PackageLoader Config for a root source file and source handlers.

--- a/packageloader/packageinfo.go
+++ b/packageloader/packageinfo.go
@@ -11,7 +11,7 @@ import (
 // PackageInfo holds information about a loaded package.
 type PackageInfo struct {
 	kind        string                       // The source kind of the package.
-	referenceId string                       // The unique ID for this package.
+	referenceID string                       // The unique ID for this package.
 	modulePaths []compilercommon.InputSource // The module paths making up this package.
 }
 
@@ -26,8 +26,8 @@ func (pi PackageInfo) Kind() string {
 }
 
 // ReferenceId returns the unique reference ID for this package.
-func (pi PackageInfo) ReferenceId() string {
-	return pi.referenceId
+func (pi PackageInfo) ReferenceID() string {
+	return pi.referenceID
 }
 
 // ModulePaths returns the list of full paths of the modules in this package.

--- a/packageloader/packageloader.go
+++ b/packageloader/packageloader.go
@@ -189,7 +189,7 @@ func (p *PackageLoader) Load(libraries ...Library) LoadResult {
 
 	// Apply all parser changes.
 	for _, parser := range p.parsers {
-		parser.Apply(result.PackageMap, result.SourceTracker)
+		parser.Apply(result.PackageMap, result.SourceTracker, p.cancelationHandle)
 	}
 
 	// Perform verification in all parsers.
@@ -204,7 +204,15 @@ func (p *PackageLoader) Load(libraries ...Library) LoadResult {
 		}
 
 		for _, parser := range p.parsers {
-			parser.Verify(errorReporter, warningReporter)
+			parser.Verify(errorReporter, warningReporter, p.cancelationHandle)
+		}
+	}
+
+	if p.cancelationHandle.WasCanceled() {
+		return LoadResult{
+			Status:   false,
+			Errors:   make([]compilercommon.SourceError, 0),
+			Warnings: make([]compilercommon.SourceWarning, 0),
 		}
 	}
 

--- a/packageloader/packageloader_test.go
+++ b/packageloader/packageloader_test.go
@@ -196,19 +196,19 @@ type localPackageInfoForPathTest struct {
 var localPackageInfoForPathTests = []localPackageInfoForPathTest{
 	localPackageInfoForPathTest{"basic", "", false, true, PackageInfo{
 		kind:        "",
-		referenceId: "tests/basic",
+		referenceID: "tests/basic",
 		modulePaths: []compilercommon.InputSource{"tests/basic/anotherfile.json", "tests/basic/somefile.json"},
 	}},
 
 	localPackageInfoForPathTest{"basic/anotherfile", "", false, true, PackageInfo{
 		kind:        "",
-		referenceId: "tests/basic/anotherfile.json",
+		referenceID: "tests/basic/anotherfile.json",
 		modulePaths: []compilercommon.InputSource{"tests/basic/anotherfile.json"},
 	}},
 
 	localPackageInfoForPathTest{"relative", "", false, true, PackageInfo{
 		kind:        "",
-		referenceId: "tests/relative",
+		referenceID: "tests/relative",
 		modulePaths: []compilercommon.InputSource{"tests/relative/entrypoint.json", "tests/relative/relativelyimported.json"},
 	}},
 

--- a/packageloader/packageloader_test.go
+++ b/packageloader/packageloader_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/compilerutil"
 
 	"github.com/stretchr/testify/assert"
 
@@ -48,11 +49,11 @@ type testParser struct {
 	tt *testTracker
 }
 
-func (tt *testParser) Apply(packageMap LoadedPackageMap, sourceTracker SourceTracker) {
+func (tt *testParser) Apply(packageMap LoadedPackageMap, sourceTracker SourceTracker, cancelationHandle compilerutil.CancelationHandle) {
 
 }
 
-func (tt *testParser) Verify(errorReporter ErrorReporter, warningReporter WarningReporter) {
+func (tt *testParser) Verify(errorReporter ErrorReporter, warningReporter WarningReporter, cancelationHandle compilerutil.CancelationHandle) {
 }
 
 func (tt *testParser) Parse(source compilercommon.InputSource, input string, importHandler ImportHandler) {

--- a/packageloader/pathinfo.go
+++ b/packageloader/pathinfo.go
@@ -1,0 +1,45 @@
+// Copyright 2018 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packageloader
+
+import (
+	"fmt"
+
+	"github.com/serulian/compiler/compilercommon"
+)
+
+// pathKind identifies the supported kind of paths
+type pathKind int
+
+const (
+	pathSourceFile pathKind = iota
+	pathLocalPackage
+	pathVCSPackage
+)
+
+// pathInformation holds information about a path to load.
+type pathInformation struct {
+	// referenceID is the unique reference ID for the path. Typically the path
+	// of the package or module itself, but can be anything, as long as it uniquely
+	// identifies this path.
+	referenceID string
+
+	// kind is the kind of path (source file, local package or vcs package).
+	kind pathKind
+
+	// path is the path being represented.
+	path string
+
+	// sourceKind is the source kind (empty string for `.seru`, `webidl` for "webidl")
+	sourceKind string
+
+	// sourceRange is the source range that *referenced* this path.
+	sourceRange compilercommon.SourceRange
+}
+
+// Returns the string representation of the given path.
+func (p *pathInformation) String() string {
+	return fmt.Sprintf("%v::%s::%s", int(p.kind), p.sourceKind, p.path)
+}

--- a/packageloader/sourcehandler.go
+++ b/packageloader/sourcehandler.go
@@ -6,6 +6,7 @@ package packageloader
 
 import (
 	"github.com/serulian/compiler/compilercommon"
+	"github.com/serulian/compiler/compilerutil"
 )
 
 // SourceHandler defines an interface for handling source files of a particular kind.
@@ -36,11 +37,11 @@ type SourceHandlerParser interface {
 
 	// Apply performs final application of all changes in the source handler. This method is called
 	// synchronously, and is typically used to apply the parsed structure to the underlying graph.
-	Apply(packageMap LoadedPackageMap, sourceTracker SourceTracker)
+	Apply(packageMap LoadedPackageMap, sourceTracker SourceTracker, cancelationHandle compilerutil.CancelationHandle)
 
 	// Verify performs verification of the loaded source. Any errors or warnings encountered
 	// should be reported via the given reporter callbacks.
-	Verify(errorReporter ErrorReporter, warningReporter WarningReporter)
+	Verify(errorReporter ErrorReporter, warningReporter WarningReporter, cancelationHandle compilerutil.CancelationHandle)
 }
 
 // PackageImportType identifies the types of imports.

--- a/webidl/graph/typecollapser.go
+++ b/webidl/graph/typecollapser.go
@@ -45,7 +45,7 @@ type gdHandler func(gd IRGDeclaration)
 // ForEachType invokes the given handler for each collapsed type. Note that the handlers will
 // be invoked in parallel via goroutines, so care must be taken if access any shared resources.
 func (tc *TypeCollapser) ForEachType(handler ctHandler) {
-	process := func(key interface{}, value interface{}) bool {
+	process := func(key interface{}, value interface{}, cancel compilerutil.CancelFunction) bool {
 		handler(key.(*CollapsedType))
 		return true
 	}
@@ -60,7 +60,7 @@ func (tc *TypeCollapser) ForEachType(handler ctHandler) {
 // ForEachGlobalDeclaration invokes the given handler for each global decl. Note that the handlers will
 // be invoked in parallel via goroutines, so care must be taken if access any shared resources.
 func (tc *TypeCollapser) ForEachGlobalDeclaration(handler gdHandler) {
-	process := func(key interface{}, value interface{}) bool {
+	process := func(key interface{}, value interface{}, cancel compilerutil.CancelFunction) bool {
 		handler(key.(IRGDeclaration))
 		return true
 	}
@@ -139,7 +139,7 @@ func (tc *TypeCollapser) getType(modifier compilergraph.GraphLayerModifier, name
 // named `Number` will result in a single *CollapsedType with name `Number`, a backing
 // node in the IRG, and the list of those declarations contained within.
 func (tc *TypeCollapser) populate(modifier compilergraph.GraphLayerModifier) {
-	collapseDeclaration := func(key interface{}, value interface{}) bool {
+	collapseDeclaration := func(key interface{}, value interface{}, cancel compilerutil.CancelFunction) bool {
 		name := key.(string)
 		declaration := value.(IRGDeclaration)
 

--- a/webidl/typeconstructor/typeconstructor_test.go
+++ b/webidl/typeconstructor/typeconstructor_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/serulian/compiler/compilergraph"
+	"github.com/serulian/compiler/compilerutil"
 	"github.com/serulian/compiler/graphs/typegraph"
 	"github.com/serulian/compiler/packageloader"
 	webidl "github.com/serulian/compiler/webidl/graph"
@@ -105,7 +106,8 @@ func TestGraphs(t *testing.T) {
 		}
 
 		// Construct the type graph.
-		result, _ := typegraph.BuildTypeGraphWithOption(graph, typegraph.BuildForTesting, GetConstructor(testIRG), typegraph.NewBasicTypesConstructorForTesting(graph))
+		result, _ := typegraph.BuildTypeGraphWithOption(graph, typegraph.BuildForTesting, compilerutil.NoopCancelationHandle(),
+			GetConstructor(testIRG), typegraph.NewBasicTypesConstructorForTesting(graph))
 
 		if test.expectedError == "" {
 			// Make sure we had no errors during construction.


### PR DESCRIPTION
This change also changes the `grok` package to make use of the new cancelation support via asynchronous handle construction: calls to recreate the handle will cancel previous in-progress handle creation.