### PR TITLE
Fix generation bug when assigning to function variables

### DIFF
--- a/generator/es5/dombuilder/build_access_expr.go
+++ b/generator/es5/dombuilder/build_access_expr.go
@@ -58,8 +58,9 @@ func (db *domBuilder) buildNamedAccess(node compilergraph.GraphNode, name string
 			if isAliasedFunctionReference {
 				_, underFuncCall := node.TryGetIncomingNode(sourceshape.NodeFunctionCallExpressionChildExpr)
 				_, underSmlCall := node.TryGetIncomingNode(sourceshape.NodeSmlExpressionTypeOrFunction)
+				_, underAssignment := node.TryGetIncomingNode(sourceshape.NodeAssignStatementName)
 
-				if !underFuncCall && !underSmlCall {
+				if !underFuncCall && !underSmlCall && !underAssignment {
 					isPromising := db.scopegraph.IsPromisingMember(memberRef, scopegraph.PromisingAccessImplicitGet)
 					return codedom.DynamicAccess(childExpr, memberRef.Name(), isPromising, node)
 				}

--- a/generator/es5/es5_test.go
+++ b/generator/es5/es5_test.go
@@ -140,6 +140,7 @@ var generationTests = []generationTest{
 	generationTest{"break statement", "statements", "break", integrationTestNone, ""},
 	generationTest{"var and assign statements", "statements", "varassign", integrationTestNone, ""},
 	generationTest{"var no init statement", "statements", "varnoinit", integrationTestNone, ""},
+	generationTest{"function var assign statement", "statements", "functionvarassign", integrationTestNone, ""},
 	generationTest{"switch no expr statement", "statements", "switchnoexpr", integrationTestNone, ""},
 	generationTest{"switch expr statement", "statements", "switchexpr", integrationTestNone, ""},
 	generationTest{"with statement", "statements", "with", integrationTestSuccessExpected, ""},

--- a/generator/es5/tests/statements/functionvarassign.js
+++ b/generator/es5/tests/statements/functionvarassign.js
@@ -1,0 +1,40 @@
+$module('functionvarassign', function () {
+  var $static = this;
+  this.$class('e7dcfe11', 'SomeClass', false, '', function () {
+    var $static = this;
+    var $instance = this.prototype;
+    $static.new = function (someFunction) {
+      var instance = new $static();
+      instance.someFunction = someFunction;
+      return instance;
+    };
+    $static.Default = function () {
+      return $g.functionvarassign.SomeClass.new(function () {
+        return $t.fastbox(41, $g.________testlib.basictypes.Integer);
+      });
+    };
+    $instance.withFunction = function (f) {
+      var $this = this;
+      $this.someFunction = f;
+      return;
+    };
+    this.$typesig = function () {
+      if (this.$cachedtypesig) {
+        return this.$cachedtypesig;
+      }
+      var computed = {
+        "Default|1|6caba86c<e7dcfe11>": true,
+      };
+      return this.$cachedtypesig = computed;
+    };
+  });
+
+  $static.TEST = function () {
+    var sc;
+    sc = $g.functionvarassign.SomeClass.Default();
+    sc.withFunction(function () {
+      return $t.fastbox(42, $g.________testlib.basictypes.Integer);
+    });
+    return $t.fastbox(sc.someFunction().$wrapped == 42, $g.________testlib.basictypes.Boolean);
+  };
+});

--- a/generator/es5/tests/statements/functionvarassign.seru
+++ b/generator/es5/tests/statements/functionvarassign.seru
@@ -1,0 +1,17 @@
+class SomeClass {
+	var someFunction function<int>()
+
+	constructor Default() {
+		return SomeClass{someFunction: function() { return 41 }}
+	}
+
+	function withFunction(f function<int>()) {
+		this.someFunction = f
+	}
+}
+
+function TEST() any {
+	sc := SomeClass.Default()
+	sc.withFunction(function() int { return 42 })
+	return sc.someFunction() == 42
+}


### PR DESCRIPTION
Function assignments were being generated as dynamic access calls on the left hand side (which makes no sense). We now check for this case and generate as normal.

Also adds a test