### PR TITLE
Fix handling of nominal root operator to always return the *root* data type

### DIFF
--- a/graphs/scopegraph/scope_op_expr.go
+++ b/graphs/scopegraph/scope_op_expr.go
@@ -713,13 +713,8 @@ func (sb *scopeBuilder) scopeRootTypeExpression(node compilergraph.GraphNode, co
 	if !childType.IsAny() {
 		referredType := childType.ReferredType()
 		if referredType.TypeKind() == typegraph.NominalType {
-			// The result of the operator is the nominal type's parent type.
-			parentType := referredType.ParentTypes()[0]
-			if childType.IsNullable() {
-				parentType = parentType.AsNullable()
-			}
-
-			return newScope().Valid().Resolving(parentType).GetScope()
+			// The result of the operator is the nominal type's root type.
+			return newScope().Valid().Resolving(childType.NominalDataType()).GetScope()
 		}
 
 		if referredType.TypeKind() != typegraph.ImplicitInterfaceType && referredType.TypeKind() != typegraph.GenericType {

--- a/graphs/scopegraph/scopegraph_test.go
+++ b/graphs/scopegraph/scopegraph_test.go
@@ -624,6 +624,7 @@ var scopeGraphTests = []scopegraphTest{
 	scopegraphTest{"root type op success test", "rootop", "success",
 		[]expectedScopeEntry{
 			expectedScopeEntry{"someclass", expectedScope{true, proto.ScopeKind_VALUE, "SomeClass", "void"}},
+			expectedScopeEntry{"someclass2", expectedScope{true, proto.ScopeKind_VALUE, "SomeClass", "void"}},
 			expectedScopeEntry{"generic", expectedScope{true, proto.ScopeKind_VALUE, "any", "void"}},
 			expectedScopeEntry{"interface", expectedScope{true, proto.ScopeKind_VALUE, "any", "void"}},
 		},

--- a/graphs/scopegraph/tests/rootop/success.seru
+++ b/graphs/scopegraph/tests/rootop/success.seru
@@ -4,8 +4,11 @@ interface SomeInterface {}
 
 type SomeType : SomeClass {}
 
-function DoSomething<T>(st SomeType, si SomeInterface, t T) {
+type AnotherType : SomeType {}
+
+function DoSomething<T>(st SomeType, si SomeInterface, at AnotherType, t T) {
 	/* someclass */(&st)
 	/* generic */(&t)
+	/* someclass2 */(&at)
 	/* interface */(&si)
 }

--- a/graphs/typegraph/typereference.go
+++ b/graphs/typegraph/typereference.go
@@ -215,7 +215,11 @@ func (tr TypeReference) CheckNominalConvertable(other TypeReference) error {
 func (tr TypeReference) NominalDataType() TypeReference {
 	root := tr.NominalRootType()
 	if root.IsNominal() {
-		return root.ReferredType().ParentTypes()[0].TransformUnder(tr)
+		dataType := root.ReferredType().ParentTypes()[0].TransformUnder(tr)
+		if root.IsNullable() {
+			dataType = dataType.AsNullable()
+		}
+		return dataType
 	}
 
 	return root
@@ -238,6 +242,10 @@ func (tr TypeReference) NominalRootType() TypeReference {
 		current = current.ReferredType().ParentTypes()[0].TransformUnder(tr)
 
 		if !current.IsNominal() {
+			if tr.IsNullable() {
+				child = child.AsNullable()
+			}
+
 			return child
 		}
 	}


### PR DESCRIPTION
Also adds tests for the various methods in the typegraph and fixes an issue around nullables