### PR TITLE
Fix range lookup in Grok of externally imported types

### DIFF
--- a/graphs/srg/imports.go
+++ b/graphs/srg/imports.go
@@ -117,6 +117,18 @@ func (i SRGPackageImport) ResolvedTypeOrMember() (SRGTypeOrMember, bool) {
 	return packageInfo.FindTypeOrMemberByName(subsource)
 }
 
+// ResolveType returns the resolved type of this import, if any.
+func (i SRGPackageImport) ResolveType() (TypeResolutionResult, bool) {
+	// Load the package information.
+	packageInfo, err := i.srg.getPackageForImport(i.GraphNode)
+	if err != nil {
+		return TypeResolutionResult{}, false
+	}
+
+	subsource, _ := i.Subsource()
+	return packageInfo.ResolveType(subsource)
+}
+
 // Code returns a code-like summarization of the import, for human consumption.
 func (i SRGPackageImport) Code() (compilercommon.CodeSummary, bool) {
 	importNode := i.GraphNode.GetIncomingNode(sourceshape.NodeImportPredicatePackageRef)

--- a/grok/handle_lookupposition.go
+++ b/grok/handle_lookupposition.go
@@ -114,6 +114,19 @@ func (gh Handle) LookupSourcePosition(sourcePosition compilercommon.SourcePositi
 			}
 		}
 
+		resolvedTypeInfo, found := packageImport.ResolveType()
+		if found && resolvedTypeInfo.IsExternalPackage {
+			resolvedType, hasResolvedType := gh.scopeResult.Graph.TypeGraph().ResolveTypeUnderPackage(resolvedTypeInfo.ExternalPackageTypePath, resolvedTypeInfo.ExternalPackage)
+			if hasResolvedType {
+				return RangeInformation{
+					Kind:           NamedReference,
+					SourceRanges:   sourceRangesOf(resolvedType),
+					NamedReference: gh.scopeResult.Graph.ReferencedNameForTypeOrMember(resolvedType),
+					TypeReference:  gh.scopeResult.Graph.TypeGraph().VoidTypeReference(),
+				}, nil
+			}
+		}
+
 		// TODO: we might need the source here.
 		subsource, _ := packageImport.Subsource()
 		return RangeInformation{

--- a/grok/range_test.go
+++ b/grok/range_test.go
@@ -118,6 +118,7 @@ var grokRangeTests = []grokRangeTest{
 	grokRangeTest{"invalidtyperef", false, []grokNamedRange{}},
 
 	grokRangeTest{"webidl", true, []grokNamedRange{
+		grokNamedRange{"sir", NamedReference, "SomeInterface", "interface SomeInterface"},
 		grokNamedRange{"si", TypeRef, "SomeInterface", "interface SomeInterface"},
 	}},
 

--- a/grok/tests/webidl/webidl.seru
+++ b/grok/tests/webidl/webidl.seru
@@ -1,3 +1,4 @@
+///                           [sir        ]
 from webidl`something` import SomeInterface
 
 function DoSomething(something any) {


### PR DESCRIPTION
This case needs to be handle specifically, as it is outside of the normal SRG resolution