### PR TITLE
Change Grok to keep the current parameter in `code` form, and instead change other parameters to be bold

### DIFF
--- a/graphs/scopegraph/referencedname.go
+++ b/graphs/scopegraph/referencedname.go
@@ -82,6 +82,11 @@ func (rn ReferencedName) IsLocal() bool {
 	return rn.typeInfo == nil
 }
 
+// IsParameter returns true if the referenced name is a parameter.
+func (rn ReferencedName) IsParameter() bool {
+	return rn.IsLocal() && rn.srgInfo.ScopeKind() == srg.NamedScopeParameter
+}
+
 // IsProperty returns true if the referenced name points to a property.
 func (rn ReferencedName) IsProperty() bool {
 	member, isMember := rn.Member()

--- a/grok/signatures_test.go
+++ b/grok/signatures_test.go
@@ -61,8 +61,8 @@ var grokSignaturesTests = []grokSignaturesTest{
 					"DoSomething does something. When `someParam` is specified, good things happen. `anotherParam` controls other things.",
 					0,
 					[]expectedParam{
-						expectedParam{"someParam", "Integer", "When ***someParam*** is specified, good things happen"},
-						expectedParam{"anotherParam", "String", "***anotherParam*** controls other things"},
+						expectedParam{"someParam", "Integer", "When `someParam` is specified, good things happen"},
+						expectedParam{"anotherParam", "String", "`anotherParam` controls other things"},
 					},
 				},
 			},
@@ -74,8 +74,8 @@ var grokSignaturesTests = []grokSignaturesTest{
 					"DoSomething does something. When `someParam` is specified, good things happen. `anotherParam` controls other things.",
 					1,
 					[]expectedParam{
-						expectedParam{"someParam", "Integer", "When ***someParam*** is specified, good things happen"},
-						expectedParam{"anotherParam", "String", "***anotherParam*** controls other things"},
+						expectedParam{"someParam", "Integer", "When `someParam` is specified, good things happen"},
+						expectedParam{"anotherParam", "String", "`anotherParam` controls other things"},
 					},
 				},
 			},
@@ -87,7 +87,7 @@ var grokSignaturesTests = []grokSignaturesTest{
 					"A cool indexer, that takes `index`.",
 					0,
 					[]expectedParam{
-						expectedParam{"index", "Integer", "A cool indexer, that takes ***index***"},
+						expectedParam{"index", "Integer", "A cool indexer, that takes `index`"},
 					},
 				},
 			},

--- a/grok/structs.go
+++ b/grok/structs.go
@@ -126,9 +126,11 @@ func (ri RangeInformation) codeToMarkedText(cs compilercommon.CodeSummary) []Mar
 	}
 
 	trimmed := trimDocumentation(cs.Documentation)
-	name, hasName := ri.Name()
-	if hasName {
-		trimmed = highlightParameter(trimmed, name)
+	if ri.Kind == NamedReference && ri.NamedReference.IsParameter() {
+		name, hasName := ri.Name()
+		if hasName {
+			trimmed = highlightParameter(trimmed, name)
+		}
 	}
 
 	if trimmed != "" {

--- a/grok/util.go
+++ b/grok/util.go
@@ -5,7 +5,7 @@
 package grok
 
 import (
-	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/serulian/compiler/compilercommon"
@@ -51,14 +51,19 @@ func trimDocumentation(documentation string) string {
 	return strings.TrimSpace(parts[0])
 }
 
-// highlightParameter highlights the given parameter name found in the given documentation, by replacing its ticked
-// form (`example`) with a bolded form (***example***).
+// highlightParameter highlights the given parameter name found in the given documentation, by replacing all ticked
+// forms that *aren't* the parameter with italics forms instead.
 func highlightParameter(documentation string, paramName string) string {
-	if paramName != "" {
-		tickedParam := fmt.Sprintf("`%s`", paramName)
-		boldParam := fmt.Sprintf("***%s***", paramName)
-		return strings.Replace(documentation, tickedParam, boldParam, -1)
+	if paramName == "" {
+		return documentation
 	}
 
+	var parameterRegex = regexp.MustCompile("([^`]|^)`(" + paramName + ")`([^`]|$)")
+	var allParametersRegex = regexp.MustCompile("([^`]|^)`([a-zA-Z0-9_]+)`([^`]|$)")
+	var SENTINAL = "#SENTINAL#"
+
+	documentation = parameterRegex.ReplaceAllString(documentation, "$1"+SENTINAL+"$3")
+	documentation = allParametersRegex.ReplaceAllString(documentation, `$1**$2**$3`)
+	documentation = strings.Replace(documentation, SENTINAL, "`"+paramName+"`", -1)
 	return documentation
 }

--- a/grok/util_test.go
+++ b/grok/util_test.go
@@ -1,0 +1,55 @@
+// Copyright 2018 The Serulian Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grok
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type highlightParameterTest struct {
+	documentation string
+	parameterName string
+	expected      string
+}
+
+var parameterTests = []highlightParameterTest{
+	highlightParameterTest{
+		"This functions is invoked with `param1`, `param2` and `param3`",
+		"param1",
+		"This functions is invoked with `param1`, **param2** and **param3**",
+	},
+
+	highlightParameterTest{
+		"This functions is invoked with `param1`, `param2` and `param3`",
+		"param2",
+		"This functions is invoked with **param1**, `param2` and **param3**",
+	},
+
+	highlightParameterTest{
+		"This functions is invoked with `param1`, `param2` and `param3`",
+		"param3",
+		"This functions is invoked with **param1**, **param2** and `param3`",
+	},
+
+	highlightParameterTest{
+		"DoSomething does something really cool with `p`. If `p` is not available, then we use `q`!",
+		"p",
+		"DoSomething does something really cool with `p`. If `p` is not available, then we use **q**!",
+	},
+
+	highlightParameterTest{
+		"DoSomething does something really cool with `p`. If `p` is not available, then we use `q`!",
+		"q",
+		"DoSomething does something really cool with **p**. If **p** is not available, then we use `q`!",
+	},
+}
+
+func TestHighlightParameter(t *testing.T) {
+	for _, parameterTest := range parameterTests {
+		assert.Equal(t, parameterTest.expected, highlightParameter(parameterTest.documentation, parameterTest.parameterName))
+	}
+}


### PR DESCRIPTION
Makes the parameter much more clear when reading the doc comment