### PR TITLE
Fix a nil deference issue in completions created by Grok for types and members

### DIFF
--- a/graphs/srg/scopename.go
+++ b/graphs/srg/scopename.go
@@ -416,6 +416,15 @@ func (ns SRGNamedScope) Name() (string, bool) {
 	}
 }
 
+// GetType returns the type pointed to by this scope, if any.
+func (ns SRGNamedScope) GetType() (SRGType, bool) {
+	if ns.ScopeKind() == NamedScopeType {
+		return SRGType{ns.GraphNode, ns.srg}, true
+	}
+
+	return SRGType{}, false
+}
+
 // GetMember returns the member pointed to by this scope, if any.
 func (ns SRGNamedScope) GetMember() (SRGMember, bool) {
 	switch ns.Kind() {

--- a/graphs/typegraph/typegraph.go
+++ b/graphs/typegraph/typegraph.go
@@ -420,6 +420,20 @@ func (g *TypeGraph) GetTypeOrModuleForSourceNode(sourceNode compilergraph.GraphN
 	return TGTypeDecl{node, g}, true
 }
 
+// GetTypeMemberForSourceNode returns the type member for the given source node, if any.
+func (g *TypeGraph) GetTypeMemberForSourceNode(sourceNode compilergraph.GraphNode) (TGMember, bool) {
+	node, found := g.tryGetMatchingTypeGraphNode(sourceNode)
+	if !found {
+		return TGMember{}, false
+	}
+
+	if node.Kind() != NodeTypeMember && node.Kind() != NodeTypeOperator {
+		return TGMember{}, false
+	}
+
+	return TGMember{node, g}, true
+}
+
 // TypeOrMembersUnderPackage returns all types or members defined under the given package.
 func (g *TypeGraph) TypeOrMembersUnderPackage(packageInfo packageloader.PackageInfo) []TGTypeOrMember {
 	var typesOrMembers = make([]TGTypeOrMember, 0)

--- a/grok/completion_test.go
+++ b/grok/completion_test.go
@@ -317,6 +317,14 @@ func TestGrokCompletion(t *testing.T) {
 					expectedCompletion.title, grokCompletionSubTest.rangeName, grokCompletionTest.name) {
 					continue
 				}
+
+				switch foundCompletion.Kind {
+				case TypeCompletion:
+					assert.NotNil(t, foundCompletion.Type)
+
+				case MemberCompletion:
+					assert.NotNil(t, foundCompletion.Member)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We forgot to fill in the `type` and `member` fields on the completion block via one of the code paths. This fixes the issue and adds a test.